### PR TITLE
Improve performance by more than 400X

### DIFF
--- a/src/CommandLine/Core/OptionMapper.cs
+++ b/src/CommandLine/Core/OptionMapper.cs
@@ -43,7 +43,7 @@ namespace CommandLine.Core
                                                 ((OptionSpecification)pt.Specification).FromOptionSpecification()))))
                             : Tuple.Create(pt, Maybe.Nothing<Error>());
                     }
-                );
+                ).Memorize();
             return Result.Succeed(
                 sequencesAndErrors.Select(se => se.Item1),
                 sequencesAndErrors.Select(se => se.Item2).OfType<Just<Error>>().Select(se => se.Value));

--- a/src/CommandLine/Core/TokenPartitioner.cs
+++ b/src/CommandLine/Core/TokenPartitioner.cs
@@ -19,14 +19,16 @@ namespace CommandLine.Core
                 IEnumerable<Token> tokens,
                 Func<string, Maybe<TypeDescriptor>> typeLookup)
         {
+            IEqualityComparer<Token> tokenComparer = ReferenceEqualityComparer.Default;
+
             var tokenList = tokens.Memorize();
-            var switches = Switch.Partition(tokenList, typeLookup).Memorize();
-            var scalars = Scalar.Partition(tokenList, typeLookup).Memorize();
-            var sequences = Sequence.Partition(tokenList, typeLookup).Memorize();
+            var switches = Switch.Partition(tokenList, typeLookup).ToSet(tokenComparer);
+            var scalars = Scalar.Partition(tokenList, typeLookup).ToSet(tokenComparer);
+            var sequences = Sequence.Partition(tokenList, typeLookup).ToSet(tokenComparer);
             var nonOptions = tokenList
-                .Where(t => !switches.Contains(t, ReferenceEqualityComparer.Default))
-                .Where(t => !scalars.Contains(t, ReferenceEqualityComparer.Default))
-                .Where(t => !sequences.Contains(t, ReferenceEqualityComparer.Default)).Memorize();
+                .Where(t => !switches.Contains(t))
+                .Where(t => !scalars.Contains(t))
+                .Where(t => !sequences.Contains(t)).Memorize();
             var values = nonOptions.Where(v => v.IsValue()).Memorize();
             var errors = nonOptions.Except(values, (IEqualityComparer<Token>)ReferenceEqualityComparer.Default).Memorize();
 

--- a/src/CommandLine/Core/TokenPartitioner.cs
+++ b/src/CommandLine/Core/TokenPartitioner.cs
@@ -11,20 +11,16 @@ namespace CommandLine.Core
     static class TokenPartitioner
     {
         public static
-            Tuple<
-                IEnumerable<KeyValuePair<string, IEnumerable<string>>>, // options
-                IEnumerable<string>,                                    // values
-                IEnumerable<Token>                                      // errors
-            > Partition(
+            Tuple<IEnumerable<KeyValuePair<string, IEnumerable<string>>>, IEnumerable<string>, IEnumerable<Token>> Partition(
                 IEnumerable<Token> tokens,
                 Func<string, Maybe<TypeDescriptor>> typeLookup)
         {
             IEqualityComparer<Token> tokenComparer = ReferenceEqualityComparer.Default;
 
             var tokenList = tokens.Memorize();
-            var switches = Switch.Partition(tokenList, typeLookup).ToSet(tokenComparer);
-            var scalars = Scalar.Partition(tokenList, typeLookup).ToSet(tokenComparer);
-            var sequences = Sequence.Partition(tokenList, typeLookup).ToSet(tokenComparer);
+            var switches = new HashSet<Token>(Switch.Partition(tokenList, typeLookup), tokenComparer);
+            var scalars = new HashSet<Token>(Scalar.Partition(tokenList, typeLookup), tokenComparer);
+            var sequences = new HashSet<Token>(Sequence.Partition(tokenList, typeLookup), tokenComparer);
             var nonOptions = tokenList
                 .Where(t => !switches.Contains(t))
                 .Where(t => !scalars.Contains(t))

--- a/src/CommandLine/Core/Tokenizer.cs
+++ b/src/CommandLine/Core/Tokenizer.cs
@@ -36,7 +36,7 @@ namespace CommandLine.Core
                           select token)
                             .Memorize();
 
-            var normalized = normalize(tokens);
+            var normalized = normalize(tokens).Memorize();
 
             var unkTokens = (from t in normalized where t.IsName() && nameLookup(t.Text) == NameLookupResult.NoOptionFound select t).Memorize();
 
@@ -60,12 +60,12 @@ namespace CommandLine.Core
             Result<IEnumerable<Token>, Error> tokenizerResult,
             Func<string, Maybe<char>> optionSequenceWithSeparatorLookup)
         {
-            var tokens = tokenizerResult.SucceededWith();
+            var tokens = tokenizerResult.SucceededWith().Memorize();
 
             var replaces = tokens.Select((t, i) =>
                 optionSequenceWithSeparatorLookup(t.Text)
                     .MapValueOrDefault(sep => Tuple.Create(i + 1, sep),
-                        Tuple.Create(-1, '\0'))).SkipWhile(x => x.Item1 < 0);
+                        Tuple.Create(-1, '\0'))).SkipWhile(x => x.Item1 < 0).Memorize();
 
             var exploded = tokens.Select((t, i) =>
                         replaces.FirstOrDefault(x => x.Item1 == i).ToMaybe()


### PR DESCRIPTION
Scenarios:
* IEnumerable option with 9000 entries: 15+ hours -> 150ms
* Options class w/20 string options all set on command line: 960ms -> 2.2ms

The speedups were predominantly achieved by memoizing IEnumerables that are enumerated multiple times.  A comparatively minor speedup was achieved by using a HashSet rather than LINQ's .Contains().

There should be no behavioral differences introduced by this change.

It should resolve #186.