### PR TITLE
Fixing DisplayWidth for newer Mono

### DIFF
--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -35,6 +35,10 @@ namespace CommandLine
             try
             {
                 maximumDisplayWidth = Console.WindowWidth;
+                if (maximumDisplayWidth < 1)
+                {
+                    maximumDisplayWidth = DefaultMaximumLength;
+                }
             }
             catch (IOException)
             {

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -105,6 +105,10 @@ namespace CommandLine.Text
             try
             {
                 maximumDisplayWidth = Console.WindowWidth;
+                if (maximumDisplayWidth < 1)
+                {
+                    maximumDisplayWidth = DefaultMaximumLength;
+                }
             }
             catch (IOException)
             {


### PR DESCRIPTION
ParserSettings and HelpText assume that Console.WindowWidth throws for non-Windows environments, but this is not true in more recent versions of Mono (returns 0 instead). This change will cause it to default to DefaultMaximumLength in the event that Console.WindowWidth returns 0.