### PR TITLE
Localization and nuspec

### DIFF
--- a/CommandLine.nuspec
+++ b/CommandLine.nuspec
@@ -16,19 +16,19 @@
     <tags>command line commandline argument option parser parsing library syntax shell</tags>
     <dependencies>
       <group targetFramework=".NETStandard1.5">
-        <dependency id="System.Collections" version="4.0.11-rc2-24027" />
-        <dependency id="System.Console" version="4.0.0-rc2-24027" />
-        <dependency id="System.Diagnostics.Debug" version="4.0.11-rc2-24027" />
-        <dependency id="System.Globalization" version="4.0.11-rc2-24027" />
-        <dependency id="System.IO" version="4.1.0-rc2-24027" />
-        <dependency id="System.Linq" version="4.1.0-rc2-24027" />
-        <dependency id="System.Linq.Expressions" version="4.0.11-rc2-24027" />
-        <dependency id="System.Reflection" version="4.1.0-rc2-24027" />
-        <dependency id="System.Reflection.Extensions" version="4.0.1-rc2-24027" />
-        <dependency id="System.Reflection.TypeExtensions" version="4.1.0-rc2-24027" />
-        <dependency id="System.Resources.ResourceManager" version="4.0.1-rc2-24027" />
-        <dependency id="System.Runtime" version="4.1.0-rc2-24027" />
-        <dependency id="System.Runtime.Extensions" version="4.1.0-rc2-24027" />
+        <dependency id="System.Collections" version="4.3.0" />
+        <dependency id="System.Console" version="4.3.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.3.0" />
+        <dependency id="System.Globalization" version="4.3.0" />
+        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.Linq" version="4.3.0" />
+        <dependency id="System.Linq.Expressions" version="4.3.0" />
+        <dependency id="System.Reflection" version="4.3.0" />
+        <dependency id="System.Reflection.Extensions" version="4.3.0" />
+        <dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.3.0" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Runtime.Extensions" version="4.3.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -416,7 +416,6 @@ namespace CommandLine.Text
 
             return AddOptionsImpl(
                 GetSpecificationsFromType(result.TypeInfo.Current),
-                SentenceBuilder.RequiredWord(),
                 MaximumDisplayWidth);
         }
 
@@ -433,7 +432,6 @@ namespace CommandLine.Text
 
             return AddOptionsImpl(
                 AdaptVerbsToSpecifications(types),
-                SentenceBuilder.RequiredWord(),
                 MaximumDisplayWidth);
         }
 
@@ -449,7 +447,6 @@ namespace CommandLine.Text
 
             return AddOptionsImpl(
                 GetSpecificationsFromType(result.TypeInfo.Current),
-                SentenceBuilder.RequiredWord(),
                 maximumLength);
         }
 
@@ -467,7 +464,6 @@ namespace CommandLine.Text
 
             return AddOptionsImpl(
                 AdaptVerbsToSpecifications(types),
-                SentenceBuilder.RequiredWord(),
                 maximumLength);
         }
 
@@ -720,7 +716,6 @@ namespace CommandLine.Text
 
         private HelpText AddOptionsImpl(
             IEnumerable<Specification> specifications,
-            string requiredWord,
             int maximumLength)
         {
             var maxLength = GetMaxLength(specifications);
@@ -731,7 +726,7 @@ namespace CommandLine.Text
 
             specifications.ForEach(
                 option =>
-                    AddOption(requiredWord, maxLength, option, remainingSpace));
+                    AddOption(maxLength, option, remainingSpace));
 
             return this;
         }
@@ -765,7 +760,7 @@ namespace CommandLine.Text
             return this;
         }
 
