### PR TITLE
Updated Public API documentation link in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To build:
 
 Public API:
 ---
-Latest changes are recorded from Version 1.9.4.91, please refer to [this document](https://github.com/gsscoder/commandline/blob/master/docs/PublicAPI.md).
+Latest changes are recorded from Version 1.9.4.91, please refer to [this document](https://github.com/commandlineparser/commandline/blob/master/docs/PublicAPI.md).
 
 Used by:
 ---


### PR DESCRIPTION
The primary README file contains a deprecated link to the 'gsscoder'
version of the Public API documentation. This commit replaces that
link with the correct reference under the 'commandlineparser'
account.

* Fixes #139