### PR TITLE
README: fix typo in C# Quick Start Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ class Options
   public bool Verbose { get; set; }
   
   [Option("stdin",
-	Default = false
+	Default = false,
 	HelpText = "Read from stdin")]
   public bool stdin { get; set; }
 


### PR DESCRIPTION
Missing comma