### PR TITLE
Expose TypeInfo on ParserResult<T>

### DIFF
--- a/src/CommandLine/ParserResult.cs
+++ b/src/CommandLine/ParserResult.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace CommandLine
 {
-    sealed class TypeInfo
+    public sealed class TypeInfo
     {
         private readonly Type current;
         private readonly IEnumerable<Type> choices; 
@@ -27,12 +27,12 @@ namespace CommandLine
             get { return this.choices; }
         }
 
-        public static TypeInfo Create(Type current)
+        internal static TypeInfo Create(Type current)
         {
             return new TypeInfo(current, Enumerable.Empty<Type>());
         }
 
-        public static TypeInfo Create(Type current, IEnumerable<Type> choices)
+        internal static TypeInfo Create(Type current, IEnumerable<Type> choices)
         {
             return new TypeInfo(current, choices);
         }
@@ -78,7 +78,7 @@ namespace CommandLine
             get { return this.tag; }
         }
 
-        internal TypeInfo TypeInfo
+        public TypeInfo TypeInfo
         {
             get { return typeInfo; }
         }


### PR DESCRIPTION
I ran across the problem of having to know which verb had been selected when an error occured. The `ParserResult` would be a `NotParsed<object>` because I use the ParseArguments overload that takes an array of types. From that result there was no way to obtain the type of the verb except with some reflection to access these private members, so I request that typeinfo be made available.

Code now:

    var typeinfo = result.GetType().GetProperty("TypeInfo", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(result);
    var option = (Type)typeinfo.GetType().GetProperty("Current", BindingFlags.Public | BindingFlags.Instance).GetValue(typeinfo);

Code then:

    var option = result.TypeInfo.Current;
