### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ let main args =
   | :? CommandLine.NotParsed<obj> -> 1
 ```
 
-# Contibutors
+# Contributors
 First off, _Thank you!_  All contributions are welcome.  
 
 Please consider sticking with the GNU getopt standard for command line parsing.  


### PR DESCRIPTION
Very small typo in the readme: contibutors -> contributors