### PR TITLE
Enhance error reporting when Options class has Value or Option attribute on unsettable property and no constructors available

### DIFF
--- a/src/CommandLine/Core/ReflectionExtensions.cs
+++ b/src/CommandLine/Core/ReflectionExtensions.cs
@@ -122,12 +122,13 @@ namespace CommandLine.Core
 
         public static bool IsMutable(this Type type)
         {
-            Func<bool> isMutable = () => {
-                var props = type.GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.Instance).Any(p => p.CanWrite);
-                var fields = type.GetTypeInfo().GetFields(BindingFlags.Public | BindingFlags.Instance).Any();
-                return props || fields;
-            };
-            return type != typeof(object) ? isMutable() : true;
+            if(type == typeof(object))
+                return true;
+
+            var props = type.GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.Instance).Any(p => p.CanWrite);
+            var fields = type.GetTypeInfo().GetFields(BindingFlags.Public | BindingFlags.Instance).Any();
+
+            return props || fields;
         }
 
         public static object CreateDefaultForImmutable(this Type type)

--- a/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
@@ -1133,6 +1133,21 @@ namespace CommandLine.Tests.Unit.Core
             // Teardown
         }
 
+        [Fact]
+        public void OptionClass_IsImmutable_HasNoCtor()
+        {
+            Action act = () => InvokeBuild<ValueWithNoSetterOptions>(new string[] { "Test" }, false, false);
+
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        private class ValueWithNoSetterOptions
+        {
+            [Value(0, MetaName = "Test", Default = 0)]
+            public int TestValue { get; }
+        }
+
+
         public static IEnumerable<object[]> RequiredValueStringData
         {
             get


### PR DESCRIPTION
PR for dealing with invalid situation where Value specified on a property that doesnt provider setter and no valid constructor available for providing the values.

Fixes #380 