### PR TITLE
Fix FormatName.  Short name not preferred?  Go with long!  No short name? Has to be long!

### DIFF
--- a/src/CommandLine/UnParserExtensions.cs
+++ b/src/CommandLine/UnParserExtensions.cs
@@ -206,9 +206,8 @@ namespace CommandLine
 
         private static string FormatName(this OptionSpecification optionSpec, UnParserSettings settings)
         {
-            var longName =
-                optionSpec.LongName.Length > 0
-                && !settings.PreferShortName;
+            // Short name not preferred? Go with long! No short name? Has to be long!
+            var longName = !settings.PreferShortName || optionSpec.ShortName.Length == 0;
 
             return
                 new StringBuilder(longName


### PR DESCRIPTION
Currently, when unformatting parsed options, if preferShortName is requested but there is not short name (length == 0) then a blank is printed.  This patch will take the long name in that case.