### PR TITLE
Deliberately inserted spaces are being trimmed-- change AddLine to only TrimEnd of input

### DIFF
--- a/src/CommandLine/Core/InstanceChooser.cs
+++ b/src/CommandLine/Core/InstanceChooser.cs
@@ -17,6 +17,7 @@ namespace CommandLine.Core
             IEnumerable<Type> types,
             IEnumerable<string> arguments,
             StringComparer nameComparer,
+            bool ignoreValueCase,
             CultureInfo parsingCulture,
             IEnumerable<ErrorType> nonFatalErrors)
         {
@@ -36,7 +37,7 @@ namespace CommandLine.Core
                             arguments.Skip(1).FirstOrDefault() ?? string.Empty, nameComparer))
                     : preprocCompare("version")
                         ? MakeNotParsed(types, new VersionRequestedError())
-                        : MatchVerb(tokenizer, verbs, arguments, nameComparer, parsingCulture, nonFatalErrors);
+                        : MatchVerb(tokenizer, verbs, arguments, nameComparer, ignoreValueCase, parsingCulture, nonFatalErrors);
             };
 
             return arguments.Any()
@@ -49,6 +50,7 @@ namespace CommandLine.Core
             IEnumerable<Tuple<Verb, Type>> verbs,
             IEnumerable<string> arguments,
             StringComparer nameComparer,
+            bool ignoreValueCase,
             CultureInfo parsingCulture,
             IEnumerable<ErrorType> nonFatalErrors)
         {
@@ -60,7 +62,7 @@ namespace CommandLine.Core
                     tokenizer,
                     arguments.Skip(1),
                     nameComparer,
-                    false,
+                    ignoreValueCase,
                     parsingCulture,
                     nonFatalErrors)
                 : MakeNotParsed(verbs.Select(v => v.Item2), new BadVerbSelectedError(arguments.First()));

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -156,6 +156,7 @@ namespace CommandLine
                     types,
                     args,
                     settings.NameComparer,
+                    settings.CaseInsensitiveEnumValues,
                     settings.ParsingCulture,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);

--- a/src/CommandLine/ParserResult.cs
+++ b/src/CommandLine/ParserResult.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace CommandLine
 {
-    sealed class TypeInfo
+    public sealed class TypeInfo
     {
         private readonly Type current;
         private readonly IEnumerable<Type> choices; 
@@ -27,12 +27,12 @@ namespace CommandLine
             get { return this.choices; }
         }
 
-        public static TypeInfo Create(Type current)
+        internal static TypeInfo Create(Type current)
         {
             return new TypeInfo(current, Enumerable.Empty<Type>());
         }
 
-        public static TypeInfo Create(Type current, IEnumerable<Type> choices)
+        internal static TypeInfo Create(Type current, IEnumerable<Type> choices)
         {
             return new TypeInfo(current, choices);
         }
@@ -78,7 +78,7 @@ namespace CommandLine
             get { return this.tag; }
         }
 
-        internal TypeInfo TypeInfo
+        public TypeInfo TypeInfo
         {
             get { return typeInfo; }
         }

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -636,7 +636,7 @@ namespace CommandLine.Text
                 throw new ArgumentOutOfRangeException(nameof(value));
             }
 
-            value = value.Trim();
+            value = value.TrimEnd();
 
             builder.AppendWhen(builder.Length > 0, Environment.NewLine);
             do

--- a/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
@@ -22,6 +22,7 @@ namespace CommandLine.Tests.Unit.Core
                 types,
                 arguments,
                 StringComparer.Ordinal,
+                false,
                 CultureInfo.InvariantCulture,
                 Enumerable.Empty<ErrorType>());
         }


### PR DESCRIPTION
Hi there,

Spaces that are inserted into error lines ([HERE](https://github.com/commandlineparser/commandline/blob/master/src/CommandLine/Text/HelpText.cs#L517-L518)) and usage lines ([HERE](https://github.com/commandlineparser/commandline/blob/master/src/CommandLine/Text/HelpText.cs#L585)) are being trimmed after-the-fact ([HERE](https://github.com/commandlineparser/commandline/blob/master/src/CommandLine/Text/HelpText.cs#L639)). As a result, usage is looking a bit cramped:

![image](https://user-images.githubusercontent.com/5761601/44356095-5ee89180-a47c-11e8-923f-985efb5a35fd.png)

Apply this single line change makes it look as it should with the coded space indents:

![image](https://user-images.githubusercontent.com/5761601/44356442-5ba1d580-a47d-11e8-95c6-50217d4a10fb.png)

Thanks,
Jesse