### PR TITLE
If no short name, use the long name when formatting the command line

### DIFF
--- a/src/CommandLine/UnParserExtensions.cs
+++ b/src/CommandLine/UnParserExtensions.cs
@@ -206,8 +206,10 @@ namespace CommandLine
 
         private static string FormatName(this OptionSpecification optionSpec, UnParserSettings settings)
         {
-            // Short name not preferred? Go with long! No short name? Has to be long!
-            var longName = !settings.PreferShortName || optionSpec.ShortName.Length == 0;
+            // Have a long name and short name not preferred? Go with long! 
+            // No short name? Has to be long!
+            var longName = (optionSpec.LongName.Length >  0 && !settings.PreferShortName)
+                         || optionSpec.ShortName.Length == 0;
 
             return
                 new StringBuilder(longName

--- a/src/CommandLine/UnParserExtensions.cs
+++ b/src/CommandLine/UnParserExtensions.cs
@@ -206,9 +206,8 @@ namespace CommandLine
 
         private static string FormatName(this OptionSpecification optionSpec, UnParserSettings settings)
         {
-            var longName =
-                optionSpec.LongName.Length > 0
-                && !settings.PreferShortName;
+            // Short name not preferred? Go with long! No short name? Has to be long!
+            var longName = !settings.PreferShortName || optionSpec.ShortName.Length == 0;
 
             return
                 new StringBuilder(longName


### PR DESCRIPTION
Currently, the code will show an empty short name if preferShortName is requested and there is no short name.  This should fix it