### PR TITLE
Added a feature to avoid linebreaks between option when displaying help

### DIFF
--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -183,7 +183,7 @@ namespace CommandLine
                     settings.EnableDashDash)(arguments, optionSpecs);
         }
 
-        private static ParserResult<T> MakeParserResult<T>(ParserResult<T> parserResult, ParserSettings settings)
+        private /*static*/ ParserResult<T> MakeParserResult<T>(ParserResult<T> parserResult, ParserSettings settings)
         {
             return DisplayHelp(
                 parserResult,
@@ -191,12 +191,12 @@ namespace CommandLine
                 settings.MaximumDisplayWidth);
         }
 
-        private static ParserResult<T> DisplayHelp<T>(ParserResult<T> parserResult, TextWriter helpWriter, int maxDisplayWidth)
+        private /*static*/ ParserResult<T> DisplayHelp<T>(ParserResult<T> parserResult, TextWriter helpWriter, int maxDisplayWidth)
         {
             parserResult.WithNotParsed(
                 errors =>
                     Maybe.Merge(errors.ToMaybe(), helpWriter.ToMaybe())
-                        .Do((_, writer) => writer.Write(HelpText.AutoBuild(parserResult, maxDisplayWidth)))
+                        .Do((_, writer) => writer.Write(HelpText.AutoBuild(parserResult, settings, maxDisplayWidth)))
                 );
 
             return parserResult;

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -173,5 +173,10 @@ namespace CommandLine
                 disposed = true;
             }
         }
+        /// <summary>
+        /// This flag indicate if there is a line break between each option display in help
+        /// </summary>
+        public bool AdditionalNewLineAfterOption { get; set; } = true;
+        
     }
 }

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -202,11 +202,13 @@ namespace CommandLine.Text
         /// <param name='onExample'>A delegate used to customize <see cref="CommandLine.Text.Example"/> model used to render text block of usage examples.</param>
         /// <param name="verbsIndex">If true the output style is consistent with verb commands (no dashes), otherwise it outputs options.</param>
         /// <param name="maxDisplayWidth">The maximum width of the display.</param>
+        /// <param name="parserSettings">Settings of the parser. Some settings are for help display.</param>
         /// <remarks>The parameter <paramref name="verbsIndex"/> is not ontly a metter of formatting, it controls whether to handle verbs or options.</remarks>
         public static HelpText AutoBuild<T>(
             ParserResult<T> parserResult,
             Func<HelpText, HelpText> onError,
             Func<Example, Example> onExample,
+            ParserSettings parserSettings,
             bool verbsIndex = false,
             int maxDisplayWidth = DefaultMaximumLength)
         {
@@ -214,7 +216,7 @@ namespace CommandLine.Text
             {
                 Heading = HeadingInfo.Empty,
                 Copyright = CopyrightInfo.Empty,
-                AdditionalNewLineAfterOption = true,
+                AdditionalNewLineAfterOption = parserSettings.AdditionalNewLineAfterOption,
                 AddDashesToOption = !verbsIndex,
                 MaximumDisplayWidth = maxDisplayWidth
             };
@@ -276,12 +278,13 @@ namespace CommandLine.Text
         /// </summary>
         /// <param name='parserResult'>The <see cref="CommandLine.ParserResult{T}"/> containing the instance that collected command line arguments parsed with <see cref="CommandLine.Parser"/> class.</param>
         /// <param name="maxDisplayWidth">The maximum width of the display.</param>
+        /// <param name="parserSettings">Settings of the parser. Some settings are for help display.</param>
         /// <returns>
         /// An instance of <see cref="CommandLine.Text.HelpText"/> class.
         /// </returns>
         /// <remarks>This feature is meant to be invoked automatically by the parser, setting the HelpWriter property
         /// of <see cref="CommandLine.ParserSettings"/>.</remarks>
-        public static HelpText AutoBuild<T>(ParserResult<T> parserResult, int maxDisplayWidth = DefaultMaximumLength)
+        public static HelpText AutoBuild<T>(ParserResult<T> parserResult, ParserSettings parserSettings, int maxDisplayWidth = DefaultMaximumLength)
         {
             if (parserResult.Tag != ParserResultType.NotParsed)
                 throw new ArgumentException("Excepting NotParsed<T> type.", "parserResult");
@@ -292,13 +295,13 @@ namespace CommandLine.Text
                 return new HelpText(HeadingInfo.Default){MaximumDisplayWidth = maxDisplayWidth }.AddPreOptionsLine(Environment.NewLine);
 
             if (!errors.Any(e => e.Tag == ErrorType.HelpVerbRequestedError))
-                return AutoBuild(parserResult, current => DefaultParsingErrorsHandler(parserResult, current), e => e, maxDisplayWidth: maxDisplayWidth);
+                return AutoBuild(parserResult, current => DefaultParsingErrorsHandler(parserResult, current), e => e, maxDisplayWidth: maxDisplayWidth, parserSettings:parserSettings);
 
             var err = errors.OfType<HelpVerbRequestedError>().Single();
             var pr = new NotParsed<object>(TypeInfo.Create(err.Type), Enumerable.Empty<Error>());
             return err.Matched
-                ? AutoBuild(pr, current => DefaultParsingErrorsHandler(pr, current), e => e, maxDisplayWidth: maxDisplayWidth)
-                : AutoBuild(parserResult, current => DefaultParsingErrorsHandler(parserResult, current), e => e, true, maxDisplayWidth);
+                ? AutoBuild(pr, current => DefaultParsingErrorsHandler(pr, current), e => e, maxDisplayWidth: maxDisplayWidth, parserSettings: parserSettings)
+                : AutoBuild(parserResult, current => DefaultParsingErrorsHandler(parserResult, current), e => e, parserSettings, true, maxDisplayWidth);
         }
 
         /// <summary>

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -315,7 +315,7 @@ namespace CommandLine.Tests.Unit.Text
                     });
 
             // Exercize system
