### PR TITLE
Fixed broken link to wiki for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ let main args =
   | :? CommandLine.NotParsed<obj> -> 1
 ```
 
-For additional examples, check the [wiki for additional examples](https://gsscoder/commandline/wiki/Examples)
+For additional examples, check the [wiki for additional examples](https://github.com/gsscoder/commandline/wiki)
 
 Acknowledgements:
 ---


### PR DESCRIPTION
Examples page did not exist specifically in the wiki, so just routed to the homepage of the wiki.