### PR TITLE
Write built-in help/version text to Console.Out when using the default parser.

### DIFF
--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using CommandLine.Core;
 using CommandLine.Text;
@@ -19,7 +18,7 @@ namespace CommandLine
         private bool disposed;
         private readonly ParserSettings settings;
         private static readonly Lazy<Parser> DefaultParser = new Lazy<Parser>(
-            () => new Parser(new ParserSettings { HelpWriter = Console.Error }));
+            () => new Parser(new ParserSettings { HelpWriter = HelpWriter.Default }));
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandLine.Parser"/> class.
@@ -198,12 +197,12 @@ namespace CommandLine
                 settings.MaximumDisplayWidth);
         }
 
-        private static ParserResult<T> DisplayHelp<T>(ParserResult<T> parserResult, TextWriter helpWriter, int maxDisplayWidth)
+        private static ParserResult<T> DisplayHelp<T>(ParserResult<T> parserResult, HelpWriter helpWriter, int maxDisplayWidth)
         {
             parserResult.WithNotParsed(
                 errors =>
                     Maybe.Merge(errors.ToMaybe(), helpWriter.ToMaybe())
-                        .Do((_, writer) => writer.Write(HelpText.AutoBuild(parserResult, maxDisplayWidth)))
+                        .Do((_, __) => helpWriter.WriteHelpText(errors, HelpText.AutoBuild(parserResult, maxDisplayWidth)))
                 );
 
             return parserResult;

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -3,8 +3,8 @@
 using System;
 using System.Globalization;
 using System.IO;
-
 using CommandLine.Infrastructure;
+using CommandLine.Text;
 
 namespace CommandLine
 {
@@ -18,7 +18,7 @@ namespace CommandLine
         private bool disposed;
         private bool caseSensitive;
         private bool caseInsensitiveEnumValues;
-        private TextWriter helpWriter;
+        private HelpWriter helpWriter;
         private bool ignoreUnknownArguments;
         private bool autoHelp;
         private bool autoVersion;
@@ -97,13 +97,13 @@ namespace CommandLine
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="System.IO.TextWriter"/> used for help method output.
+        /// Gets or sets the <see cref="Text.HelpWriter"/> used for help method output.
         /// Setting this property to null, will disable help screen.
         /// </summary>
         /// <remarks>
-        /// It is the caller's responsibility to dispose or close the <see cref="TextWriter"/>.
+        /// It is the caller's responsibility to dispose or close the <see cref="TextWriter"/>(s) inside the <see cref="Text.HelpWriter"/>.
         /// </remarks>
-        public TextWriter HelpWriter
+        public HelpWriter HelpWriter
         {
             get { return helpWriter; }
             set { PopsicleSetter.Set(Consumed, ref helpWriter, value); }

--- a/src/CommandLine/Text/HelpWriter.cs
+++ b/src/CommandLine/Text/HelpWriter.cs
@@ -1,0 +1,86 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace CommandLine.Text
+{
+    /// <summary>
+    /// Provides a way to write <see cref="HelpText"/> to a <see cref="TextWriter"/> with the option to distinguish between user requested and parsing error triggered help.
+    /// </summary>
+    public class HelpWriter
+    {
+        private static readonly Lazy<HelpWriter> DefaultWriter = new Lazy<HelpWriter>(() => new HelpWriter(Console.Out, Console.Error));
+
+        private readonly TextWriter writer;
+        private readonly TextWriter errorWriter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HelpWriter"/> class that writes all <see cref="HelpText"/> to the same <see cref="TextWriter"/>.
+        /// The user is responsible for disposing the provided <see cref="TextWriter"/> instance.
+        /// </summary>
+        /// <param name="writer">The <see cref="TextWriter"/> to write all <see cref="HelpText"/> to.</param>
+        public HelpWriter(TextWriter writer)
+            : this(writer, writer)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HelpWriter"/> class that writes user requested <see cref="HelpText"/> to the <see cref="TextWriter"/> provided through
+        /// <paramref name="writer"/> and error triggered <see cref="HelpText"/> to the <see cref="TextWriter"/> provided through <paramref name="errorWriter"/>.
+        /// The user is responsible for disposing the provided <see cref="TextWriter"/> instances.
+        /// </summary>
+        /// <param name="writer">The <see cref="TextWriter"/> to write user requested <see cref="HelpText"/> to.</param>
+        /// <param name="errorWriter">The <see cref="TextWriter"/> to write error triggered <see cref="HelpText"/> to.</param>
+        public HelpWriter(TextWriter writer, TextWriter errorWriter)
+        {
+            this.writer = writer;
+            this.errorWriter = errorWriter;
+        }
+
+        /// <summary>
+        /// Gets a default <see cref="HelpWriter"/> that writes user requested <see cref="HelpText"/> to <see cref="Console.Out"/>
+        /// and error triggered <see cref="HelpText"/> to <see cref="Console.Error"/>.
+        /// </summary>
+        public static HelpWriter Default
+        {
+            get { return DefaultWriter.Value; }
+        }
+
+        /// <summary>
+        /// Writes the provided <see cref="HelpText"/> to the <see cref="TextWriter"/>(s) this <see cref="HelpWriter"/> was initialized with.
+        /// </summary>
+        /// <param name="errors">The <see cref="Error"/> instances to use when determining whether or not the <paramref name="helpText"/> was user requested or error triggered.</param>
+        /// <param name="helpText">The <see cref="HelpText"/> to write to the <see cref="TextWriter"/>(s).</param>
+        public void WriteHelpText(IEnumerable<Error> errors, HelpText helpText)
+        {
+            if (writer == null && errorWriter == null || helpText == null)
+            {
+                return;
+            }
+
+            TextWriter targetWriter = null;
+
+            bool isUserRequestedError(Error error)
+            {
+                return error != null
+                    && error.Tag == ErrorType.VersionRequestedError
+                    || error.Tag == ErrorType.HelpRequestedError
+                    || error.Tag == ErrorType.HelpVerbRequestedError;
+            }
+
+            if (writer == errorWriter || errors != null && errors.Any(isUserRequestedError))
+            {
+                targetWriter = writer;
+            }
+            else
+            {
+                targetWriter = errorWriter;
+            }
+
+            targetWriter?.Write(helpText);
+        }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/ParserSettingsTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserSettingsTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using CommandLine.Text;
 using FluentAssertions;
 using Xunit;
 
@@ -34,7 +35,7 @@ namespace CommandLine.Tests.Unit
             {
                 using (ParserSettings parserSettings = new ParserSettings())
                 {
-                    parserSettings.HelpWriter = textWriter;
+                    parserSettings.HelpWriter = new HelpWriter(textWriter);
                 }
 
                 textWriter.Disposed.Should().BeFalse("not disposed");

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using CommandLine.Tests.Fakes;
+using CommandLine.Text;
 using FluentAssertions;
 using Xunit;
 
@@ -18,7 +19,7 @@ namespace CommandLine.Tests.Unit
         {
             // Fixture setup
             var writer = new StringWriter();
-            var sut = new Parser(with => with.HelpWriter = writer);
+            var sut = new Parser(with => with.HelpWriter = new HelpWriter(writer));
 
             // Exercize system
             sut.ParseArguments<Options_With_Required_Set_To_True>(new string[] { });
@@ -34,7 +35,7 @@ namespace CommandLine.Tests.Unit
         {
             // Fixture setup
             var writer = new StringWriter();
-            var sut = new Parser(with => with.HelpWriter = writer);
+            var sut = new Parser(with => with.HelpWriter = new HelpWriter(writer));
 
             // Exercize system
             sut.ParseArguments(new string[] { }, typeof(Add_Verb), typeof(Commit_Verb), typeof(Clone_Verb));
@@ -50,7 +51,7 @@ namespace CommandLine.Tests.Unit
         {
             // Fixture setup
             var writer = new StringWriter();
-            var sut = new Parser(with => with.HelpWriter = writer);
+            var sut = new Parser(with => with.HelpWriter = new HelpWriter(writer));
 
             // Exercize system
             sut.ParseArguments<Add_Verb, Commit_Verb, Clone_Verb>(new string[] { });
@@ -299,7 +300,7 @@ namespace CommandLine.Tests.Unit
         {
             // Fixture setup
             var help = new StringWriter();
-            var sut = new Parser(config => config.HelpWriter = help);
+            var sut = new Parser(config => config.HelpWriter = new HelpWriter(help));
 
             // Exercize system
             sut.ParseArguments<Immutable_Simple_Options>(new[] { "--help" });
@@ -331,7 +332,7 @@ namespace CommandLine.Tests.Unit
         {
             // Fixture setup
             var help = new StringWriter();
-            var sut = new Parser(config => config.HelpWriter = help);
+            var sut = new Parser(config => config.HelpWriter = new HelpWriter(help));
 
             // Exercize system
             sut.ParseArguments<Simple_Options>(new[] { "--version" });
@@ -355,7 +356,7 @@ namespace CommandLine.Tests.Unit
         {
             // Fixture setup
             var help = new StringWriter();
-            var sut = new Parser(config => config.HelpWriter = help);
+            var sut = new Parser(config => config.HelpWriter = new HelpWriter(help));
 
             // Exercize system
             sut.ParseArguments<Add_Verb, Commit_Verb, Clone_Verb>(new string[] { });
@@ -387,7 +388,7 @@ namespace CommandLine.Tests.Unit
         {
             // Fixture setup
             var help = new StringWriter();
-            var sut = new Parser(config => config.HelpWriter = help);
+            var sut = new Parser(config => config.HelpWriter = new HelpWriter(help));
 
             // Exercize system
             sut.ParseArguments<Add_Verb, Commit_Verb, Clone_Verb>(new[] { "--help" });
@@ -418,7 +419,7 @@ namespace CommandLine.Tests.Unit
         {
             // Fixture setup
             var help = new StringWriter();
-            var sut = new Parser(config => config.HelpWriter = help);
+            var sut = new Parser(config => config.HelpWriter = new HelpWriter(help));
 
             // Exercize system
             sut.ParseArguments<Add_Verb, Commit_Verb, Clone_Verb>(new[] { command });
@@ -442,7 +443,7 @@ namespace CommandLine.Tests.Unit
         {
             // Fixture setup
             var help = new StringWriter();
-            var sut = new Parser(config => config.HelpWriter = help);
+            var sut = new Parser(config => config.HelpWriter = new HelpWriter(help));
 
             // Exercize system
             sut.ParseArguments<Options_With_Two_Option_Required_Set_To_True_And_Two_Sets>(new[] { "--weburl=value.com", "--ftpurl=value.org" });
@@ -474,7 +475,7 @@ namespace CommandLine.Tests.Unit
         {
             // Fixture setup
             var help = new StringWriter();
-            var sut = new Parser(config => config.HelpWriter = help);
+            var sut = new Parser(config => config.HelpWriter = new HelpWriter(help));
 
             // Exercize system
             sut.ParseArguments<Add_Verb, Commit_Verb, Clone_Verb>(new[] { "commit", "--help" });
@@ -492,7 +493,7 @@ namespace CommandLine.Tests.Unit
             var help = new StringWriter();
             var sut = new Parser(config =>
             {
-                config.HelpWriter = help;
+                config.HelpWriter = new HelpWriter(help);
                 config.MaximumDisplayWidth = 80;
             });
 
@@ -535,7 +536,7 @@ namespace CommandLine.Tests.Unit
         {
             // Fixture setup
             var help = new StringWriter();
-            var sut = new Parser(config => config.HelpWriter = help);
+            var sut = new Parser(config => config.HelpWriter = new HelpWriter(help));
 
             // Exercize system
             sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { });
@@ -565,7 +566,7 @@ namespace CommandLine.Tests.Unit
         {
             // Fixture setup
             var help = new StringWriter();
-            var sut = new Parser(config => config.HelpWriter = help);
+            var sut = new Parser(config => config.HelpWriter = new HelpWriter(help));
 
             // Exercize system
             sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { "secert", "--help" });
@@ -594,7 +595,7 @@ namespace CommandLine.Tests.Unit
             // Fixture setup
             var expectedOptions = new Secert_Verb { Force = true, SecertOption = null};
             var help = new StringWriter();
-            var sut = new Parser(config => config.HelpWriter = help);
+            var sut = new Parser(config => config.HelpWriter = new HelpWriter(help));
 
             // Exercize system
             var result = sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { "secert", "--force" });
@@ -614,7 +615,7 @@ namespace CommandLine.Tests.Unit
             // Fixture setup
             var expectedOptions = new Secert_Verb { Force = true, SecertOption = "shhh" };
             var help = new StringWriter();
-            var sut = new Parser(config => config.HelpWriter = help);
+            var sut = new Parser(config => config.HelpWriter = new HelpWriter(help));
 
             // Exercize system
             var result = sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { "secert", "--force", "--secert-option", "shhh" });
@@ -634,7 +635,7 @@ namespace CommandLine.Tests.Unit
             var help = new StringWriter();
             var sut = new Parser(config =>
             {
-                config.HelpWriter = help;
+                config.HelpWriter = new HelpWriter(help);
                 config.MaximumDisplayWidth = 80;
             });
 
@@ -708,7 +709,7 @@ namespace CommandLine.Tests.Unit
             var help = new StringWriter();
             var sut = new Parser(config =>
             {
-                config.HelpWriter = help;
+                config.HelpWriter = new HelpWriter(help);
                 config.MaximumDisplayWidth = 80;
             });
 

--- a/tests/CommandLine.Tests/Unit/Text/HelpWriterTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpWriterTests.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using CommandLine.Tests.Fakes;
+using CommandLine.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace CommandLine.Tests.Unit.Text
+{
+    public class HelpWriterTests
+    {
+        private static readonly HelpText TestHelpText = new HelpText("Test Heading", "Test Copyright");
+
+        private static readonly IEnumerable<Error> UserRequestedErrors = new Error[]
+        {
+            new HelpRequestedError(),
+            new HelpVerbRequestedError("add", typeof(Add_Verb), false),
+            new VersionRequestedError()
+        };
+
+        private static readonly IEnumerable<Error> ErrorTriggeredErrors = new Error[]
+        {
+            new BadFormatTokenError("someToken"),
+            new MissingValueOptionError(new NameInfo("t", "test")),
+            new UnknownOptionError("someToken"),
+            new MissingRequiredOptionError(new NameInfo("t", "test")),
+            new MutuallyExclusiveSetError(new NameInfo("t", "test"), "someSetName"),
+            new BadFormatConversionError(new NameInfo("t", "test")),
+            new SequenceOutOfRangeError(new NameInfo("t", "test")),
+            new RepeatedOptionError(new NameInfo("t", "test")),
+            new BadVerbSelectedError("someToken"),
+            new NoVerbSelectedError(),
+            new SetValueExceptionError(new NameInfo("t", "test"), new Exception(), 0)
+        };
+
+        [Fact]
+        public void Initializing_With_One_TextWriter_Writes_All_Help_To_That_Writer()
+        {
+            StringBuilder builder = new StringBuilder();
+            StringWriter writer = new StringWriter(builder);
+            HelpWriter helpWriter = new HelpWriter(writer);
+
+            AssertHelpWritten(helpWriter, UserRequestedErrors.Concat(ErrorTriggeredErrors), builder);
+        }
+
+        [Fact]
+        public void Initializing_With_Only_Writer_Writes_User_Requested_Help_To_That_Writer()
+        {
+            StringBuilder builder = new StringBuilder();
+            StringWriter writer = new StringWriter(builder);
+            HelpWriter helpWriter = new HelpWriter(writer, null);
+
+            AssertHelpWritten(helpWriter, UserRequestedErrors, builder);
+        }
+
+        [Fact]
+        public void Initializing_With_Only_Writer_Skips_Writing_Error_Triggered_Help_To_That_Writer()
+        {
+            StringBuilder builder = new StringBuilder();
+            StringWriter writer = new StringWriter(builder);
+            HelpWriter helpWriter = new HelpWriter(writer, null);
+
+            AssertNoHelpWritten(helpWriter, ErrorTriggeredErrors, builder);
+        }
+
+        [Fact]
+        public void Initializing_With_Only_ErrorWriter_Writes_Error_Triggered_Help_To_That_Writer()
+        {
+            StringBuilder builder = new StringBuilder();
+            StringWriter writer = new StringWriter(builder);
+            HelpWriter helpWriter = new HelpWriter(null, writer);
+
+            AssertHelpWritten(helpWriter, ErrorTriggeredErrors, builder);
+        }
+
+        [Fact]
+        public void Initializing_With_Only_ErrorWriter_Skips_Writing_User_Requested_Help_To_That_Writer()
+        {
+            StringBuilder builder = new StringBuilder();
+            StringWriter writer = new StringWriter(builder);
+            HelpWriter helpWriter = new HelpWriter(null, writer);
+
+            AssertNoHelpWritten(helpWriter, UserRequestedErrors, builder);
+        }
+
+        [Fact]
+        public void Initializing_With_Both_Writers_Redirects_Help_Based_On_Errors()
+        {
+            StringBuilder userRequestedBuilder = new StringBuilder();
+            StringBuilder errorTriggeredBuilder = new StringBuilder();
+
+            StringWriter userRequestedWriter = new StringWriter(userRequestedBuilder);
+            StringWriter errorTriggeredWriter = new StringWriter(errorTriggeredBuilder);
+
+            HelpWriter helpWriter = new HelpWriter(userRequestedWriter, errorTriggeredWriter);
+
+            foreach (Error error in UserRequestedErrors)
+            {
+                userRequestedBuilder.Length.Should().Be(0, "no help text should have been written to the writer before WriteHelpText is called.");
+                errorTriggeredBuilder.Length.Should().Be(0, "no help text should have been written to the writer before WriteHelpText is called.");
+
+                Error[] currentError = new Error[] { error };
+
+                helpWriter.WriteHelpText(currentError, TestHelpText);
+
+                userRequestedBuilder.Length.Should().BeGreaterThan(0, "user requested help text should have been written to the writer.");
+                errorTriggeredBuilder.Length.Should().Be(0, "no user requested help text should have been written to the writer.");
+
+                userRequestedBuilder.Clear();
+            }
+
+            foreach (Error error in ErrorTriggeredErrors)
+            {
+                userRequestedBuilder.Length.Should().Be(0, "no help text should have been written to the writer before WriteHelpText is called.");
+                errorTriggeredBuilder.Length.Should().Be(0, "no help text should have been written to the writer before WriteHelpText is called.");
+
+                Error[] currentError = new Error[] { error };
+
+                helpWriter.WriteHelpText(currentError, TestHelpText);
+
+                userRequestedBuilder.Length.Should().Be(0, "no error triggered help text should have been written to the writer.");
+                errorTriggeredBuilder.Length.Should().BeGreaterThan(0, "error triggered help text should have been written to the writer.");
+
+                errorTriggeredBuilder.Clear();
+            }
+        }
+
+        private void AssertHelpWritten(HelpWriter helpWriter, IEnumerable<Error> errors, StringBuilder builder)
+        {
+            foreach (Error error in errors)
+            {
+                builder.Length.Should().Be(0, "no help text should have been written to the writer before WriteHelpText is called.");
+
+                Error[] currentError = new Error[] { error };
+
+                helpWriter.WriteHelpText(currentError, TestHelpText);
+
+                builder.Length.Should().BeGreaterThan(0, "help text should have been written to the writer.");
+
+                builder.Clear();
+            }
+        }
+
+        private void AssertNoHelpWritten(HelpWriter helpWriter, IEnumerable<Error> errors, StringBuilder builder)
+        {
+            foreach (Error error in errors)
+            {
+                builder.Length.Should().Be(0, "no help text should have been written to the writer before WriteHelpText is called.");
+
+                Error[] currentError = new Error[] { error };
+
+                helpWriter.WriteHelpText(currentError, TestHelpText);
+
+                builder.Length.Should().Be(0, "no help text should have been written to the writer.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #399.

Instead of adding another TextWriter property to ParserSettings I've opted to move the new behavior into a separate class.

This ensures that:
- Disabling all help text via ```settings.HelpWriter = null``` still works.
- Developers assigning their own TextWriter are notified that the help text output can be split into user requested help and parser error triggered help because the HelpWriter class cannot be assigned with a TextWriter so updating the library will break their builds at the assignment code.
- Because their build breaks after updating, developers won't miss help text output they may have expected to be written to their own TextWriter just because they didn't notice a new TextWriter property in the ParserSettings.
- Developers can still get the old behavior where all help text is written to the same TextWriter by changing their code from ```settings.HelpWriter = textWriter``` to ```settings.HelpWriter = new HelpWriter(textWriter)```.

Should this fix be considered adequate then the [wiki page](https://github.com/commandlineparser/commandline/wiki/Generating-Help-and-Usage-information#customizing-help-output) for customizing help output might also need an update.