### PR TITLE
Change string argument default to null

### DIFF
--- a/src/CommandLine/Core/ReflectionExtensions.cs
+++ b/src/CommandLine/Core/ReflectionExtensions.cs
@@ -153,10 +153,6 @@ namespace CommandLine.Core
 
         public static object CreateDefaultForImmutable(this Type type)
         {
-            if (type == typeof(string))
-            {
-                return string.Empty;
-            }
             if (type.GetTypeInfo().IsGenericType && type.GetTypeInfo().GetGenericTypeDefinition() == typeof(IEnumerable<>))
             {
                 return type.GetTypeInfo().GetGenericArguments()[0].CreateEmptyArray();

--- a/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
@@ -1052,11 +1052,11 @@ namespace CommandLine.Tests.Unit.Core
         {
             get
             {
-                yield return new object[] { new string[] { }, new Immutable_Simple_Options("", new int[] { }, default(bool), default(long)) };
+                yield return new object[] { new string[] { }, new Immutable_Simple_Options(null, new int[] { }, default(bool), default(long)) };
                 yield return new object[] { new[] { "--stringvalue=strval0" }, new Immutable_Simple_Options("strval0", new int[] { }, default(bool), default(long)) };
-                yield return new object[] { new[] { "-i", "9", "7", "8" }, new Immutable_Simple_Options("", new[] { 9, 7, 8 }, default(bool), default(long)) };
-                yield return new object[] { new[] { "-x" }, new Immutable_Simple_Options("", new int[] { }, true, default(long)) };
-                yield return new object[] { new[] { "9876543210" }, new Immutable_Simple_Options("", new int[] { }, default(bool), 9876543210L) };
+                yield return new object[] { new[] { "-i", "9", "7", "8" }, new Immutable_Simple_Options(null, new[] { 9, 7, 8 }, default(bool), default(long)) };
+                yield return new object[] { new[] { "-x" }, new Immutable_Simple_Options(null, new int[] { }, true, default(long)) };
+                yield return new object[] { new[] { "9876543210" }, new Immutable_Simple_Options(null, new int[] { }, default(bool), 9876543210L) };
                 yield return new object[] { new[] { "--stringvalue=strval0", "-i", "9", "7", "8", "-x", "9876543210" }, new Immutable_Simple_Options("strval0", new[] { 9, 7, 8 }, true, 9876543210L) };
             }
         }


### PR DESCRIPTION
Instead of `String.Empty` (`""`)
Closes https://github.com/commandlineparser/commandline/issues/187