### PR TITLE
Added AutoHelp and AutoVersion properties to control adding of implicit 'help' and 'version' options/verbs

### DIFF
--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -23,6 +23,8 @@ namespace CommandLine.Core
             StringComparer nameComparer,
             bool ignoreValueCase,
             CultureInfo parsingCulture,
+            bool autoHelp,
+            bool autoVersion,
             IEnumerable<ErrorType> nonFatalErrors)
         {
             var typeInfo = factory.MapValueOrDefault(f => f().GetType(), typeof(T));
@@ -129,7 +131,7 @@ namespace CommandLine.Core
             };
 
             var preprocessorErrors = arguments.Any()
-                ? arguments.Preprocess(PreprocessorGuards.Lookup(nameComparer))
+                ? arguments.Preprocess(PreprocessorGuards.Lookup(nameComparer, autoHelp, autoVersion))
                 : Enumerable.Empty<Error>();
 
             var result = arguments.Any()

--- a/src/CommandLine/Core/InstanceChooser.cs
+++ b/src/CommandLine/Core/InstanceChooser.cs
@@ -18,6 +18,8 @@ namespace CommandLine.Core
             IEnumerable<string> arguments,
             StringComparer nameComparer,
             CultureInfo parsingCulture,
+            bool autoHelp,
+            bool autoVersion,
             IEnumerable<ErrorType> nonFatalErrors)
         {
             Func<ParserResult<object>> choose = () =>
@@ -30,13 +32,13 @@ namespace CommandLine.Core
 
                 var verbs = Verb.SelectFromTypes(types);
 
-                return preprocCompare("help")
+                return (autoHelp && preprocCompare("help"))
                     ? MakeNotParsed(types,
                         MakeHelpVerbRequestedError(verbs,
                             arguments.Skip(1).FirstOrDefault() ?? string.Empty, nameComparer))
-                    : preprocCompare("version")
+                    : (autoVersion && preprocCompare("version"))
                         ? MakeNotParsed(types, new VersionRequestedError())
-                        : MatchVerb(tokenizer, verbs, arguments, nameComparer, parsingCulture, nonFatalErrors);
+                        : MatchVerb(tokenizer, verbs, arguments, nameComparer, parsingCulture, autoHelp, autoVersion, nonFatalErrors);
             };
 
             return arguments.Any()
@@ -50,6 +52,8 @@ namespace CommandLine.Core
             IEnumerable<string> arguments,
             StringComparer nameComparer,
             CultureInfo parsingCulture,
+            bool autoHelp,
+            bool autoVersion,
             IEnumerable<ErrorType> nonFatalErrors)
         {
             return verbs.Any(a => nameComparer.Equals(a.Item1.Name, arguments.First()))
@@ -62,6 +66,8 @@ namespace CommandLine.Core
                     nameComparer,
                     false,
                     parsingCulture,
+                    autoHelp,
+                    autoVersion,
                     nonFatalErrors)
                 : MakeNotParsed(verbs.Select(v => v.Item2), new BadVerbSelectedError(arguments.First()));
         }

--- a/src/CommandLine/Core/PreprocessorGuards.cs
+++ b/src/CommandLine/Core/PreprocessorGuards.cs
@@ -9,13 +9,14 @@ namespace CommandLine.Core
     static class PreprocessorGuards
     {
         public static IEnumerable<Func<IEnumerable<string>, IEnumerable<Error>>>
-            Lookup(StringComparer nameComparer)
+            Lookup(StringComparer nameComparer, bool autoHelp, bool autoVersion)
         {
-            return new List<Func<IEnumerable<string>, IEnumerable<Error>>>
-                {
-                    HelpCommand(nameComparer),
-                    VersionCommand(nameComparer)
-                };
+            var list = new List<Func<IEnumerable<string>, IEnumerable<Error>>>();
+            if (autoHelp)
+                list.Add(HelpCommand(nameComparer));
+            if (autoVersion)
+                list.Add(VersionCommand(nameComparer));
+            return list;
         }
 
         public static Func<IEnumerable<string>, IEnumerable<Error>> HelpCommand(StringComparer nameComparer)

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -99,6 +99,8 @@ namespace CommandLine
                     settings.NameComparer,
                     settings.CaseInsensitiveEnumValues,
                     settings.ParsingCulture,
+                    settings.AutoHelp,
+                    settings.AutoVersion,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }
@@ -128,6 +130,8 @@ namespace CommandLine
                     settings.NameComparer,
                     settings.CaseInsensitiveEnumValues,
                     settings.ParsingCulture,
