### PR TITLE
Fix #379, Enum with 0 value not shown on Example

### DIFF
--- a/src/CommandLine/UnParserExtensions.cs
+++ b/src/CommandLine/UnParserExtensions.cs
@@ -121,7 +121,7 @@ namespace CommandLine
                     type.GetSpecifications(
                         pi => new { Specification = Specification.FromProperty(pi),
                             Value = pi.GetValue(options, null).NormalizeValue(), PropertyValue = pi.GetValue(options, null) })
-                where !info.PropertyValue.IsEmpty()
+                where !info.PropertyValue.IsEmpty(info.Specification)
                 select info)
                     .Memorize();
 
@@ -242,14 +242,13 @@ namespace CommandLine
             return value;
         }
 
-        private static bool IsEmpty(this object value)
+        private static bool IsEmpty(this object value, Specification spec)
         {
             if (value == null) return true;
 #if !SKIP_FSHARP
             if (ReflectionHelper.IsFSharpOptionType(value.GetType()) && !FSharpOptionHelper.IsSome(value)) return true;
 #endif
-            if (value is Enum) return false;
-            if (value is ValueType && value.Equals(value.GetType().GetDefaultValue())) return true;
+            if (!spec.Required && value is ValueType && value.Equals(value.GetType().GetDefaultValue())) return true;
             if (value is string && ((string)value).Length == 0) return true;
             if (value is IEnumerable && !((IEnumerable)value).GetEnumerator().MoveNext()) return true;
             return false;

--- a/src/CommandLine/UnParserExtensions.cs
+++ b/src/CommandLine/UnParserExtensions.cs
@@ -248,6 +248,7 @@ namespace CommandLine
 #if !SKIP_FSHARP
             if (ReflectionHelper.IsFSharpOptionType(value.GetType()) && !FSharpOptionHelper.IsSome(value)) return true;
 #endif
+            if (value is Enum) return false;
             if (value is ValueType && value.Equals(value.GetType().GetDefaultValue())) return true;
             if (value is string && ((string)value).Length == 0) return true;
             if (value is IEnumerable && !((IEnumerable)value).GetEnumerator().MoveNext()) return true;

--- a/tests/CommandLine.Tests/Fakes/Help_Fakes.cs
+++ b/tests/CommandLine.Tests/Fakes/Help_Fakes.cs
@@ -93,24 +93,32 @@ namespace CommandLine.Tests.Fakes
         }
     }
 
-    class Required_Enum_Option_With_Usage_Attribute
+    class Options_With_Default_Value_Examples
     {
-        [Option('t', "type", Required = true, HelpText = "My entity")]
+        [Option('t', "type", Required = true)]
         public EntityType MyEntityType { get; set; }
 
         public enum EntityType
         {
-            T0,
-            T1
+            T0
         }
 
-        [Usage(ApplicationAlias = "testapp.exe")]
+        [Option('i', "int", Required = true)]
+        public int Int { get; set; }
+
+        [Option('d', "double", Required = true)]
+        public double Double { get; set; }
+
+        [Option('o', "optional")]
+        public bool Optional { get; set; }
+
+        [Usage(ApplicationAlias = "mono testapp.exe")]
         public static IEnumerable<Example> Examples
         {
             get
             {
-                yield return new Example(EntityType.T0.ToString(), new Required_Enum_Option_With_Usage_Attribute { MyEntityType = EntityType.T0 });
-                yield return new Example(EntityType.T1.ToString(), new Required_Enum_Option_With_Usage_Attribute { MyEntityType = EntityType.T1 });
+                yield return new Example("Normal scenario", new Options_With_Default_Value_Examples { });
+                yield return new Example("With Optional Value", new Options_With_Default_Value_Examples { Optional = true });
             }
         }
     }

--- a/tests/CommandLine.Tests/Fakes/Help_Fakes.cs
+++ b/tests/CommandLine.Tests/Fakes/Help_Fakes.cs
@@ -93,6 +93,28 @@ namespace CommandLine.Tests.Fakes
         }
     }
 