-            var helpText = HelpText.AutoBuild(fakeResult);
+            var helpText = HelpText.AutoBuild(fakeResult, new ParserSettings());
 
             // Verify outcome
             var lines = helpText.ToString().ToNotEmptyLines().TrimStringArray();
@@ -350,7 +350,7 @@ namespace CommandLine.Tests.Unit.Text
                     });
 
             // Exercize system
-            var helpText = HelpText.AutoBuild(fakeResult);
+            var helpText = HelpText.AutoBuild(fakeResult, new ParserSettings());
 
             // Verify outcome
             var lines = helpText.ToString().ToNotEmptyLines().TrimStringArray();
@@ -383,7 +383,7 @@ namespace CommandLine.Tests.Unit.Text
                     });
 
             // Exercize system
-            var helpText = HelpText.AutoBuild(fakeResult, maxDisplayWidth: 100);            
+            var helpText = HelpText.AutoBuild(fakeResult, new ParserSettings(), maxDisplayWidth: 100);            
 
             // Verify outcome
             var lines = helpText.ToString().ToNotEmptyLines().TrimStringArray();
@@ -415,7 +415,7 @@ namespace CommandLine.Tests.Unit.Text
                 new Error[] { new HelpVerbRequestedError(null, null, false) });
 
             // Exercize system
-            var helpText = HelpText.AutoBuild(fakeResult);
+            var helpText = HelpText.AutoBuild(fakeResult, new ParserSettings());
 
             // Verify outcome
             var lines = helpText.ToString().ToNotEmptyLines().TrimStringArray();
@@ -501,7 +501,7 @@ namespace CommandLine.Tests.Unit.Text
                     });
 
             // Exercize system
-            var helpText = HelpText.AutoBuild(fakeResult);
+            var helpText = HelpText.AutoBuild(fakeResult, new ParserSettings());
 
             // Verify outcome
             var text = helpText.ToString();            
@@ -554,7 +554,7 @@ namespace CommandLine.Tests.Unit.Text
 
             // Exercize system
             handlers.ChangeCulture();
-            var helpText = HelpText.AutoBuild(fakeResult);
+            var helpText = HelpText.AutoBuild(fakeResult, new ParserSettings());
             handlers.ResetCulture();
 
             // Verify outcome
@@ -585,7 +585,7 @@ namespace CommandLine.Tests.Unit.Text
                 {
                     onErrorCalled = true;
                     return ht;
-                }, ex => ex);
+                }, ex => ex, new ParserSettings());
                 
                 onErrorCalled.Should().BeTrue();
                 actualResult.Copyright.Should().Be(expectedCopyright);
@@ -617,7 +617,7 @@ namespace CommandLine.Tests.Unit.Text
                 {
                     onErrorCalled = true;
                     return ht;
-                }, ex => ex);
+                }, ex => ex, new ParserSettings());
 
                 onErrorCalled.Should().BeTrue();
                 actualResult.Heading.Should().Be(string.Format("{0} {1}", expectedTitle, expectedVersion));
@@ -648,7 +648,7 @@ namespace CommandLine.Tests.Unit.Text
                 {
                     onErrorCalled = true;
                     return ht;
-                }, ex => ex);
+                }, ex => ex, new ParserSettings());
 
                 onErrorCalled.Should().BeFalse(); // Other attributes have fallback logic
                 actualResult.Copyright.Should().Be(string.Format("Copyright (C) {0} {1}", DateTime.Now.Year, expectedCompany));


### PR DESCRIPTION
Hi

Linked with issue #224.
I try to make this to allow users to set option in ParserSettings to have or not linebreaks between option when displaying help.

Thanks for advance