### PR TITLE
Improve support for multiline help text

### DIFF
--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -657,7 +657,7 @@ namespace CommandLine.Text
                 .ToString();
         }
 
-     internal static void AddLine(StringBuilder builder, string value, int maximumLength)
+        internal static void AddLine(StringBuilder builder, string value, int maximumLength)
         {
             if (builder == null)
             {
@@ -730,7 +730,7 @@ namespace CommandLine.Text
             return optionSpecs;
         }
 
-       private HelpText AddOptionsImpl(
+        private HelpText AddOptionsImpl(
             IEnumerable<Specification> specifications,
             string requiredWord,
             int maximumLength)

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -971,7 +971,12 @@ namespace CommandLine.Text
         private static string WrapAndIndentText(string input,int indentLevel,int columnWidth)
         {
             //start by splitting at newlines and then reinserting the newline as a separate word
-            var lines = input.Split(new[] {Environment.NewLine}, StringSplitOptions.None);
+            //Note that on the input side, we can't assume the line-break style at run time so we have to
+            //be able to handle both.  We cant use Environment.NewLine because that changes at
+            //_runtime_ and may not match the line-break style that was compiled in
+            var lines = input
+                .Replace("\r","")
+                .Split(new[] {'\n'}, StringSplitOptions.None);
             var lineCount = lines.Length;
             
             var tokens = lines

--- a/src/CommandLine/Text/TextWrapper.cs
+++ b/src/CommandLine/Text/TextWrapper.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using CommandLine.Infrastructure;
+
+namespace CommandLine.Text
+{
+    /// <summary>
+    /// A utility class to word-wrap and indent blocks of text
+    /// </summary>
+    public class TextWrapper
+    {
+        private string[] lines;
+        public TextWrapper(string input)
+        {
+            //start by splitting at newlines and then reinserting the newline as a separate word
+            //Note that on the input side, we can't assume the line-break style at run time so we have to
+            //be able to handle both.  We can't use Environment.NewLine because that changes at
+            //_runtime_ and may not match the line-break style that was compiled in
+            lines = input
+                .Replace("\r","")
+                .Split(new[] {'\n'}, StringSplitOptions.None);
+        }
+
+        /// <summary>
+        /// Splits a string into a words and performs wrapping while also preserving line-breaks and sub-indentation
+        /// </summary>
+        /// <param name="columnWidth">The number of characters we can use for text</param>
+        /// <remarks>
+        /// This method attempts to wrap text without breaking words 
+        /// For example, if columnWidth is 10 , the input
+        /// "a string for wrapping 01234567890123"
+        /// would return
+        /// "a string
+        /// "for 
+        /// "wrapping
+        /// "0123456789
+        /// "0123"          
+        /// </remarks>
+        /// <returns>this</returns>
+        public TextWrapper WordWrap(int columnWidth)
+        {
+
+            lines= lines
+                .SelectMany(line => WordWrapLine(line, columnWidth))
+                .ToArray();
+            return this;
+        }
+
+        /// <summary>
+        /// Indent all lines in the TextWrapper by the desired number of spaces
+        /// </summary>
+        /// <param name="numberOfSpaces">The number of spaces to indent by</param>
+        /// <returns>this</returns>
+        public TextWrapper Indent(int numberOfSpaces)
+        {
+            lines = lines
+                .Select(line => numberOfSpaces.Spaces() + line)
+                .ToArray();
+            return this;
+        }
+
+        /// <summary>
+        /// Returns the current state of the TextWrapper as a string
+        /// </summary>
+        /// <returns></returns>
+        public string ToText()
+        {
+            //return the whole thing as a single string
+            return string.Join(Environment.NewLine,lines);
+        }
+
+        /// <summary>
+        /// Convenience method to wraps and indent a string in a single operation
+        /// </summary>
+        /// <param name="input">The string to operate on</param>
+        /// <param name="indentLevel">The number of spaces to indent by</param>
+        /// <param name="columnWidth">The width of the column used for wrapping</param>
+        /// <remarks>
+        /// The string is wrapped _then_ indented so the columnWidth is the width of the
+        /// usable text block, and does NOT include the indentLevel.
+        /// </remarks>
+        /// <returns>the processed string</returns>
+        public static string WrapAndIndentText(string input, int indentLevel,int columnWidth)
+        {
+            return new TextWrapper(input)
+                .WordWrap(columnWidth)
+                .Indent(indentLevel)
+                .ToText();
+        }
+
+
+        private string [] WordWrapLine(string line,int columnWidth)
+        {
+            //create a list of individual lines generated from the supplied line
+
+            //When handling sub-indentation we must always reserve at least one column for text!
+            var unindentedLine = line.TrimStart();
+            var currentIndentLevel = Math.Min(line.Length - unindentedLine.Length,columnWidth-1) ;
+            columnWidth -= currentIndentLevel;
+
+            return unindentedLine.Split(' ')
+                .Aggregate(
+                    new List<StringBuilder>(),
+                    (lineList, word) => AddWordToLastLineOrCreateNewLineIfNecessary(lineList, word, columnWidth)
+                )
+                .Select(builder => currentIndentLevel.Spaces()+builder.ToString().TrimEnd())
+                .ToArray();
+        }
+
+        /// <summary>
+        /// When presented with a word, either append to the last line in the list or start a new line
+        /// </summary>
+        /// <param name="lines">A list of StringBuilders containing results so far</param>
+        /// <param name="word">The individual word to append</param>
+        /// <param name="columnWidth">The usable text space</param>
+        /// <remarks>
+        /// The 'word' can actually be an empty string.  It's important to keep these -
+        /// empty strings allow us to preserve indentation and extra spaces within a line.
+        /// </remarks>
+        /// <returns>The same list as is passed in</returns>
+        private static List<StringBuilder> AddWordToLastLineOrCreateNewLineIfNecessary(List<StringBuilder> lines, string word,int columnWidth)
+        {
+            //The current indentation level is based on the previous line but we need to be careful
+            var previousLine = lines.LastOrDefault()?.ToString() ??string.Empty;
+            
+            var wouldWrap = !lines.Any() || (word.Length>0 && previousLine.Length + word.Length > columnWidth);
+          
+            if (!wouldWrap)
+            {
+                //The usual case is we just append the 'word' and a space to the current line
+                //Note that trailing spaces will get removed later when we turn the line list 
+                //into a single string
+                lines.Last().Append(word + ' ');
+            }
+            else
+            {
+                //The 'while' here is to take account of the possibility of someone providing a word
+                //which just can't fit in the current column.  In that case we just split it at the 
+                //column end.
+                //That's a rare case though - most of the time we'll succeed in a single pass without
+                //having to split
+                //Note that we always do at least one pass even if the 'word' is empty in order to 
+                //honour sub-indentation and extra spaces within strings
+                do
+                {
+                    var availableCharacters = Math.Min(columnWidth, word.Length);
+                    var segmentToAdd = LeftString(word,availableCharacters) + ' ';
+                    lines.Add(new StringBuilder(segmentToAdd));
+                    word = RightString(word,availableCharacters);
+                } while (word.Length > 0);
+            }
+            return lines;
+        }
+
+       
+        private static string RightString(string str,int n)
+        {
+            return (n >= str.Length || str.Length==0) 
+                ? string.Empty 
+                : str.Substring(n);
+        }
+
+        private static string LeftString(string str,int n)
+        {
+            
+            return  (n >= str.Length || str.Length==0)
+                ? str 
+                : str.Substring(0,n);
+        }
+    }
+}

--- a/src/CommandLine/Text/TextWrapper.cs
+++ b/src/CommandLine/Text/TextWrapper.cs
@@ -155,13 +155,18 @@ namespace CommandLine.Text
         }
 
        
+        /// <summary>
+        /// Return the right part of a string in a way that compensates for Substring's deficiencies
+        /// </summary>
         private static string RightString(string str,int n)
         {
             return (n >= str.Length || str.Length==0) 
                 ? string.Empty 
                 : str.Substring(n);
         }
-
+        /// <summary>
+        /// Return the left part of a string in a way that compensates for Substring's deficiencies
+        /// </summary>
         private static string LeftString(string str,int n)
         {
             

--- a/src/CommandLine/Text/TextWrapper.cs
+++ b/src/CommandLine/Text/TextWrapper.cs
@@ -41,7 +41,8 @@ namespace CommandLine.Text
         /// <returns>this</returns>
         public TextWrapper WordWrap(int columnWidth)
         {
-
+            //ensure we always use at least 1 column even if the client has told us there's no space available
+            columnWidth = Math.Max(1, columnWidth);
             lines= lines
                 .SelectMany(line => WordWrapLine(line, columnWidth))
                 .ToArray();

--- a/tests/CommandLine.Tests/Fakes/HelpTextWithLineBreaksAndSubIndentation_Options.cs
+++ b/tests/CommandLine.Tests/Fakes/HelpTextWithLineBreaksAndSubIndentation_Options.cs
@@ -1,0 +1,13 @@
+﻿namespace CommandLine.Tests.Fakes
+{
+    public class HelpTextWithLineBreaksAndSubIndentation_Options
+    {
+
+        [Option(HelpText = @"This is a help text description where we want:
+    * The left pad after a linebreak to be honoured and the indentation to be preserved across to the next line
+    * The ability to return to no indent.
+Like this.")]
+        public string StringValue { get; set; }
+
+    }
+}

--- a/tests/CommandLine.Tests/Fakes/HelpTextWithLineBreaks_Options.cs
+++ b/tests/CommandLine.Tests/Fakes/HelpTextWithLineBreaks_Options.cs
@@ -1,0 +1,23 @@
+﻿namespace CommandLine.Tests.Fakes
+{
+    public class HelpTextWithLineBreaks_Options
+    {
+        [Option(HelpText = 
+            @"This is a help text description.
+It has multiple lines.
+We also want to ensure that indentation is correct.")]
+        public string StringValue { get; set; }
+
+
+        [Option(HelpText = @"This is a help text description where we want
+   The left pad after a linebreak to be honoured so that
+   we can sub-indent within a description.")]
+        public string StringValu2 { get; set; }
+
+
+        [Option(HelpText = @"This is a help text description where we want
+    The left pad after a linebreak to be honoured and the indentation to be preserved across to the next line in a way that looks pleasing")]
+        public string StringValu3 { get; set; }
+
+    }
+}

--- a/tests/CommandLine.Tests/Fakes/HelpTextWithMixedLineBreaks_Options.cs
+++ b/tests/CommandLine.Tests/Fakes/HelpTextWithMixedLineBreaks_Options.cs
@@ -1,0 +1,9 @@
+﻿namespace CommandLine.Tests.Fakes
+{
+    public class HelpTextWithMixedLineBreaks_Options
+    {
+        [Option(HelpText = 
+            "This is a help text description\n  It has multiple lines.\r\n  Third line")]
+        public string StringValue { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/StringExtensions.cs
+++ b/tests/CommandLine.Tests/StringExtensions.cs
@@ -13,6 +13,11 @@ namespace CommandLine.Tests
             return value.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
         }
 
+        public static string[] ToLines(this string value)
+        {
+            return value.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+        }
+
         public static string[] TrimStringArray(this IEnumerable<string> array)
         {
             return array.Select(item => item.Trim()).ToArray();

--- a/tests/CommandLine.Tests/Unit/Core/TextWrapperTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TextWrapperTests.cs
@@ -1,0 +1,170 @@
+﻿using CommandLine.Tests.Fakes;
+using CommandLine.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace CommandLine.Tests.Unit.Core
+{
+    public class TextWrapperTests
+    {
+        [Fact]
+        public void IndentWorksCorrectly()
+        {
+
+            var input =
+                @"line1
+line2";
+            var expected = @"  line1
+  line2";
+            var wrapper = new TextWrapper(input);
+            wrapper.Indent(2).ToText().Should().Be(expected);
+
+        }
+
+        [Fact]
+        public void SimpleWrappingIsAsExpected()
+        {
+
+            var input =
+                @"here is some text that needs wrapping";
+            var expected = @"here is
+some text
+that needs
+wrapping";
+            var wrapper = new TextWrapper(input);
+            wrapper.WordWrap(10).ToText().Should().Be(expected);
+
+        }
+
+        [Fact]
+        public void WrappingAvoidsBreakingWords()
+        {
+
+            var input =
+                @"here hippopotamus is some text that needs wrapping";
+            var expected = @"here
+hippopotamus is
+some text that
+needs wrapping";
+            var wrapper = new TextWrapper(input);
+            wrapper.WordWrap(15).ToText().Should().Be(expected);
+
+        }
+
+        [Fact]
+        public void WrappingObeysLineBreaksOfAllStyles()
+        {
+
+            var input =
+                "here is some text\nthat needs\r\nwrapping";
+            var expected = @"here is some text
+that needs
+wrapping";
+            var wrapper = new TextWrapper(input);
+            wrapper.WordWrap(20).ToText().Should().Be(expected);
+
+        }
+
+
+        [Fact]
+        public void WrappingPreservesSubIndentation()
+        {
+
+            var input =
+                "here is some text\n   that needs wrapping where we want the wrapped part to preserve indentation\nand this part to not be indented";
+            var expected = @"here is some text
+   that needs
+   wrapping where we
+   want the wrapped
+   part to preserve
+   indentation
+and this part to not
+be indented";
+            var wrapper = new TextWrapper(input);
+            wrapper.WordWrap(20).ToText().Should().Be(expected);
+
+        }
+
+        [Fact]
+        public void LongWordsAreBroken()
+        {
+
+            var input =
+                "here is some text that contains a veryLongWordThatWontFitOnASingleLine";
+            var expected = @"here is some text
+that contains a
+veryLongWordThatWont
+FitOnASingleLine";
+            var wrapper = new TextWrapper(input);
+            wrapper.WordWrap(20).ToText().Should().Be(expected);
+
+        }
+
+        [Fact]
+        public void SubIndentationIsPreservedWhenBreakingWords()
+        {
+
+            var input =
+                "here is some text that contains \n  a veryLongWordThatWontFitOnASingleLine";
+            var expected = @"here is some text
+that contains
+  a
+  veryLongWordThatWo
+  ntFitOnASingleLine";
+            var wrapper = new TextWrapper(input);
+            wrapper.WordWrap(20).ToText().Should().Be(expected);
+
+        }
+
+        [Fact]
+        public void SpacesWithinStringAreRespected()
+        {
+
+            var input =
+                "here     is some text with some extra spacing";
+            var expected = @"here     is some
+text with some extra
+spacing";
+            var wrapper = new TextWrapper(input);
+            wrapper.WordWrap(20).ToText().Should().Be(expected);
+
+        }
+
+        
+        [Fact]
+        public void ExtraSpacesAreTreatedAsNonBreaking()
+        {
+
+            var input =
+                "here is some text                                                          with some extra spacing";
+            var expected = @"here is some text
+with some extra
+spacing";
+            var wrapper = new TextWrapper(input);
+            wrapper.WordWrap(20).ToText().Should().Be(expected);
+
+        }
+
+         
+        [Fact]
+        public void WrappingExtraSpacesObeySubIndent()
+        {
+
+            var input =
+                "here is some\n   text                                                          with some extra spacing";
+            var expected = @"here is some
+   text
+   with some extra
+   spacing";
+            var wrapper = new TextWrapper(input);
+            wrapper.WordWrap(20).ToText().Should().Be(expected);
+
+        }
+
+
+
+    }
+
+
+    
+}

--- a/tests/CommandLine.Tests/Unit/Core/TextWrapperTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TextWrapperTests.cs
@@ -7,6 +7,17 @@ namespace CommandLine.Tests.Unit.Core
 {
     public class TextWrapperTests
     {
+        private string NormalizeLineBreaks(string str)
+        {
+            return str.Replace("\r", "");
+        }
+        private void EnsureEquivalent(string a,string b)
+        {
+            //workaround build system line-end inconsistencies
+            NormalizeLineBreaks(a).Should().Be(NormalizeLineBreaks(b));
+        }
+
+        
         [Fact]
         public void IndentWorksCorrectly()
         {
@@ -17,7 +28,7 @@ line2";
             var expected = @"  line1
   line2";
             var wrapper = new TextWrapper(input);
-            wrapper.Indent(2).ToText().Should().Be(expected);
+            EnsureEquivalent(wrapper.Indent(2).ToText(),expected);
 
         }
 
@@ -32,7 +43,7 @@ some text
 that needs
 wrapping";
             var wrapper = new TextWrapper(input);
-            wrapper.WordWrap(10).ToText().Should().Be(expected);
+            EnsureEquivalent(wrapper.WordWrap(10).ToText(),expected);
 
         }
 
@@ -47,7 +58,7 @@ hippopotamus is
 some text that
 needs wrapping";
             var wrapper = new TextWrapper(input);
-            wrapper.WordWrap(15).ToText().Should().Be(expected);
+            EnsureEquivalent(wrapper.WordWrap(15).ToText(),expected);
 
         }
 
@@ -61,7 +72,7 @@ needs wrapping";
 that needs
 wrapping";
             var wrapper = new TextWrapper(input);
-            wrapper.WordWrap(20).ToText().Should().Be(expected);
+            EnsureEquivalent(wrapper.WordWrap(20).ToText(),expected);
 
         }
 
@@ -81,7 +92,7 @@ wrapping";
 and this part to not
 be indented";
             var wrapper = new TextWrapper(input);
-            wrapper.WordWrap(20).ToText().Should().Be(expected);
+            EnsureEquivalent(wrapper.WordWrap(20).ToText(),expected);
 
         }
 
@@ -96,7 +107,7 @@ that contains a
 veryLongWordThatWont
 FitOnASingleLine";
             var wrapper = new TextWrapper(input);
-            wrapper.WordWrap(20).ToText().Should().Be(expected);
+            EnsureEquivalent(wrapper.WordWrap(20).ToText(),expected);
 
         }
 
@@ -112,7 +123,7 @@ that contains
   veryLongWordThatWo
   ntFitOnASingleLine";
             var wrapper = new TextWrapper(input);
-            wrapper.WordWrap(20).ToText().Should().Be(expected);
+            EnsureEquivalent(wrapper.WordWrap(20).ToText(),expected);
 
         }
 
@@ -126,7 +137,7 @@ that contains
 text with some extra
 spacing";
             var wrapper = new TextWrapper(input);
-            wrapper.WordWrap(20).ToText().Should().Be(expected);
+            EnsureEquivalent(wrapper.WordWrap(20).ToText(),expected);
 
         }
 
@@ -141,7 +152,7 @@ spacing";
 with some extra
 spacing";
             var wrapper = new TextWrapper(input);
-            wrapper.WordWrap(20).ToText().Should().Be(expected);
+            EnsureEquivalent(wrapper.WordWrap(20).ToText(),expected);
 
         }
 
@@ -157,7 +168,7 @@ spacing";
    with some extra
    spacing";
             var wrapper = new TextWrapper(input);
-            wrapper.WordWrap(20).ToText().Should().Be(expected);
+            EnsureEquivalent(wrapper.WordWrap(20).ToText(),expected);
 
         }
 

--- a/tests/CommandLine.Tests/Unit/Core/TextWrapperTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TextWrapperTests.cs
@@ -1,4 +1,5 @@
-﻿using CommandLine.Tests.Fakes;
+﻿using System;
+using System.Linq;
 using CommandLine.Text;
 using FluentAssertions;
 using Xunit;
@@ -11,31 +12,64 @@ namespace CommandLine.Tests.Unit.Core
         {
             return str.Replace("\r", "");
         }
-        private void EnsureEquivalent(string a,string b)
+
+        private void EnsureEquivalent(string a, string b)
         {
             //workaround build system line-end inconsistencies
             NormalizeLineBreaks(a).Should().Be(NormalizeLineBreaks(b));
         }
 
-        
+
+        [Fact]
+        public void ExtraSpacesAreTreatedAsNonBreaking()
+        {
+            var input =
+                "here is some text                                                          with some extra spacing";
+            var expected = @"here is some text
+with some extra
+spacing";
+            var wrapper = new TextWrapper(input);
+            EnsureEquivalent(wrapper.WordWrap(20).ToText(), expected);
+        }
+
+
         [Fact]
         public void IndentWorksCorrectly()
         {
-
             var input =
                 @"line1
 line2";
             var expected = @"  line1
   line2";
             var wrapper = new TextWrapper(input);
-            EnsureEquivalent(wrapper.Indent(2).ToText(),expected);
+            EnsureEquivalent(wrapper.Indent(2).ToText(), expected);
+        }
 
+        [Fact]
+        public void LongWordsAreBroken()
+        {
+            var input =
+                "here is some text that contains a veryLongWordThatWontFitOnASingleLine";
+            var expected = @"here is some text
+that contains a
+veryLongWordThatWont
+FitOnASingleLine";
+            var wrapper = new TextWrapper(input);
+            EnsureEquivalent(wrapper.WordWrap(20).ToText(), expected);
+        }
+
+        [Fact]
+        public void NegativeColumnWidthStillProducesOutput()
+        {
+            var input = @"test";
+            var expected = string.Join(Environment.NewLine, input.Select(c => c.ToString()));
+            var wrapper = new TextWrapper(input);
+            EnsureEquivalent(wrapper.WordWrap(-1).ToText(), expected);
         }
 
         [Fact]
         public void SimpleWrappingIsAsExpected()
         {
-
             var input =
                 @"here is some text that needs wrapping";
             var expected = @"here is
@@ -43,14 +77,69 @@ some text
 that needs
 wrapping";
             var wrapper = new TextWrapper(input);
-            EnsureEquivalent(wrapper.WordWrap(10).ToText(),expected);
+            EnsureEquivalent(wrapper.WordWrap(10).ToText(), expected);
+        }
 
+        [Fact]
+        public void SingleColumnStillProducesOutputForSubIndentation()
+        {
+            var input = @"test
+    ind";
+
+            var expected = @"t
+e
+s
+t
+i
+n
+d";
+            var wrapper = new TextWrapper(input);
+            EnsureEquivalent(wrapper.WordWrap(-1).ToText(), expected);
+        }
+
+        [Fact]
+        public void SpacesWithinStringAreRespected()
+        {
+            var input =
+                "here     is some text with some extra spacing";
+            var expected = @"here     is some
+text with some extra
+spacing";
+            var wrapper = new TextWrapper(input);
+            EnsureEquivalent(wrapper.WordWrap(20).ToText(), expected);
+        }
+
+        [Fact]
+        public void SubIndentationCorrectlyWrapsWhenColumnWidthRequiresIt()
+        {
+            var input = @"test
+    indented";
+            var expected = @"test
+    in
+    de
+    nt
+    ed";
+            var wrapper = new TextWrapper(input);
+            EnsureEquivalent(wrapper.WordWrap(6).ToText(), expected);
+        }
+
+        [Fact]
+        public void SubIndentationIsPreservedWhenBreakingWords()
+        {
+            var input =
+                "here is some text that contains \n  a veryLongWordThatWontFitOnASingleLine";
+            var expected = @"here is some text
+that contains
+  a
+  veryLongWordThatWo
+  ntFitOnASingleLine";
+            var wrapper = new TextWrapper(input);
+            EnsureEquivalent(wrapper.WordWrap(20).ToText(), expected);
         }
 
         [Fact]
         public void WrappingAvoidsBreakingWords()
         {
-
             var input =
                 @"here hippopotamus is some text that needs wrapping";
             var expected = @"here
@@ -58,29 +147,39 @@ hippopotamus is
 some text that
 needs wrapping";
             var wrapper = new TextWrapper(input);
-            EnsureEquivalent(wrapper.WordWrap(15).ToText(),expected);
+            EnsureEquivalent(wrapper.WordWrap(15).ToText(), expected);
+        }
 
+
+        [Fact]
+        public void WrappingExtraSpacesObeySubIndent()
+        {
+            var input =
+                "here is some\n   text                                                          with some extra spacing";
+            var expected = @"here is some
+   text
+   with some extra
+   spacing";
+            var wrapper = new TextWrapper(input);
+            EnsureEquivalent(wrapper.WordWrap(20).ToText(), expected);
         }
 
         [Fact]
         public void WrappingObeysLineBreaksOfAllStyles()
         {
-
             var input =
                 "here is some text\nthat needs\r\nwrapping";
             var expected = @"here is some text
 that needs
 wrapping";
             var wrapper = new TextWrapper(input);
-            EnsureEquivalent(wrapper.WordWrap(20).ToText(),expected);
-
+            EnsureEquivalent(wrapper.WordWrap(20).ToText(), expected);
         }
 
 
         [Fact]
         public void WrappingPreservesSubIndentation()
         {
-
             var input =
                 "here is some text\n   that needs wrapping where we want the wrapped part to preserve indentation\nand this part to not be indented";
             var expected = @"here is some text
@@ -92,90 +191,7 @@ wrapping";
 and this part to not
 be indented";
             var wrapper = new TextWrapper(input);
-            EnsureEquivalent(wrapper.WordWrap(20).ToText(),expected);
-
+            EnsureEquivalent(wrapper.WordWrap(20).ToText(), expected);
         }
-
-        [Fact]
-        public void LongWordsAreBroken()
-        {
-
-            var input =
-                "here is some text that contains a veryLongWordThatWontFitOnASingleLine";
-            var expected = @"here is some text
-that contains a
-veryLongWordThatWont
-FitOnASingleLine";
-            var wrapper = new TextWrapper(input);
-            EnsureEquivalent(wrapper.WordWrap(20).ToText(),expected);
-
-        }
-
-        [Fact]
-        public void SubIndentationIsPreservedWhenBreakingWords()
-        {
-
-            var input =
-                "here is some text that contains \n  a veryLongWordThatWontFitOnASingleLine";
-            var expected = @"here is some text
-that contains
-  a
-  veryLongWordThatWo
-  ntFitOnASingleLine";
-            var wrapper = new TextWrapper(input);
-            EnsureEquivalent(wrapper.WordWrap(20).ToText(),expected);
-
-        }
-
-        [Fact]
-        public void SpacesWithinStringAreRespected()
-        {
-
-            var input =
-                "here     is some text with some extra spacing";
-            var expected = @"here     is some
-text with some extra
-spacing";
-            var wrapper = new TextWrapper(input);
-            EnsureEquivalent(wrapper.WordWrap(20).ToText(),expected);
-
-        }
-
-        
-        [Fact]
-        public void ExtraSpacesAreTreatedAsNonBreaking()
-        {
-
-            var input =
-                "here is some text                                                          with some extra spacing";
-            var expected = @"here is some text
-with some extra
-spacing";
-            var wrapper = new TextWrapper(input);
-            EnsureEquivalent(wrapper.WordWrap(20).ToText(),expected);
-
-        }
-
-         
-        [Fact]
-        public void WrappingExtraSpacesObeySubIndent()
-        {
-
-            var input =
-                "here is some\n   text                                                          with some extra spacing";
-            var expected = @"here is some
-   text
-   with some extra
-   spacing";
-            var wrapper = new TextWrapper(input);
-            EnsureEquivalent(wrapper.WordWrap(20).ToText(),expected);
-
-        }
-
-
-
     }
-
-
-    
 }

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -860,5 +860,25 @@ namespace CommandLine.Tests.Unit
                     Assert.Equal("two", args.Arg2);
                 });
         }
+
+
+        [Fact]
+        public void Blank_lines_are_inserted_between_verbs()
+        {
+            // Fixture setup
+            var help = new StringWriter();
+            var sut = new Parser(config => config.HelpWriter = help);
+
+            // Exercize system
+            sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { });
+            var result = help.ToString();
+            
+            // Verify outcome
+            var lines = result.ToLines().TrimStringArray();
+            lines[6].Should().BeEquivalentTo("add        Add file contents to the index.");
+            lines[8].Should().BeEquivalentTo("help       Display more information on a specific command.");
+            lines[10].Should().BeEquivalentTo("version    Display version information.");
+            // Teardown
+        }
     }
 }

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -79,7 +79,7 @@ namespace CommandLine.Tests.Unit.Text
 
 
 
