### PR TITLE
Fix #197

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ __This library provides _hassle free_ command line parsing with a constantly upd
 
 You can utilize the parser library in several ways:
 
-- Install via Nuget/Paket
+- Install via Nuget/Paket: [https://www.nuget.org/packages/CommandLineParser/](https://www.nuget.org/packages/CommandLineParser/)
 - Integrate directly into your project by copying the .cs files into your project.
 - ILMerge during your build process.
 

--- a/src/CommandLine/Core/InstanceChooser.cs
+++ b/src/CommandLine/Core/InstanceChooser.cs
@@ -17,6 +17,7 @@ namespace CommandLine.Core
             IEnumerable<Type> types,
             IEnumerable<string> arguments,
             StringComparer nameComparer,
+            bool ignoreValueCase,
             CultureInfo parsingCulture,
             IEnumerable<ErrorType> nonFatalErrors)
         {
@@ -36,7 +37,7 @@ namespace CommandLine.Core
                             arguments.Skip(1).FirstOrDefault() ?? string.Empty, nameComparer))
                     : preprocCompare("version")
                         ? MakeNotParsed(types, new VersionRequestedError())
-                        : MatchVerb(tokenizer, verbs, arguments, nameComparer, parsingCulture, nonFatalErrors);
+                        : MatchVerb(tokenizer, verbs, arguments, nameComparer, ignoreValueCase, parsingCulture, nonFatalErrors);
             };
 
             return arguments.Any()
@@ -49,6 +50,7 @@ namespace CommandLine.Core
             IEnumerable<Tuple<Verb, Type>> verbs,
             IEnumerable<string> arguments,
             StringComparer nameComparer,
+            bool ignoreValueCase,
             CultureInfo parsingCulture,
             IEnumerable<ErrorType> nonFatalErrors)
         {
@@ -60,7 +62,7 @@ namespace CommandLine.Core
                     tokenizer,
                     arguments.Skip(1),
                     nameComparer,
-                    false,
+                    ignoreValueCase,
                     parsingCulture,
                     nonFatalErrors)
                 : MakeNotParsed(verbs.Select(v => v.Item2), new BadVerbSelectedError(arguments.First()));

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -156,6 +156,7 @@ namespace CommandLine
                     types,
                     args,
                     settings.NameComparer,
+                    settings.CaseInsensitiveEnumValues,
                     settings.ParsingCulture,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);

--- a/src/CommandLine/ParserResult.cs
+++ b/src/CommandLine/ParserResult.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace CommandLine
 {
-    sealed class TypeInfo
+    public sealed class TypeInfo
     {
         private readonly Type current;
         private readonly IEnumerable<Type> choices; 
@@ -27,12 +27,12 @@ namespace CommandLine
             get { return this.choices; }
         }
 
-        public static TypeInfo Create(Type current)
+        internal static TypeInfo Create(Type current)
         {
             return new TypeInfo(current, Enumerable.Empty<Type>());
         }
 
-        public static TypeInfo Create(Type current, IEnumerable<Type> choices)
+        internal static TypeInfo Create(Type current, IEnumerable<Type> choices)
         {
             return new TypeInfo(current, choices);
         }
@@ -78,7 +78,7 @@ namespace CommandLine
             get { return this.tag; }
         }
 
-        internal TypeInfo TypeInfo
+        public TypeInfo TypeInfo
         {
             get { return typeInfo; }
         }

--- a/src/CommandLine/Text/HeadingInfo.cs
+++ b/src/CommandLine/Text/HeadingInfo.cs
@@ -57,7 +57,7 @@ namespace CommandLine.Text
             {
                 var title = ReflectionHelper.GetAttribute<AssemblyTitleAttribute>()
                     .MapValueOrDefault(
-                        titleAttribute => Path.GetFileNameWithoutExtension(titleAttribute.Title),
+                        titleAttribute => titleAttribute.Title,
                         ReflectionHelper.GetAssemblyName());
                 var version = ReflectionHelper.GetAttribute<AssemblyInformationalVersionAttribute>()
                     .MapValueOrDefault(

--- a/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
@@ -22,6 +22,7 @@ namespace CommandLine.Tests.Unit.Core
                 types,
                 arguments,
                 StringComparer.Ordinal,
+                false,
                 CultureInfo.InvariantCulture,
                 Enumerable.Empty<ErrorType>());
         }


### PR DESCRIPTION
Removed Path.GetFileNameWithoutExtension() applied to assembly title.

Before:
![before cmd](https://user-images.githubusercontent.com/5012992/46501785-5b3b7f00-c81e-11e8-9412-00f8083f5337.png)


After:

![after cmd](https://user-images.githubusercontent.com/5012992/46501801-68f10480-c81e-11e8-9c15-a5141d8c09d1.png)

 
