### PR TITLE
Fix not showing correct header info, issue #34

### DIFF
--- a/src/CommandLine/Text/HeadingInfo.cs
+++ b/src/CommandLine/Text/HeadingInfo.cs
@@ -55,10 +55,19 @@ namespace CommandLine.Text
         {
             get
             {
-                var title = ReflectionHelper.GetAttribute<AssemblyTitleAttribute>()
+                string title = ReflectionHelper.GetAssemblyName();
+#if NETSTANDARD1_5
+                title = ReflectionHelper.GetAttribute<AssemblyTitleAttribute>()
                     .MapValueOrDefault(
                         titleAttribute => Path.GetFileNameWithoutExtension(titleAttribute.Title),
-                        ReflectionHelper.GetAssemblyName());
+                        title);
+#else
+                title = ReflectionHelper.GetAttribute<AssemblyTitleAttribute>()
+                    .MapValueOrDefault(
+                        titleAttribute => titleAttribute.Title,
+                        title);
+#endif
+
                 var version = ReflectionHelper.GetAttribute<AssemblyInformationalVersionAttribute>()
                     .MapValueOrDefault(
                         versionAttribute => versionAttribute.InformationalVersion,

--- a/src/CommandLine/Text/HeadingInfo.cs
+++ b/src/CommandLine/Text/HeadingInfo.cs
@@ -55,18 +55,17 @@ namespace CommandLine.Text
         {
             get
             {
-                string title = ReflectionHelper.GetAssemblyName();
-#if NETSTANDARD1_5
-                title = ReflectionHelper.GetAttribute<AssemblyTitleAttribute>()
+                var title = ReflectionHelper.GetAttribute<AssemblyTitleAttribute>()
                     .MapValueOrDefault(
-                        titleAttribute => Path.GetFileNameWithoutExtension(titleAttribute.Title),
-                        title);
-#else
-                title = ReflectionHelper.GetAttribute<AssemblyTitleAttribute>()
-                    .MapValueOrDefault(
-                        titleAttribute => titleAttribute.Title,
-                        title);
-#endif
+                        titleAttribute =>
+                        {
+                            if (titleAttribute.Title.ToLowerInvariant().EndsWith(".dll"))
+                            {
+                                return titleAttribute.Title.Substring(0, titleAttribute.Title.Length - ".dll".Length);
+                            }
+                            return titleAttribute.Title;
+                        },
+                        ReflectionHelper.GetAssemblyName());
 
                 var version = ReflectionHelper.GetAttribute<AssemblyInformationalVersionAttribute>()
                     .MapValueOrDefault(


### PR DESCRIPTION
Added preprocessor for .NET Standard and .NET Framework to fix HeadingInfo issue #34 .