-        //[Fact]
+        [Fact]
         public void Create_instance_with_enum_options_enabled()
         {
             // Fixture setup
@@ -184,7 +184,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void When_help_text_has_hidden_option_it_should_not_be_added_to_help_text_output()
         {
             // Fixture setup
@@ -198,7 +198,7 @@ namespace CommandLine.Tests.Unit.Text
 
             // Verify outcome
             var lines = sut.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.None);
-            lines[2].Should().BeEquivalentTo("  v, verbose    This is the description of the verbosity to test out the "); //"The first line should have the arguments and the start of the Help Text.");
+            lines[2].Should().BeEquivalentTo("  v, verbose    This is the description of the verbosity to test out the"); //"The first line should have the arguments and the start of the Help Text.");
             //string formattingMessage = "Beyond the second line should be formatted as though it's in a column.";
             lines[3].Should().BeEquivalentTo("                wrapping capabilities of the Help Text.");
             // Teardown
@@ -309,7 +309,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Invoke_AutoBuild_for_Options_returns_appropriate_formatted_text()
         {
             // Fixture setup
@@ -330,9 +330,7 @@ namespace CommandLine.Tests.Unit.Text
             lines[0].Should().StartWithEquivalent("CommandLine");
             lines[1].Should().StartWithEquivalent("Copyright (c)");
 #else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+           // The first two lines depend on the test-runner so ignore them
 #endif
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Token 'badtoken' is not recognized.");
@@ -345,7 +343,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Invoke_AutoBuild_for_Verbs_with_specific_verb_returns_appropriate_formatted_text()
         {
             // Fixture setup
@@ -366,9 +364,7 @@ namespace CommandLine.Tests.Unit.Text
             lines[0].Should().StartWithEquivalent("CommandLine");
             lines[1].Should().StartWithEquivalent("Copyright (c)");
 #else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+         // The first two lines depend on the test-runner so ignore them
 #endif
             lines[2].Should().BeEquivalentTo("-p, --patch      Use the interactive patch selection interface to chose which");
             lines[3].Should().BeEquivalentTo("changes to commit.");
@@ -378,7 +374,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Invoke_AutoBuild_for_Verbs_with_specific_verb_returns_appropriate_formatted_text_given_display_width_100()
         {
             // Fixture setup
@@ -399,9 +395,7 @@ namespace CommandLine.Tests.Unit.Text
             lines[0].Should().StartWithEquivalent("CommandLine");
             lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
 #else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            // The first two lines depend on the test-runner so ignore them
 #endif
             lines[2].Should().BeEquivalentTo("-p, --patch      Use the interactive patch selection interface to chose which changes to commit.");
             lines[3].Should().BeEquivalentTo("--amend          Used to amend the tip of the current branch.");
@@ -410,7 +404,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Invoke_AutoBuild_for_Verbs_with_unknown_verb_returns_appropriate_formatted_text()
         {
             // Fixture setup
@@ -431,9 +425,7 @@ namespace CommandLine.Tests.Unit.Text
             lines[0].Should().StartWithEquivalent("CommandLine");
             lines[1].Should().StartWithEquivalent("Copyright (c)");
 #else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            // The first two lines depend on the test-runner so ignore them
 #endif
             lines[2].Should().BeEquivalentTo("add        Add file contents to the index.");
             lines[3].Should().BeEquivalentTo("commit     Record changes to the repository.");
@@ -496,7 +488,7 @@ namespace CommandLine.Tests.Unit.Text
             lines[10].Should().BeEquivalentTo("  mono testapp.exe value");
         }
 
-        //[Fact]
+        [Fact]
         public void Invoke_AutoBuild_for_Options_with_Usage_returns_appropriate_formatted_text()
         {
             // Fixture setup
@@ -518,32 +510,32 @@ namespace CommandLine.Tests.Unit.Text
             lines[1].Should().StartWithEquivalent("Copyright (c)");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            //the first lines may depend on the test-runner (Ncrunch in my case) so ignore them
+           
 #endif
             lines[2].Should().BeEquivalentTo("ERROR(S):");
-            lines[3].Should().BeEquivalentTo("Token 'badtoken' is not recognized.");
+            lines[3].Should().BeEquivalentTo("  Token 'badtoken' is not recognized.");
             lines[4].Should().BeEquivalentTo("USAGE:");
             lines[5].Should().BeEquivalentTo("Normal scenario:");
-            lines[6].Should().BeEquivalentTo("mono testapp.exe --input file.bin --output out.bin");
+            lines[6].Should().BeEquivalentTo("  mono testapp.exe --input file.bin --output out.bin");
             lines[7].Should().BeEquivalentTo("Logging warnings:");
-            lines[8].Should().BeEquivalentTo("mono testapp.exe -w --input file.bin");
+            lines[8].Should().BeEquivalentTo("  mono testapp.exe -w --input file.bin");
             lines[9].Should().BeEquivalentTo("Logging errors:");
-            lines[10].Should().BeEquivalentTo("mono testapp.exe -e --input file.bin");
-            lines[11].Should().BeEquivalentTo("mono testapp.exe --errs --input=file.bin");
+            lines[10].Should().BeEquivalentTo("  mono testapp.exe -e --input file.bin");
+            lines[11].Should().BeEquivalentTo("  mono testapp.exe --errs --input=file.bin");
             lines[12].Should().BeEquivalentTo("List:");
-            lines[13].Should().BeEquivalentTo("mono testapp.exe -l 1,2");
+            lines[13].Should().BeEquivalentTo("  mono testapp.exe -l 1,2");
             lines[14].Should().BeEquivalentTo("Value:");
-            lines[15].Should().BeEquivalentTo("mono testapp.exe value");
-            lines[16].Should().BeEquivalentTo("-i, --input     Set input file.");
-            lines[17].Should().BeEquivalentTo("-i, --output    Set output file.");
-            lines[18].Should().BeEquivalentTo("--verbose       Set verbosity level.");
-            lines[19].Should().BeEquivalentTo("-w, --warns     Log warnings.");
-            lines[20].Should().BeEquivalentTo("-e, --errs      Log errors.");
-            lines[21].Should().BeEquivalentTo("-l              List.");
-            lines[22].Should().BeEquivalentTo("--help          Display this help screen.");
-            lines[23].Should().BeEquivalentTo("--version       Display version information.");
-            lines[24].Should().BeEquivalentTo("value pos. 0    Value.");
+            lines[15].Should().BeEquivalentTo("  mono testapp.exe value");
+            lines[16].Should().BeEquivalentTo("  -i, --input     Set input file.");
+            lines[17].Should().BeEquivalentTo("  -i, --output    Set output file.");
+            lines[18].Should().BeEquivalentTo("  --verbose       Set verbosity level.");
+            lines[19].Should().BeEquivalentTo("  -w, --warns     Log warnings.");
+            lines[20].Should().BeEquivalentTo("  -e, --errs      Log errors.");
+            lines[21].Should().BeEquivalentTo("  -l              List.");
+            lines[22].Should().BeEquivalentTo("  --help          Display this help screen.");
+            lines[23].Should().BeEquivalentTo("  --version       Display version information.");
+            lines[24].Should().BeEquivalentTo("  value pos. 0    Value.");
 
             // Teardown
         }
@@ -736,6 +728,21 @@ namespace CommandLine.Tests.Unit.Text
          
             // Teardown
         }
+        [Fact]
+        public void HelpTextPreservesIndentationAcrossWordWrapWithSmallMaximumDisplayWidth()
+        {
+            // Fixture setup
+            // Exercise system 
+            var sut = new HelpText {AddDashesToOption = true,MaximumDisplayWidth = 10} 
+                .AddOptions(new NotParsed<Simple_Options>(TypeInfo.Create(typeof(HelpTextWithLineBreaksAndSubIndentation_Options)),
+                    Enumerable.Empty<Error>()));
 
+            // Verify outcome
+          
+            Assert.True(sut.ToString().Length>0);
+			
+            // Teardown
+        }
+        
     }
 }

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -718,5 +718,24 @@ namespace CommandLine.Tests.Unit.Text
         }
 
 