+    class Required_Enum_Option_With_Usage_Attribute
+    {
+        [Option('t', "type", Required = true, HelpText = "My entity")]
+        public EntityType MyEntityType { get; set; }
+
+        public enum EntityType
+        {
+            T0,
+            T1
+        }
+
+        [Usage(ApplicationAlias = "testapp.exe")]
+        public static IEnumerable<Example> Examples
+        {
+            get
+            {
+                yield return new Example(EntityType.T0.ToString(), new Required_Enum_Option_With_Usage_Attribute { MyEntityType = EntityType.T0 });
+                yield return new Example(EntityType.T1.ToString(), new Required_Enum_Option_With_Usage_Attribute { MyEntityType = EntityType.T1 });
+            }
+        }
+    }
+
     [Verb("secert", Hidden = true, HelpText = "This is a secert hidden verb that should never be visible to the user via help text.")]
     public class Secert_Verb
     {

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -495,12 +495,12 @@ namespace CommandLine.Tests.Unit.Text
         }
 
         [Fact]
-        public static void RenderUsageText_returns_proper_text_for_required_enum_option()
+        public static void RenderUsageText_returns_proper_text_for_Examples_with_default_values()
         {
             // Fixture setup
-            ParserResult<Required_Enum_Option_With_Usage_Attribute> result =
-                new NotParsed<Required_Enum_Option_With_Usage_Attribute>(
-                    TypeInfo.Create(typeof(Required_Enum_Option_With_Usage_Attribute)), Enumerable.Empty<Error>());
+            ParserResult<Options_With_Default_Value_Examples> result =
+                new NotParsed<Options_With_Default_Value_Examples>(
+                    TypeInfo.Create(typeof(Options_With_Default_Value_Examples)), Enumerable.Empty<Error>());
 
             // Exercize system
             var text = HelpText.RenderUsageText(result);
@@ -508,10 +508,10 @@ namespace CommandLine.Tests.Unit.Text
             // Verify outcome
             var lines = text.ToNotEmptyLines();
 
-            lines[0].Should().BeEquivalentTo("T0:");
-            lines[1].Should().BeEquivalentTo("  testapp.exe --type T0");
-            lines[2].Should().BeEquivalentTo("T1:");
-            lines[3].Should().BeEquivalentTo("  testapp.exe --type T1");
+            lines[0].Should().BeEquivalentTo("Normal scenario:");
+            lines[1].Should().BeEquivalentTo("  mono testapp.exe --double 0 --int 0 --type T0");
+            lines[2].Should().BeEquivalentTo("With Optional Value:");
+            lines[3].Should().BeEquivalentTo("  mono testapp.exe --double 0 --int 0 --optional --type T0");
 
             // Teardown
         }

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -494,6 +494,28 @@ namespace CommandLine.Tests.Unit.Text
             lines[10].Should().BeEquivalentTo("  mono testapp.exe value");
         }
 
+        [Fact]
+        public static void RenderUsageText_returns_proper_text_for_required_enum_option()
+        {
+            // Fixture setup
+            ParserResult<Required_Enum_Option_With_Usage_Attribute> result =
+                new NotParsed<Required_Enum_Option_With_Usage_Attribute>(
+                    TypeInfo.Create(typeof(Required_Enum_Option_With_Usage_Attribute)), Enumerable.Empty<Error>());
+
+            // Exercize system
+            var text = HelpText.RenderUsageText(result);
+
+            // Verify outcome
+            var lines = text.ToNotEmptyLines();
+
+            lines[0].Should().BeEquivalentTo("T0:");
+            lines[1].Should().BeEquivalentTo("  testapp.exe --type T0");
+            lines[2].Should().BeEquivalentTo("T1:");
+            lines[3].Should().BeEquivalentTo("  testapp.exe --type T1");
+
+            // Teardown
+        }
+
         //[Fact]
         public void Invoke_AutoBuild_for_Options_with_Usage_returns_appropriate_formatted_text()
         {


### PR DESCRIPTION
See #379

The bug seems to be caused by
https://github.com/commandlineparser/commandline/blob/4d69a3898b84c821161b2db948075cd9e162832c/src/CommandLine/UnParserExtensions.cs#L251

returned to
https://github.com/commandlineparser/commandline/blob/4d69a3898b84c821161b2db948075cd9e162832c/src/CommandLine/UnParserExtensions.cs#L124

I ran all tests after the change and none of them failed.