+                    settings.AutoHelp,
+                    settings.AutoVersion,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }
@@ -157,6 +161,8 @@ namespace CommandLine
                     args,
                     settings.NameComparer,
                     settings.ParsingCulture,
+                    settings.AutoHelp,
+                    settings.AutoVersion,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -20,6 +20,8 @@ namespace CommandLine
         private bool caseInsensitiveEnumValues;
         private TextWriter helpWriter;
         private bool ignoreUnknownArguments;
+        private bool autoHelp;
+        private bool autoVersion;
         private CultureInfo parsingCulture;
         private bool enableDashDash;
         private int maximumDisplayWidth;
@@ -31,6 +33,8 @@ namespace CommandLine
         {
             caseSensitive = true;
             caseInsensitiveEnumValues = false;
+            autoHelp = true;
+            autoVersion = true;
             parsingCulture = CultureInfo.InvariantCulture;
             try
             {
@@ -116,6 +120,24 @@ namespace CommandLine
         {
             get { return ignoreUnknownArguments; }
             set { PopsicleSetter.Set(Consumed, ref ignoreUnknownArguments, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether implicit option or verb 'help' should be supported.
+        /// </summary>
+        public bool AutoHelp
+        {
+            get { return autoHelp; }
+            set { PopsicleSetter.Set(Consumed, ref autoHelp, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether implicit option or verb 'version' should be supported.
+        /// </summary>
+        public bool AutoVersion
+        {
+            get { return autoVersion; }
+            set { PopsicleSetter.Set(Consumed, ref autoVersion, value); }
         }
 
         /// <summary>

--- a/tests/CommandLine.Tests/CommandLine.Tests.csproj
+++ b/tests/CommandLine.Tests/CommandLine.Tests.csproj
@@ -58,6 +58,8 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="CultureInfoExtensions.cs" />
+    <Compile Include="Fakes\Options_With_Custom_Help_Option.cs" />
+    <Compile Include="Fakes\Options_With_Custom_Version_Option.cs" />
     <Compile Include="Fakes\Options_With_Default_Set_To_Sequence.cs" />
     <Compile Include="Fakes\Options_With_Guid.cs" />
     <Compile Include="Fakes\Options_With_Option_And_Value_Of_String_Type.cs" />

--- a/tests/CommandLine.Tests/Fakes/Options_With_Custom_Help_Option.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_Custom_Help_Option.cs
@@ -1,0 +1,8 @@
+﻿namespace CommandLine.Tests.Fakes
+{
+    class Options_With_Custom_Help_Option : Simple_Options
+    {
+        [Option('h', "help")]
+        public bool Help { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Fakes/Options_With_Custom_Version_Option.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_Custom_Version_Option.cs
@@ -1,0 +1,8 @@
+﻿namespace CommandLine.Tests.Fakes
+{
+    class Options_With_Custom_Version_Option : Simple_Options
+    {
+        [Option('v', "version")]
+        public bool MyVersion { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
@@ -19,7 +19,7 @@ namespace CommandLine.Tests.Unit.Core
 {
     public class InstanceBuilderTests
     {
-        private static ParserResult<T> InvokeBuild<T>(string[] arguments)
+        private static ParserResult<T> InvokeBuild<T>(string[] arguments, bool autoHelp = true, bool autoVersion = true)
             where T : new()
         {
             return InstanceBuilder.Build(
@@ -29,8 +29,8 @@ namespace CommandLine.Tests.Unit.Core
                 StringComparer.Ordinal,
                 false,
                 CultureInfo.InvariantCulture,
-                true,
-                true,
+                autoHelp,
+                autoVersion,
                 Enumerable.Empty<ErrorType>());
         }
 
@@ -1011,6 +1011,76 @@ namespace CommandLine.Tests.Unit.Core
 
             // Verify outcome
             expected.ShouldBeEquivalentTo(((Parsed<Simple_Options>)result).Value.StringValue);
+
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(new[] { "--help" }, ErrorType.UnknownOptionError)]
+        public void Parse_without_auto_help_should_not_recognize_help_option(string[] arguments, ErrorType errorType)
+        {
+            // Fixture setup in attributes
+
+            // Exercize system 
+            var result = InvokeBuild<Simple_Options>(arguments, autoHelp: false);
+
+            // Verify outcome
+            result.Should().BeOfType<NotParsed<Simple_Options>>()
+                .Which.Errors.Should().ContainSingle()
+                .Which.Tag.Should().Be(errorType);
+
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(new[] { "--help" }, true)]
+        [InlineData(new[] { "-h" }, true)]
+        [InlineData(new[] { "-x" }, false)]
+        public void Parse_with_custom_help_option(string[] arguments, bool isHelp)
+        {
+            // Fixture setup in attributes
+
+            // Exercize system 
+            var result = InvokeBuild<Options_With_Custom_Help_Option>(arguments, autoHelp: false);
+
+            // Verify outcome
+            result.Should().BeOfType<Parsed<Options_With_Custom_Help_Option>>()
+                .Which.Value.Help.Should().Be(isHelp);
+
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(new[] { "--version" }, ErrorType.UnknownOptionError)]
+        public void Parse_without_auto_version_should_not_recognize_version_option(string[] arguments, ErrorType errorType)
+        {
+            // Fixture setup in attributes
+
+            // Exercize system 
+            var result = InvokeBuild<Simple_Options>(arguments, autoVersion: false);
+
+            // Verify outcome
+            result.Should().BeOfType<NotParsed<Simple_Options>>()
+                .Which.Errors.Should().ContainSingle()
+                .Which.Tag.Should().Be(errorType);
+
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(new[] { "--version" }, true)]
+        [InlineData(new[] { "-v" }, true)]
+        [InlineData(new[] { "-s", "s" }, false)]
+        public void Parse_with_custom_version_option(string[] arguments, bool isVersion)
+        {
+            // Fixture setup in attributes
+
+            // Exercize system 
+            var result = InvokeBuild<Options_With_Custom_Version_Option>(arguments, autoVersion: false);
+
+            // Verify outcome
+            result.Should().BeOfType<Parsed<Options_With_Custom_Version_Option>>()
+                .Which.Value.MyVersion.Should().Be(isVersion);
 
             // Teardown
         }

--- a/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
@@ -29,6 +29,8 @@ namespace CommandLine.Tests.Unit.Core
                 StringComparer.Ordinal,
                 false,
                 CultureInfo.InvariantCulture,
+                true,
+                true,
                 Enumerable.Empty<ErrorType>());
         }
 
@@ -42,6 +44,8 @@ namespace CommandLine.Tests.Unit.Core
                 StringComparer.Ordinal,
                 true,
                 CultureInfo.InvariantCulture,
+                true,
+                true,
                 Enumerable.Empty<ErrorType>());
         }
 
@@ -54,6 +58,8 @@ namespace CommandLine.Tests.Unit.Core
                 StringComparer.Ordinal,
                 false,
                 CultureInfo.InvariantCulture,
+                true,
+                true,
                 Enumerable.Empty<ErrorType>());
         }
 
@@ -451,6 +457,8 @@ namespace CommandLine.Tests.Unit.Core
                 StringComparer.Ordinal,
                 false,
                 CultureInfo.InvariantCulture,
+                true,
+                true,
                 Enumerable.Empty<ErrorType>());
 
             // Verify outcome

--- a/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
@@ -23,6 +23,8 @@ namespace CommandLine.Tests.Unit.Core
                 arguments,
                 StringComparer.Ordinal,
                 CultureInfo.InvariantCulture,
+                true,
+                true,
                 Enumerable.Empty<ErrorType>());
         }
 


### PR DESCRIPTION
Covers #87 and #200.