+        [Fact]
+        public void HelpTextIsConsitentRegardlessOfCompileTimeLineStyle()
+        {
+            // Fixture setup
+            // Exercize system 
+            var sut = new HelpText {AddDashesToOption = true}
+                .AddOptions(new NotParsed<Simple_Options>(TypeInfo.Create(typeof(HelpTextWithMixedLineBreaks_Options)),
+                    Enumerable.Empty<Error>()));
+
+            // Verify outcome
+
+            var lines = sut.ToString().ToNotEmptyLines();
+            lines[0].Should().BeEquivalentTo("  --stringvalue    This is a help text description");
+            lines[1].Should().BeEquivalentTo("                     It has multiple lines.");
+            lines[2].Should().BeEquivalentTo("                     Third line");
+         
+            // Teardown
+        }
+
     }
 }

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -540,7 +540,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-#if !PLATFORM_DOTNET
+
         [Fact]
         public void Default_set_to_sequence_should_be_properly_printed()
         {
@@ -566,7 +566,6 @@ namespace CommandLine.Tests.Unit.Text
 
             // Teardown
         }
-#endif
 
         [Fact]
         public void AutoBuild_when_no_assembly_attributes()
@@ -744,5 +743,34 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
         
+     
+
+        [Fact]
+        public void Options_should_be_separated_by_spaces()
+        {
+            // Fixture setup
+            var handlers = new CultureInfo("en-US").MakeCultureHandlers();
+            var fakeResult =
+                new NotParsed<Options_With_Default_Set_To_Sequence>(
+                    typeof(Options_With_Default_Set_To_Sequence).ToTypeInfo(),
+                    Enumerable.Empty<Error>()
+                    );
+
+            // Exercize system
+            handlers.ChangeCulture();
+            var helpText = HelpText.AutoBuild(fakeResult);
+            handlers.ResetCulture();
+
+            // Verify outcome
+            var text = helpText.ToString();
+            var lines = text.ToLines().TrimStringArray();
+            Console.WriteLine(text);
+            lines[3].Should().Be("-z, --strseq    (Default: a b c)");
+            lines[5].Should().Be("-y, --intseq    (Default: 1 2 3)");
+            lines[7].Should().Be("-q, --dblseq    (Default: 1.1 2.2 3.3)");
+
+            // Teardown
+        }
+
     }
 }

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -77,6 +77,8 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
+
+
         //[Fact]
         public void Create_instance_with_enum_options_enabled()
         {
@@ -154,10 +156,10 @@ namespace CommandLine.Tests.Unit.Text
             var lines = sut.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.None);
             lines[2].Should().BeEquivalentTo("  v, verbose    This is the description"); //"The first line should have the arguments and the start of the Help Text.");
             //string formattingMessage = "Beyond the second line should be formatted as though it's in a column.";
