### PR TITLE
Update project links in nuget package spec

### DIFF
--- a/nuget/CommandLine.nuspec
+++ b/nuget/CommandLine.nuspec
@@ -8,10 +8,10 @@
     <description>Terse syntax C# command line parser for .NET with F# support. The Command Line Parser Library offers to CLR applications a clean and concise API for manipulating command line arguments and related tasks.</description>
     <releaseNotes />
     <copyright>Copyright (c) 2005 - 2016 Giacomo Stelluti Scala</copyright>
-    <licenseUrl>https://github.com/gsscoder/commandline/blob/master/License.md</licenseUrl>
-    <projectUrl>https://github.com/gsscoder/commandline</projectUrl>
+    <licenseUrl>https://github.com/commandlineparser/commandline/blob/master/License.md</licenseUrl>
+    <projectUrl>https://github.com/commandlineparser/commandline</projectUrl>
     <owners>Giacomo Stelluti Scala</owners>
-    <iconUrl>https://raw.githubusercontent.com/gsscoder/commandline/master/art/CommandLine20.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/commandlineparser/commandline/master/art/CommandLine20.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>command line commandline argument option parser parsing library syntax shell</tags>
     <dependencies>


### PR DESCRIPTION
Project moved to a new organization, updating links to match.