### PR TITLE
Support of Xamarin.Mac / mono

### DIFF
--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -44,7 +44,7 @@ namespace CommandLine
                     maximumDisplayWidth = DefaultMaximumLength;
                 }
             }
-            catch (IOException)
+            catch (Exception e) when (e is IOException || e is PlatformNotSupportedException)
             {
                 maximumDisplayWidth = DefaultMaximumLength;
             }


### PR DESCRIPTION
When mono compiled without MONO_FEATURE_CONSOLE define, some methods of System.Console are throw System.PlatformNotSupportedException.

To be exact: [Console.WindowWidth](https://github.com/mono/mono/tree/afd4971208135b8e1f1b11755f531647a4195b9f/mcs/class/corlib/System/Console.cs#L895-L899) in this case.