-            lines[3].Should().BeEquivalentTo("                of the verbosity to ");
-            lines[4].Should().BeEquivalentTo("                test out the wrapping ");
-            lines[5].Should().BeEquivalentTo("                capabilities of the ");
-            lines[6].Should().BeEquivalentTo("                Help Text.");
+            lines[3].Should().BeEquivalentTo("                of the verbosity to test");
+            lines[4].Should().BeEquivalentTo("                out the wrapping");
+            lines[5].Should().BeEquivalentTo("                capabilities of the Help");
+            lines[6].Should().BeEquivalentTo("                Text.");
             // Teardown
         }
         
@@ -176,7 +178,7 @@ namespace CommandLine.Tests.Unit.Text
 
             // Verify outcome
             var lines = sut.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.None);
-            lines[2].Should().BeEquivalentTo("  v, verbose    This is the description of the verbosity to test out the wrapping capabilities of "); //"The first line should have the arguments and the start of the Help Text.");
+            lines[2].Should().BeEquivalentTo("  v, verbose    This is the description of the verbosity to test out the wrapping capabilities of"); //"The first line should have the arguments and the start of the Help Text.");
             //string formattingMessage = "Beyond the second line should be formatted as though it's in a column.";
             lines[3].Should().BeEquivalentTo("                the Help Text.");
             // Teardown
