### PR TITLE
Fix to Display Width Tests

### DIFF
--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -490,7 +490,11 @@ namespace CommandLine.Tests.Unit
         {
             // Fixture setup
             var help = new StringWriter();
-            var sut = new Parser(config => config.HelpWriter = help);
+            var sut = new Parser(config =>
+            {
+                config.HelpWriter = help;
+                config.MaximumDisplayWidth = 80;
+            });
 
             // Exercize system
             sut.ParseArguments<Add_Verb_With_Usage_Attribute, Commit_Verb_With_Usage_Attribute, Clone_Verb_With_Usage_Attribute>(
@@ -628,7 +632,11 @@ namespace CommandLine.Tests.Unit
         {
             // Fixture setup
             var help = new StringWriter();
-            var sut = new Parser(config => config.HelpWriter = help);
+            var sut = new Parser(config =>
+            {
+                config.HelpWriter = help;
+                config.MaximumDisplayWidth = 80;
+            });
 
             // Exercize system
             sut.ParseArguments<Add_Verb, Commit_Verb, Clone_Verb>(
@@ -698,7 +706,11 @@ namespace CommandLine.Tests.Unit
         {
             // Fixture setup
             var help = new StringWriter();
-            var sut = new Parser(config => config.HelpWriter = help);
+            var sut = new Parser(config =>
+            {
+                config.HelpWriter = help;
+                config.MaximumDisplayWidth = 80;
+            });
 
             // Exercize system
             sut.ParseArguments<Add_Verb, Commit_Verb, Clone_Verb>(

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -78,7 +78,7 @@ namespace CommandLine.Tests.Unit.Text
         {
             // Fixture setup
             // Exercize system 
-            var sut = new HelpText { AddDashesToOption = true, AddEnumValuesToHelpText = true }
+            var sut = new HelpText { AddDashesToOption = true, AddEnumValuesToHelpText = true, MaximumDisplayWidth = 80 }
                 .AddPreOptionsLine("pre-options")
                 .AddOptions(new NotParsed<Options_With_Enum_Having_HelpText>(TypeInfo.Create(typeof(Options_With_Enum_Having_HelpText)), Enumerable.Empty<Error>()))
                 .AddPostOptionsLine("post-options");
@@ -184,6 +184,7 @@ namespace CommandLine.Tests.Unit.Text
             // Fixture setup
             // Exercize system 
             var sut = new HelpText(new HeadingInfo("CommandLine.Tests.dll", "1.9.4.131"));
+            sut.MaximumDisplayWidth = 80;
             sut.AddOptions(
                 new NotParsed<Simple_Options_With_HelpText_Set_To_Long_Description>(
                     TypeInfo.Create(typeof(Simple_Options_With_HelpText_Set_To_Long_Description)),


### PR DESCRIPTION
Explicitly passing MaximumDisplayWidth = 80 to tests that fail unless your Maximum Display Width is 80