### PR TITLE
Fix support for .NET 4.0 and .NET 4.5

### DIFF
--- a/CommandLine.nuspec
+++ b/CommandLine.nuspec
@@ -30,6 +30,8 @@
         <dependency id="System.Runtime" version="4.1.0-rc2-24027" />
         <dependency id="System.Runtime.Extensions" version="4.1.0-rc2-24027" />
       </group>
+      <group targetFramework=".NETFramework4.0" />
+      <group targetFramework=".NETFramework4.5" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Covers #222 and #227.

I would have fixed .nuspec more throroughly, but I can't even get .NET Standard 1.5 library to build, so this is the only change I can do reliably without breaking anything.

See https://github.com/commandlineparser/commandline/issues/227#issuecomment-373979501 for more details on the issues with .nuspec file and the following comment with a way to fix it.