-        private HelpText AddOption(string requiredWord, int maxLength, Specification specification, int widthOfHelpText)
+        private HelpText AddOption(int maxLength, Specification specification, int widthOfHelpText)
         {
             if (specification.Hidden)
                 return this;
@@ -784,13 +779,13 @@ namespace CommandLine.Text
             var optionHelpText = specification.HelpText;
 
             if (addEnumValuesToHelpText && specification.EnumValues.Any())
-                optionHelpText += " Valid values: " + string.Join(", ", specification.EnumValues);
+                optionHelpText += " {0}: ".FormatInvariant(SentenceBuilder.ValidValuesPhrase()) + string.Join(", ", specification.EnumValues);
 
             specification.DefaultValue.Do(
-                defaultValue => optionHelpText = "(Default: {0}) ".FormatInvariant(FormatDefaultValue(defaultValue)) + optionHelpText);
+                defaultValue => optionHelpText = "({0}: {1}) ".FormatInvariant(SentenceBuilder.DefaultWord(), FormatDefaultValue(defaultValue)) + optionHelpText);
 
             if (specification.Required)
-                optionHelpText = "{0} ".FormatInvariant(requiredWord) + optionHelpText;
+                optionHelpText = "{0} ".FormatInvariant(SentenceBuilder.RequiredWord()) + optionHelpText;
 
             if (!string.IsNullOrEmpty(optionHelpText))
             {
@@ -860,8 +855,8 @@ namespace CommandLine.Text
             return new StringBuilder(maxLength)
                 .BimapIf(
                     specification.MetaName.Length > 0,
-                    it => it.AppendFormat("{0} (pos. {1})", specification.MetaName, specification.Index),
-                    it => it.AppendFormat("value pos. {0}", specification.Index))
+                    it => it.AppendFormat("{0} ({1} {2})", specification.MetaName, SentenceBuilder.PositionWord(), specification.Index),
+                    it => it.AppendFormat("{0} {1}", SentenceBuilder.ValuePositionPhrase(), specification.Index))
                 .AppendFormatWhen(
                     specification.MetaValue.Length > 0, " {0}", specification.MetaValue)
                 .ToString();

--- a/src/CommandLine/Text/SentenceBuilder.cs
+++ b/src/CommandLine/Text/SentenceBuilder.cs
@@ -34,6 +34,26 @@ namespace CommandLine.Text
         public abstract Func<string> RequiredWord { get; }
 
         /// <summary>
+        /// Gets a delegate that returns the word 'Default'.
+        /// </summary>
+        public abstract Func<string> DefaultWord { get; }
+
+        /// <summary>
+        /// Gets a delegate that returns the word 'pos.'.
+        /// </summary>
+        public abstract Func<string> PositionWord { get; }
+
+        /// <summary>
+        /// Gets a delegate that returns the phrase 'value pos.'.
+        /// </summary>
+        public abstract Func<string> ValuePositionPhrase { get; }
+
+        /// <summary>
+        /// Gets a delegate that returns the phrase 'Valid values'.
+        /// </summary>
+        public abstract Func<string> ValidValuesPhrase { get; }
+
+        /// <summary>
         /// Gets a delegate that returns that errors block heading text.
         /// </summary>
         public abstract Func<string> ErrorsHeadingText { get; }
@@ -72,6 +92,26 @@ namespace CommandLine.Text
             public override Func<string> RequiredWord
             {
                 get { return () => "Required."; }
+            }
+
+            public override Func<string> DefaultWord
+            {
+                get { return () => "Default"; }
+            }
+
+            public override Func<string> PositionWord
+            {
+                get { return () => "pos."; }
+            }
+
+            public override Func<string> ValuePositionPhrase
+            {
+                get { return () => "value pos."; }
+            }
+
+            public override Func<string> ValidValuesPhrase
+            {
+                get { return () => "Valid values"; }
             }
 
             public override Func<string> ErrorsHeadingText


### PR DESCRIPTION
Changes in CommandLine.nuspec - dependencies version was changed to 4.3
Additional localization for Default and pos. words, Valid values and value pos phrases.
Also required word as function parameter was removed from some private functions and it was replaced with invoking SentenceBuilder instance functions.
Issue #321 
Issue #297 
