### PR TITLE
Added simpler C# Quick Start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,43 @@ You can utilize the parser library in several ways:
 1. Create a class to define valid options, and to receive the parsed options.
 2. Call ParseArguments with the args string array.
 
+C# Quick Start:
+
+```csharp
+using System;
+using CommandLine;
+
+namespace QuickStart
+{
+    class Program
+    {
+        public class Options
+        {
+            [Option('v', "verbose", Required = false, HelpText = "Set output to verbose messages.")]
+            public bool Verbose { get; set; }
+        }
+
+        static void Main(string[] args)
+        {
+            Parser.Default.ParseArguments<Options>(args)
+                   .WithParsed<Options>(o =>
+                   {
+                       if (o.Verbose)
+                       {
+                           Console.WriteLine($"Verbose output has been enabled. Current Arguments: -v {o.Verbose}");
+                           Console.WriteLine("Quick Start Example! App is in Verbose mode so verbose messages will be shown!");
+                       }
+                       else
+                       {
+                           Console.WriteLine($"Current Arguments: -v {o.Verbose}");
+                           Console.WriteLine("Quick Start Example!");
+                       }
+                   });
+        }
+    }
+}
+```
+
 C# Examples:
 
 ```csharp

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ namespace QuickStart
                        if (o.Verbose)
                        {
                            Console.WriteLine($"Verbose output has been enabled. Current Arguments: -v {o.Verbose}");
-                           Console.WriteLine("Quick Start Example! App is in Verbose mode so verbose messages will be shown!");
+                           Console.WriteLine("Quick Start Example! App is in Verbose mode!");
                        }
                        else
                        {

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ namespace QuickStart
                    {
                        if (o.Verbose)
                        {
-                           Console.WriteLine($"Verbose output has been enabled. Current Arguments: -v {o.Verbose}");
+                           Console.WriteLine($"Verbose output enabled. Current Arguments: -v {o.Verbose}");
                            Console.WriteLine("Quick Start Example! App is in Verbose mode!");
                        }
                        else


### PR DESCRIPTION
I struggled to get my head around the examples in the Readme file, since some recent changes to how to use Commandlineparser were introduced. 

I have created a simple and minimal example to get up and running. Goal here was to show the minimum amount of code to use command line parser. The advanced fancy stuff can come later in the Readme. 