### PR TITLE
[WIP][Tests] Fix locally failing tests 

### DIFF
--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -488,6 +488,7 @@ namespace CommandLine.Tests.Unit
         [Fact]
         public void Properly_formatted_help_screen_is_displayed_when_usage_is_defined_in_verb_scenario()
         {
+            Console.WindowWidth = 80;
             // Fixture setup
             var help = new StringWriter();
             var sut = new Parser(config => config.HelpWriter = help);
@@ -626,6 +627,7 @@ namespace CommandLine.Tests.Unit
         [Fact]
         public void Specific_verb_help_screen_should_be_displayed_regardless_other_argument()
         {
+            Console.WindowWidth = 80;
             // Fixture setup
             var help = new StringWriter();
             var sut = new Parser(config => config.HelpWriter = help);
@@ -696,6 +698,7 @@ namespace CommandLine.Tests.Unit
         [Fact]
         public void Properly_formatted_help_screen_excludes_help_as_unknown_option()
         {
+            Console.WindowWidth = 80;
             // Fixture setup
             var help = new StringWriter();
             var sut = new Parser(config => config.HelpWriter = help);

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -181,6 +181,7 @@ namespace CommandLine.Tests.Unit.Text
         [Fact]
         public void When_help_text_has_hidden_option_it_should_not_be_added_to_help_text_output()
         {
+            Console.WindowWidth = 80;
             // Fixture setup
             // Exercize system 
             var sut = new HelpText(new HeadingInfo("CommandLine.Tests.dll", "1.9.4.131"));


### PR DESCRIPTION
Do not assume Console width in contributors machines
(in my situation: Win10 with console width=120)

I fixed all failing tests: basically all tests with some option help-text's length higher than 80 (that are expected to be wrapped) but I think this should be done for all tests.