@@ -216,10 +218,10 @@ namespace CommandLine.Tests.Unit.Text
 
             // Verify outcome
             var lines = sut.ToString().ToNotEmptyLines();
-            lines[1].Should().BeEquivalentTo("  v, verbose    Before ");
+            lines[1].Should().BeEquivalentTo("  v, verbose    Before");
             lines[2].Should().BeEquivalentTo("                012345678901234567890123");
             lines[3].Should().BeEquivalentTo("                After");
-            lines[4].Should().BeEquivalentTo("  input-file    Before ");
+            lines[4].Should().BeEquivalentTo("  input-file    Before");
             lines[5].Should().BeEquivalentTo("                012345678901234567890123");
             lines[6].Should().BeEquivalentTo("                456789 After");
             // Teardown
@@ -238,12 +240,12 @@ namespace CommandLine.Tests.Unit.Text
 
             // Verify outcome
             var lines = sut.ToString().ToNotEmptyLines();
-            lines[1].Should().BeEquivalentTo("Before ");
+            lines[1].Should().BeEquivalentTo("Before");
             lines[2].Should().BeEquivalentTo("0123456789012345678901234567890123456789");
             lines[3].Should().BeEquivalentTo("012 After");
-            lines[lines.Length - 3].Should().BeEquivalentTo("Before ");
+            lines[lines.Length - 3].Should().BeEquivalentTo("Before");
             lines[lines.Length - 2].Should().BeEquivalentTo("0123456789012345678901234567890123456789");
-            lines[lines.Length - 1].Should().BeEquivalentTo(" After");
+            lines[lines.Length - 1].Should().BeEquivalentTo("After");
 
             // Teardown
         }
@@ -653,5 +655,68 @@ namespace CommandLine.Tests.Unit.Text
 
             Assert.Equal("T" + Environment.NewLine + "e" + Environment.NewLine + "s" + Environment.NewLine + "t", b.ToString());
         }
+        
+        [Fact]
+        public void HelpTextHonoursLineBreaks()
+        {
+            // Fixture setup
+            // Exercize system 
+            var sut = new HelpText {AddDashesToOption = true}
+                .AddOptions(new NotParsed<Simple_Options>(TypeInfo.Create(typeof(HelpTextWithLineBreaks_Options)),
+                    Enumerable.Empty<Error>()));
+
+            // Verify outcome
+
+            var lines = sut.ToString().ToNotEmptyLines();
+            lines[0].Should().BeEquivalentTo("  --stringvalue    This is a help text description.");
+            lines[1].Should().BeEquivalentTo("                   It has multiple lines.");
+            lines[2].Should().BeEquivalentTo("                   We also want to ensure that indentation is correct.");
+         
+            // Teardown
+        }
+
+        [Fact]
+        public void HelpTextHonoursIndentationAfterLineBreaks()
+        {
+            // Fixture setup
+            // Exercize system 
+            var sut = new HelpText {AddDashesToOption = true}
+                .AddOptions(new NotParsed<Simple_Options>(TypeInfo.Create(typeof(HelpTextWithLineBreaks_Options)),
+                    Enumerable.Empty<Error>()));
+
+            // Verify outcome
+
+            var lines = sut.ToString().ToNotEmptyLines();
+            lines[3].Should().BeEquivalentTo("  --stringvalu2    This is a help text description where we want");
+            lines[4].Should().BeEquivalentTo("                      the left pad after a linebreak to be honoured so that");
+            lines[5].Should().BeEquivalentTo("                      we can sub-indent within a description.");
+         
+            // Teardown
+        }
+
+        [Fact]
+        public void HelpTextPreservesIndentationAcrossWordWrap()
+        {
+            // Fixture setup
+            // Exercise system 
+            var sut = new HelpText {AddDashesToOption = true,MaximumDisplayWidth = 60}
+                .AddOptions(new NotParsed<Simple_Options>(TypeInfo.Create(typeof(HelpTextWithLineBreaksAndSubIndentation_Options)),
+                    Enumerable.Empty<Error>()));
+
+            // Verify outcome
+
+            var lines = sut.ToString().ToNotEmptyLines();
+            lines[0].Should().BeEquivalentTo("  --stringvalue    This is a help text description where we");
+            lines[1].Should().BeEquivalentTo("                   want:");
+            lines[2].Should().BeEquivalentTo("                       * The left pad after a linebreak to");
+            lines[3].Should().BeEquivalentTo("                       be honoured and the indentation to be");
+            lines[4].Should().BeEquivalentTo("                       preserved across to the next line");
+            lines[5].Should().BeEquivalentTo("                       * The ability to return to no indent.");
+            lines[6].Should().BeEquivalentTo("                   Like this.");
+
+            // Teardown
+        }
+
+
     }
 }


### PR DESCRIPTION
This PR improves support for multiline and semi-formatted HelpText.  For example, it is now possible to write 

```
[Option(HelpText=
@"This option could be used in lots of ways:
        * a flag
        * another thing
or just  ignored altogether")]
public string AnOption {get;set;}
```
and have the help text output in the expected fashion.  Sub-indentation is correctly preserved even when long lines are supplied.  E.g.

> 
> "Use this like
>      - this
>      - or in another way that takes quite a lot of words to describe
>      - or like this"

will be output as 

> Use this like
>      - this
>      - or in another way 
>      that takes quite a lot 
>      of words to describe
>      - or like this"

for a narrow screen.

There are a couple of unit tests supplied to ensure correct operation (I'm not sure these adhere to the current naming convention - happy to change if you want).

As well as the main functionality there are a few 'drive-by' changes in the HelpText and test code.  

- I've hoisted a few bare numbers into constants to improve consistency
- I refactored the main text-wrapping code since it was actually duplicated previously.
- Some of the original tests were actually asserting less-than-optimal operation.  Specifically, they were asserting the requirement for trailing spaces at the end/beginning of lines and were also *incorrectly* asserting that lines would be wrapped at one character less than the allowed line width.  It should be pretty obvious from the diffs which ones I've fixed and why.

Any questions, drop me a line.  This is great library I've been using for a couple of years and it's good to see it back under active maintenance :-)


