### PR TITLE
Make it easier to configure HelpText

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,48 @@ let main args =
   | :? CommandLine.NotParsed<obj> -> 1
 ```
 
+# Configuring Help output
+
+One of the most valuable aspects of the library is its ability to automatically generate help text for the user when parsing fails. The **HelpText** property of each **Option** is displayed when a command is not recognised or there is a mistake in the parameters.  Multi-line  'Verbatim' strings are allowed and are correctly wrapped with sub-indentation honoured.  For example:
+
+```csharp
+[Option(HelpText = 
+@"Length can take several types of values
+ -- a string such as 'ten days'
+ -- a number like 1000 - this is interpreted as a number of milliseconds"
+ )]
+public string Length {get;set;}
+```
+
+In previous versions of the library, configuration of the help output was achieved through calling the AutoBuild method directly.  This is now deprecated and a number of helper methods are supplied to simplify the process.
+
+
+```csharp
+  var textwriter = ... my custom stream ....
+
+  Action<HelpText> configurer = h => {
+      h.AddEnumValuesToHelpText = true;
+      h.AdditionalNewLineAfterOption==true;
+      h.Copyright ="(C) Acme Solutions";
+  }; 
+
+  var parser = Parser.Default
+                  .SetDisplayWidth(40,WidthPolicy.FitToScreen)
+                  .SetTextWriter(textwriter)
+                  .SetHelpTextConfiguration(configurer)
+```
+
+
+By default, the parser  optionally automatically generates help and version commands. To disable these use:
+
+
+```csharp
+
+  var parser = Parser.Default
+                  .SetAutoHelp(false)
+                  .SetAutoVersion(false)
+```
+
 # Contributors
 First off, _Thank you!_  All contributions are welcome.  
 

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -232,9 +232,6 @@ namespace CommandLine
         /// </summary>
         /// <param name="writer">The output stream to use </param>
         /// <returns>The parser</returns>
-        /// REVIEW - to be honest the "Consumed" flag seems to be adding very little value in ParserSettings.  I understand the
-        /// desire to stop clients messing around with settings during parsing but it's hard to abuse the API in a way that would
-        /// really happen.  My suggestion would be to remove it.
         public Parser SetTextWriter(TextWriter writer)
         {
             settings.Consumed = false;
@@ -273,5 +270,32 @@ namespace CommandLine
             return this;
         }
        
+        
+        /// <summary>
+        /// Allows the client to turn the automatic help verb on and off 
+        /// </summary>
+        /// <param name="enable">turn on/off</param>
+        /// <returns>The parser</returns>
+        public Parser SetAutoHelp(bool enable)
+        {
+            settings.Consumed = false;
+            settings.HelpTextConfiguration = settings.HelpTextConfiguration.WithAutoHelp(enable);
+            settings.Consumed = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Allows the client to turn the automatic version reporting on and off
+        /// </summary>
+        /// <param name="enable">turn on/off</param>
+        /// <returns>The parser</returns>
+        public Parser SetAutoVersion(bool enable)
+        {
+            settings.Consumed = false;
+            settings.HelpTextConfiguration = settings.HelpTextConfiguration.WithAutoVersion(enable);
+            settings.Consumed = true;
+            return this;
+        }
+
     }
 }

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -19,7 +19,7 @@ namespace CommandLine
         private bool disposed;
         private readonly ParserSettings settings;
         private static readonly Lazy<Parser> DefaultParser = new Lazy<Parser>(
-            () => new Parser(new ParserSettings { HelpWriter = Console.Error }));
+            () => new Parser(new ParserSettings() ));
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandLine.Parser"/> class.
@@ -194,16 +194,15 @@ namespace CommandLine
         {
             return DisplayHelp(
                 parserResult,
-                settings.HelpWriter,
-                settings.MaximumDisplayWidth);
+                settings.HelpTextConfiguration);
         }
 
-        private static ParserResult<T> DisplayHelp<T>(ParserResult<T> parserResult, TextWriter helpWriter, int maxDisplayWidth)
+        private static ParserResult<T> DisplayHelp<T>(ParserResult<T> parserResult, HelpTextConfiguration helpTextConfig)
         {
             parserResult.WithNotParsed(
                 errors =>
-                    Maybe.Merge(errors.ToMaybe(), helpWriter.ToMaybe())
-                        .Do((_, writer) => writer.Write(HelpText.AutoBuild(parserResult, maxDisplayWidth)))
+                    Maybe.Merge(errors.ToMaybe(), helpTextConfig.HelpWriter.ToMaybe())
+                        .Do((_, writer) => writer.Write(HelpText.AutoBuild(parserResult,helpTextConfig)))
                 );
 
             return parserResult;

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -227,5 +227,51 @@ namespace CommandLine
                 disposed = true;
             }
         }
+        /// <summary>
+        /// Allows the client to use a stream other than Console.Error for ouput.  NOTE - client should dispose the stream
+        /// </summary>
+        /// <param name="writer">The output stream to use </param>
+        /// <returns>The parser</returns>
+        /// REVIEW - to be honest the "Consumed" flag seems to be adding very little value in ParserSettings.  I understand the
+        /// desire to stop clients messing around with settings during parsing but it's hard to abuse the API in a way that would
+        /// really happen.  My suggestion would be to remove it.
+        public Parser SetTextWriter(TextWriter writer)
+        {
+            settings.Consumed = false;
+            settings.HelpTextConfiguration = settings.HelpTextConfiguration.WithHelpWriter(writer);
+            settings.Consumed = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Allows the client to select the display width
+        /// </summary>
+        /// <param name="width">The desired width</param>
+        /// <param name="policy">The policy to use when setting the width</param>
+        /// <returns>The parser</returns>
+        public Parser SetDisplayWidth(int width,WidthPolicy policy)
+        {
+            settings.Consumed = false;
+            //Note that the parser constructor has probably already worked out the console width
+            if (policy == WidthPolicy.FitToScreen)
+                width = Math.Min(settings.HelpTextConfiguration.DisplayWidth, width);
+            settings.HelpTextConfiguration = settings.HelpTextConfiguration.WithDisplayWidth(width);
+            settings.Consumed = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Allows the client to configure flags in the helpText class
+        /// </summary>
+        /// <param name="configurer">An action which can set flags in the HelpText class</param>
+        /// <returns>The parser</returns>
+        public Parser SetHelpTextConfiguration(Action<HelpText> configurer)
+        {
+            settings.Consumed = false;
+            settings.HelpTextConfiguration = settings.HelpTextConfiguration.WithConfigurer(configurer);
+            settings.Consumed = true;
+            return this;
+        }
+       
     }
 }

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -194,16 +194,15 @@ namespace CommandLine
         {
             return DisplayHelp(
                 parserResult,
-                settings.HelpWriter,
-                settings.MaximumDisplayWidth);
+                settings);
         }
 
-        private static ParserResult<T> DisplayHelp<T>(ParserResult<T> parserResult, TextWriter helpWriter, int maxDisplayWidth)
+        private static ParserResult<T> DisplayHelp<T>(ParserResult<T> parserResult, ParserSettings settings)
         {
             parserResult.WithNotParsed(
                 errors =>
-                    Maybe.Merge(errors.ToMaybe(), helpWriter.ToMaybe())
-                        .Do((_, writer) => writer.Write(HelpText.AutoBuild(parserResult, maxDisplayWidth)))
+                    Maybe.Merge(errors.ToMaybe(), settings.HelpWriter.ToMaybe())
+                        .Do((_, writer) => writer.Write(HelpText.AutoBuild(parserResult, settings)))
                 );
 
             return parserResult;

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -24,6 +24,7 @@ namespace CommandLine
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandLine.Parser"/> class.
         /// </summary>
+        [Obsolete("Calling the constructor directly is deprecated - prefer Parser.Default")]
         public Parser()
         {
             settings = new ParserSettings { Consumed = true };
@@ -35,6 +36,7 @@ namespace CommandLine
         /// </summary>
         /// <param name="configuration">The <see cref="Action&lt;ParserSettings&gt;"/> delegate used to configure
         /// aspects and behaviors of the parser.</param>
+        [Obsolete("Calling the constructor directly is deprecated - prefer Parser.Default.Set....")]
         public Parser(Action<ParserSettings> configuration)
         {
             if (configuration == null) throw new ArgumentNullException("configuration");

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -20,8 +20,6 @@ namespace CommandLine
         private bool caseInsensitiveEnumValues;
         private HelpTextConfiguration helpTextConfiguration = HelpTextConfiguration.Default;
         private bool ignoreUnknownArguments;
-        private bool autoHelp;
-        private bool autoVersion;
         private CultureInfo parsingCulture;
         private bool enableDashDash;
     
@@ -32,8 +30,6 @@ namespace CommandLine
         {
             caseSensitive = true;
             caseInsensitiveEnumValues = false;
-            autoHelp = true;
-            autoVersion = true;
             parsingCulture = CultureInfo.InvariantCulture;
             try
             {
@@ -100,24 +96,21 @@ namespace CommandLine
         /// </summary>
         /// <remarks>
         /// It is the caller's responsibility to dispose or close the <see cref="TextWriter"/>.
-        /// REVIEW - this is preserve solely to provide backwards compatibility with code
-        /// where it was directly exposed.  Ideally it would be deprecated.
         /// </remarks>
+        [Obsolete("Internal use only - prefer Parser.Default.SetHelpWriter")]
         public TextWriter HelpWriter
         {
             get { return HelpTextConfiguration.HelpWriter; }
             set { HelpTextConfiguration = HelpTextConfiguration.WithHelpWriter(value); }
         }
 
-
         /// <summary>
         /// Allows the HelpText to be configured
         /// </summary>
         /// <remarks>
-        /// It is intended that any future HelpText configuraion should be encapusulated in this object.
-        /// REVIEW - It's actually not obvious to me that this should be supplied here rather than passed in during
-        /// WithNotParsed but since that's the pattern set by the original TextWriter I've left it here.
+        /// It is intended that any future HelpText configuration should be encapsulated in this object.
         /// </remarks>
+        [Obsolete("Internal use only - prefer Parser.Default.SetHelpTextConfiguration")]
         public HelpTextConfiguration HelpTextConfiguration
         {
             get { return helpTextConfiguration; }
@@ -141,24 +134,7 @@ namespace CommandLine
             get { return ignoreUnknownArguments; }
             set { PopsicleSetter.Set(Consumed, ref ignoreUnknownArguments, value); }
         }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether implicit option or verb 'help' should be supported.
-        /// </summary>
-        public bool AutoHelp
-        {
-            get { return autoHelp; }
-            set { PopsicleSetter.Set(Consumed, ref autoHelp, value); }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether implicit option or verb 'version' should be supported.
-        /// </summary>
-        public bool AutoVersion
-        {
-            get { return autoVersion; }
-            set { PopsicleSetter.Set(Consumed, ref autoVersion, value); }
-        }
+     
 
         /// <summary>
         /// Gets or sets a value indicating whether enable double dash '--' syntax,
@@ -174,14 +150,39 @@ namespace CommandLine
         /// Gets or sets the maximum width of the display.  This determines word wrap when displaying the text.
         /// </summary>
         /// <remarks>
-        /// REVIEW - this is provided only for backwards compatibility.  Ideally it would be deprecated and the display width
-        /// accessed solely through HelpTextConfiguration
         /// </remarks>
+        [Obsolete("Prefer Parser.Default.SetDisplayWidth")]
         public int MaximumDisplayWidth
         {
             get { return HelpTextConfiguration.DisplayWidth; }
             set { HelpTextConfiguration = HelpTextConfiguration.WithDisplayWidth(value); }
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether implicit option or verb 'version' should be supported.
+        /// </summary>
+        /// <remarks>
+        /// Note that AutoVersion and AutoHelp straddle the line between being PARSER and HELP settings;
+        /// the are used buy the Help-text system to generate output but but the parser itself to decide
+        /// which verbs to accept.  For simplicity, they are stored in HelpTextConfiguration and proxied here
+        /// </remarks>
+        [Obsolete("Internal use only - prefer Parser.Default.SetAutoVersion")]
+        public bool AutoVersion
+        {
+            get { return HelpTextConfiguration.AutoVersion; }
+            set { HelpTextConfiguration = HelpTextConfiguration.WithAutoVersion(value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether implicit option or verb 'help' should be supported.
+        /// </summary>
+        [Obsolete("Internal use only - prefer Parser.Default.SetAutoHelp")]
+        public bool AutoHelp
+        {
+            get { return HelpTextConfiguration.AutoHelp; }
+            set { HelpTextConfiguration = HelpTextConfiguration.WithAutoHelp(value); }
+        }
+       
 
         internal StringComparer NameComparer
         {

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -15,8 +15,6 @@ namespace CommandLine
     /// </summary>
     public class ParserSettings : IDisposable
     {
-        private const int DefaultMaximumLength = 80; // default console width
-
         private bool disposed;
         private bool caseSensitive;
         private bool caseInsensitiveEnumValues;
@@ -26,8 +24,7 @@ namespace CommandLine
         private bool autoVersion;
         private CultureInfo parsingCulture;
         private bool enableDashDash;
-        private int maximumDisplayWidth;
-
+    
         /// <summary>
         /// Initializes a new instance of the <see cref="ParserSettings"/> class.
         /// </summary>
@@ -40,15 +37,13 @@ namespace CommandLine
             parsingCulture = CultureInfo.InvariantCulture;
             try
             {
-                maximumDisplayWidth = Console.WindowWidth;
-                if (maximumDisplayWidth < 1)
+                if (Console.WindowWidth >= 1)
                 {
-                    maximumDisplayWidth = DefaultMaximumLength;
+                    HelpTextConfiguration=HelpTextConfiguration.WithDisplayWidth(Console.WindowWidth);
                 }
             }
             catch (IOException)
             {
-                maximumDisplayWidth = DefaultMaximumLength;
             }
         }
 
@@ -178,10 +173,14 @@ namespace CommandLine
         /// <summary>
         /// Gets or sets the maximum width of the display.  This determines word wrap when displaying the text.
         /// </summary>
+        /// <remarks>
+        /// REVIEW - this is provided only for backwards compatibility.  Ideally it would be deprecated and the display width
+        /// accessed solely through HelpTextConfiguration
+        /// </remarks>
         public int MaximumDisplayWidth
         {
-            get { return maximumDisplayWidth; }
-            set { maximumDisplayWidth = value; }
+            get { return HelpTextConfiguration.DisplayWidth; }
+            set { HelpTextConfiguration = HelpTextConfiguration.WithDisplayWidth(value); }
         }
 
         internal StringComparer NameComparer

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -5,6 +5,8 @@ using System.Globalization;
 using System.IO;
 
 using CommandLine.Infrastructure;
+using CommandLine.Text;
+
 
 namespace CommandLine
 {
@@ -18,7 +20,7 @@ namespace CommandLine
         private bool disposed;
         private bool caseSensitive;
         private bool caseInsensitiveEnumValues;
-        private TextWriter helpWriter;
+        private HelpTextConfiguration helpTextConfiguration = HelpTextConfiguration.Default;
         private bool ignoreUnknownArguments;
         private bool autoHelp;
         private bool autoVersion;
@@ -69,6 +71,7 @@ namespace CommandLine
             set { PopsicleSetter.Set(Consumed, ref caseSensitive, value); }
         }
 
+      
         /// <summary>
         /// Gets or sets a value indicating whether perform case sensitive comparisons of <i>values</i>.
         /// Note that case insensitivity only applies to <i>values</i>, not the parameters.
@@ -102,12 +105,30 @@ namespace CommandLine
         /// </summary>
         /// <remarks>
         /// It is the caller's responsibility to dispose or close the <see cref="TextWriter"/>.
+        /// REVIEW - this is preserve solely to provide backwards compatibility with code
+        /// where it was directly exposed.  Ideally it would be deprecated.
         /// </remarks>
         public TextWriter HelpWriter
         {
-            get { return helpWriter; }
-            set { PopsicleSetter.Set(Consumed, ref helpWriter, value); }
+            get { return HelpTextConfiguration.HelpWriter; }
+            set { HelpTextConfiguration = HelpTextConfiguration.WithHelpWriter(value); }
         }
+
+
+        /// <summary>
+        /// Allows the HelpText to be configured
+        /// </summary>
+        /// <remarks>
+        /// It is intended that any future HelpText configuraion should be encapusulated in this object.
+        /// REVIEW - It's actually not obvious to me that this should be supplied here rather than passed in during
+        /// WithNotParsed but since that's the pattern set by the original TextWriter I've left it here.
+        /// </remarks>
+        public HelpTextConfiguration HelpTextConfiguration
+        {
+            get { return helpTextConfiguration; }
+            set { PopsicleSetter.Set(Consumed, ref helpTextConfiguration, value); }
+        }
+
 
         /// <summary>
         /// Gets or sets a value indicating whether the parser shall move on to the next argument and ignore the given argument if it

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -314,7 +314,7 @@ namespace CommandLine.Text
         //in a HelpTextConfiguration object
         public static HelpText AutoBuild<T>(ParserResult<T> parserResult, int maxDisplayWidth = HelpTextConfiguration.DefaultMaximumLength)
         {
-            return AutoBuild(parserResult,  HelpTextConfiguration.Default.WithWidth(maxDisplayWidth));
+            return AutoBuild(parserResult,  HelpTextConfiguration.Default.WithDisplayWidth(maxDisplayWidth));
         }
 
 

--- a/src/CommandLine/Text/HelpTextConfiguration.cs
+++ b/src/CommandLine/Text/HelpTextConfiguration.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+
+
+namespace CommandLine.Text
+{
+    /// <summary>
+    /// Contains the configuration used when building HelpText
+    /// </summary>
+    /// <remarks>
+    /// It is intended that this class should contain all settings/logic associated with configuring the
+    /// display of helptext.
+    /// </remarks>
+    public class HelpTextConfiguration
+    {
+        /// <summary>
+        /// The default console width
+        /// </summary>
+        public const int DefaultMaximumLength = 80; 
+
+        /// <summary>
+        /// The width of the display.  Text will wrap if this is exceeded.
+        /// </summary>
+        public readonly int DisplayWidth;
+
+        /// <summary>
+        /// Method used to set display options within the HelpText
+        /// </summary>
+        /// <remarks>
+        /// In the current implementation, there is only one HelpText and it grows as verbs and options
+        /// are scanned.  Hence any flags this method sets will apply to all text.  E.g. setting the 
+        /// 'display enums' flag will set it for all options.</remarks>
+        public readonly Action<HelpText> Configurer;
+
+        /// <summary>
+        /// The output for the HelpText
+        /// </summary>
+        /// <remarks>
+        /// This was moved from ParserSettings because logically is part of the help-text generation phase.
+        /// </remarks>
+        public readonly TextWriter HelpWriter;
+
+        /// <summary>
+        /// Constructor - private to avoid too much reliance on the particular argument list 
+        /// </summary>
+        private HelpTextConfiguration(Action<HelpText> configurer, int displayWidth,TextWriter writer)
+        {
+            Configurer = configurer;
+            DisplayWidth = displayWidth;
+            HelpWriter = writer;
+        }
+       
+        /// <summary>
+        /// Default Configuration which will give acceptable results 
+        /// </summary>
+        public static HelpTextConfiguration Default { get; } = new HelpTextConfiguration(_ => { },DefaultMaximumLength,Console.Error);
+       
+        /// <summary>
+        /// Sets the TextWriter
+        /// </summary>
+        /// <remarks>
+        /// The client is expected to dispose of the writer
+        /// </remarks>
+        public HelpTextConfiguration WithHelpWriter(TextWriter writer)
+        {
+            return new HelpTextConfiguration(Configurer,DisplayWidth,writer);
+        }
+        /// <summary>
+        /// Sets a different width of the help-text output
+        /// </summary>
+        public HelpTextConfiguration WithWidth(int maxDisplayWidth)
+        {
+            return new HelpTextConfiguration(Configurer,maxDisplayWidth,HelpWriter);
+        }
+        /// <summary>
+        /// Allows the client to pass in an action which will be called to configure the HelpText class
+        /// </summary>
+        /// <remarks>
+        /// The Parser constructs the HelpText object then calls this method at the earliest opportunity
+        /// which allows various display flags and options to be set.
+        /// </remarks>
+        public HelpTextConfiguration WithConfigurer(Action<HelpText> func)
+        {
+            return new HelpTextConfiguration(func,DisplayWidth,HelpWriter);
+        }
+    }
+}

--- a/src/CommandLine/Text/HelpTextConfiguration.cs
+++ b/src/CommandLine/Text/HelpTextConfiguration.cs
@@ -68,7 +68,7 @@ namespace CommandLine.Text
         /// <summary>
         /// Sets a different width of the help-text output
         /// </summary>
-        public HelpTextConfiguration WithWidth(int maxDisplayWidth)
+        public HelpTextConfiguration WithDisplayWidth(int maxDisplayWidth)
         {
             return new HelpTextConfiguration(Configurer,maxDisplayWidth,HelpWriter);
         }

--- a/src/CommandLine/Text/HelpTextConfiguration.cs
+++ b/src/CommandLine/Text/HelpTextConfiguration.cs
@@ -1,87 +1,121 @@
 using System;
 using System.IO;
 
-
 namespace CommandLine.Text
 {
     /// <summary>
-    /// Contains the configuration used when building HelpText
+    ///     Contains the configuration used when building HelpText
     /// </summary>
     /// <remarks>
-    /// It is intended that this class should contain all settings/logic associated with configuring the
-    /// display of helptext.
+    ///     It is intended that this class should contain all settings/logic associated with configuring the
+    ///     display of helptext.
     /// </remarks>
     public class HelpTextConfiguration
     {
         /// <summary>
-        /// The default console width
+        ///     The default console width
         /// </summary>
-        public const int DefaultMaximumLength = 80; 
+        public const int DefaultMaximumLength = 80;
 
         /// <summary>
-        /// The width of the display.  Text will wrap if this is exceeded.
+        ///     Constructor - private to avoid too much reliance on the particular argument list
         /// </summary>
-        public readonly int DisplayWidth;
-
-        /// <summary>
-        /// Method used to set display options within the HelpText
-        /// </summary>
-        /// <remarks>
-        /// In the current implementation, there is only one HelpText and it grows as verbs and options
-        /// are scanned.  Hence any flags this method sets will apply to all text.  E.g. setting the 
-        /// 'display enums' flag will set it for all options.</remarks>
-        public readonly Action<HelpText> Configurer;
-
-        /// <summary>
-        /// The output for the HelpText
-        /// </summary>
-        /// <remarks>
-        /// This was moved from ParserSettings because logically is part of the help-text generation phase.
-        /// </remarks>
-        public readonly TextWriter HelpWriter;
-
-        /// <summary>
-        /// Constructor - private to avoid too much reliance on the particular argument list 
-        /// </summary>
-        private HelpTextConfiguration(Action<HelpText> configurer, int displayWidth,TextWriter writer)
+        private HelpTextConfiguration(Action<HelpText> configurer, int displayWidth, TextWriter writer,
+            bool autoVersion, bool autoHelp)
         {
             Configurer = configurer;
             DisplayWidth = displayWidth;
             HelpWriter = writer;
+            AutoVersion = autoVersion;
+            AutoHelp = autoHelp;
         }
-       
+
         /// <summary>
-        /// Default Configuration which will give acceptable results 
+        ///     The width of the display.  Text will wrap if this is exceeded.
         /// </summary>
-        public static HelpTextConfiguration Default { get; } = new HelpTextConfiguration(_ => { },DefaultMaximumLength,Console.Error);
-       
+        public int DisplayWidth { get; private set; }
+
         /// <summary>
-        /// Sets the TextWriter
+        ///     Method used to set display options within the HelpText
         /// </summary>
         /// <remarks>
-        /// The client is expected to dispose of the writer
+        ///     In the current implementation, there is only one HelpText and it grows as verbs and options
+        ///     are scanned.  Hence any flags this method sets will apply to all text.  E.g. setting the
+        ///     'display enums' flag will set it for all options.
+        /// </remarks>
+        public Action<HelpText> Configurer { get; private set; }
+
+        /// <summary>
+        ///     The output for the HelpText
+        /// </summary>
+        /// <remarks>
+        ///     This was moved from ParserSettings because logically is part of the help-text generation phase.
+        /// </remarks>
+        public TextWriter HelpWriter { get; private set; }
+
+        /// <summary>
+        ///     Default Configuration which will give acceptable results
+        /// </summary>
+        public static HelpTextConfiguration Default { get; } =
+            new HelpTextConfiguration(_ => { }, DefaultMaximumLength, Console.Error, true, true);
+
+        public bool AutoHelp { get; private set; }
+        public bool AutoVersion { get; private set; }
+
+        private HelpTextConfiguration Copy()
+        {
+            return new HelpTextConfiguration(Configurer, DisplayWidth, HelpWriter, AutoVersion, AutoHelp);
+        }
+
+        /// <summary>
+        ///     Sets the TextWriter
+        /// </summary>
+        /// <remarks>
+        ///     The client is expected to dispose of the writer
         /// </remarks>
         public HelpTextConfiguration WithHelpWriter(TextWriter writer)
         {
-            return new HelpTextConfiguration(Configurer,DisplayWidth,writer);
+            var c = Copy();
+            c.HelpWriter = writer;
+            return c;
         }
+
         /// <summary>
-        /// Sets a different width of the help-text output
+        ///     Sets a different width of the help-text output
         /// </summary>
         public HelpTextConfiguration WithDisplayWidth(int maxDisplayWidth)
         {
-            return new HelpTextConfiguration(Configurer,maxDisplayWidth,HelpWriter);
+            var c = Copy();
+            c.DisplayWidth = maxDisplayWidth;
+            return c;
         }
+
         /// <summary>
-        /// Allows the client to pass in an action which will be called to configure the HelpText class
+        ///     Allows the client to pass in an action which will be called to configure the HelpText class
         /// </summary>
         /// <remarks>
-        /// The Parser constructs the HelpText object then calls this method at the earliest opportunity
-        /// which allows various display flags and options to be set.
+        ///     The Parser constructs the HelpText object then calls this method at the earliest opportunity
+        ///     which allows various display flags and options to be set.
         /// </remarks>
         public HelpTextConfiguration WithConfigurer(Action<HelpText> func)
         {
-            return new HelpTextConfiguration(func,DisplayWidth,HelpWriter);
+            var c = Copy();
+            c.Configurer = func;
+            return c;
+        }
+
+        public HelpTextConfiguration WithAutoVersion(bool enable)
+        {
+            var c = Copy();
+            c.AutoVersion = enable;
+            return c;
+        }
+
+        public HelpTextConfiguration WithAutoHelp(bool enable)
+        {
+            var c = Copy();
+            c.AutoHelp = enable;
+            return c;
         }
     }
 }

--- a/src/CommandLine/WidthPolicy.cs
+++ b/src/CommandLine/WidthPolicy.cs
@@ -1,0 +1,17 @@
+﻿namespace CommandLine
+{
+    /// <summary>
+    /// Policy that controls how to configure the width of help text
+    /// </summary>
+    public enum WidthPolicy
+    {
+        /// <summary>
+        /// Use the supplied width regardless of whether it will fit on screen (recommended if you are writing to custom stream)
+        /// </summary>
+        ForceUse,
+        /// <summary>
+        /// Use the screen width if smaller than the supplied width
+        /// </summary>
+        FitToScreen
+    }
+}

--- a/tests/CommandLine.Tests/Unit/HelpTextConfigurationTests.cs
+++ b/tests/CommandLine.Tests/Unit/HelpTextConfigurationTests.cs
@@ -26,7 +26,7 @@ namespace CommandLine.Tests.Unit
 
         // Test method (xUnit) which fails
         [Fact]
-        public void DetailTextIsShownCorrectly()
+        public void ConfigurationIsAccepted()
         {
             var help = new StringWriter();
             var sut = new Parser(config =>
@@ -41,8 +41,31 @@ namespace CommandLine.Tests.Unit
             });
 
 
-            //There seems to a bug that prevents "help VERB" outputing anything if
-            //the parser is only supplied one option class so this test provides
+            //There seems to a bug that prevents "help VERB" outputting anything if
+            //the parser is only supplied one verb  so this test provides
+            //Add_verb as a workaround
+            sut.ParseArguments<Add_Verb,Options>(
+                new[] {"help", "run",});
+            var result = help.ToString();
+
+            // Verify outcome
+            var lines = result.ToNotEmptyLines().TrimStringArray();
+            lines.Any(line=>line.Contains("Option1")).Should().BeTrue();
+            lines.Any(line=>line.Contains("Option2")).Should().BeTrue();
+
+        }
+
+        [Fact]
+        public void ConfigurationIsAcceptedUsingFluentAPI()
+        {
+            var help = new StringWriter();
+            var sut =Parser.Default
+                .SetDisplayWidth(80,WidthPolicy.FitToScreen)
+                .SetTextWriter(help)
+                .SetHelpTextConfiguration(h => h.AddEnumValuesToHelpText = true);
+
+            //There seems to a bug that prevents "help VERB" outputting anything if
+            //the parser is only supplied one verb  so this test provides
             //Add_verb as a workaround
             sut.ParseArguments<Add_Verb,Options>(
                 new[] {"help", "run",});

--- a/tests/CommandLine.Tests/Unit/HelpTextConfigurationTests.cs
+++ b/tests/CommandLine.Tests/Unit/HelpTextConfigurationTests.cs
@@ -36,9 +36,10 @@ namespace CommandLine.Tests.Unit
 
                 config.HelpTextConfiguration = HelpTextConfiguration.Default
                     .WithHelpWriter(help)
-                    .WithWidth(50)
+                    .WithDisplayWidth(50)
                     .WithConfigurer(h => h.AddEnumValuesToHelpText = true);
             });
+
 
             //There seems to a bug that prevents "help VERB" outputing anything if
             //the parser is only supplied one option class so this test provides

--- a/tests/CommandLine.Tests/Unit/HelpTextConfigurationTests.cs
+++ b/tests/CommandLine.Tests/Unit/HelpTextConfigurationTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using CommandLine.Tests.Fakes;
+using CommandLine.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace CommandLine.Tests.Unit
+{
+    public class HelpTextConfigurationTests
+    {
+        public enum AnEnum
+        {
+            Option1,
+            Option2
+        }
+        // Options
+        [Verb("run", HelpText = "a verb")]
+        internal class Options
+        {
+            [Option]
+            public AnEnum AnOption { get; set; }
+        }
+
+
+        // Test method (xUnit) which fails
+        [Fact]
+        public void DetailTextIsShownCorrectly()
+        {
+            var help = new StringWriter();
+            var sut = new Parser(config =>
+            {
+                config.HelpWriter = help;
+                config.MaximumDisplayWidth = 80;
+
+                config.HelpTextConfiguration = HelpTextConfiguration.Default
+                    .WithHelpWriter(help)
+                    .WithConfigurer(h => h.AddEnumValuesToHelpText = true);
+            });
+
+            //There seems to a bug that prevents "help VERB" outputing anything if
+            //the parser is only supplied one option class so this test provides
+            //Add_verb as a workaround
+            sut.ParseArguments<Add_Verb,Options>(
+                new[] {"help", "run",});
+            var result = help.ToString();
+
+            // Verify outcome
+            var lines = result.ToNotEmptyLines().TrimStringArray();
+            lines.Any(line=>line.Contains("Option1")).Should().BeTrue();
+            lines.Any(line=>line.Contains("Option2")).Should().BeTrue();
+
+        }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/HelpTextConfigurationTests.cs
+++ b/tests/CommandLine.Tests/Unit/HelpTextConfigurationTests.cs
@@ -36,6 +36,7 @@ namespace CommandLine.Tests.Unit
 
                 config.HelpTextConfiguration = HelpTextConfiguration.Default
                     .WithHelpWriter(help)
+                    .WithWidth(50)
                     .WithConfigurer(h => h.AddEnumValuesToHelpText = true);
             });
 

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -860,5 +860,117 @@ namespace CommandLine.Tests.Unit
                     Assert.Equal("two", args.Arg2);
                 });
         }
+
+        [Fact]
+        // Tests a fix for issue #455
+        public void Help_screen_does_not_show_help_verb_if_AutoHelp_is_disabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoHelp = false; config.HelpWriter = output; });
+
+            sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.DoesNotContain("help", helpText, StringComparison.InvariantCulture);
+            Assert.DoesNotContain("Display more information on a specific command", helpText, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        // Tests a fix for issue #455
+        public void Help_screen_does_not_show_help_option_if_AutoHelp_is_disabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoHelp = false; config.HelpWriter = output; });
+
+            sut.ParseArguments<Simple_Options_With_HelpText_Set>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.DoesNotContain("--help", helpText, StringComparison.InvariantCulture);
+            Assert.DoesNotContain("Display this help screen.", helpText, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        // Tests a fix for issue #455
+        public void Help_screen_shows_help_verb_if_AutoHelp_is_enabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoHelp = true; config.HelpWriter = output; });
+
+            sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.Contains("help", helpText, StringComparison.InvariantCulture);
+            Assert.Contains("Display more information on a specific command", helpText, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        // Tests a fix for issue #455
+        public void Help_screen_shows_help_option_if_AutoHelp_is_enabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoHelp = true; config.HelpWriter = output; });
+
+            sut.ParseArguments<Simple_Options_With_HelpText_Set>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.Contains("help", helpText, StringComparison.InvariantCulture);
+            Assert.Contains("Display this help screen.", helpText, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        // Tests a fix for issue #414
+        public void Help_screen_does_not_show_version_verb_if_AutoVersion_is_disabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoVersion = false; config.HelpWriter = output; });
+
+            sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.DoesNotContain("version", helpText, StringComparison.InvariantCulture);
+            Assert.DoesNotContain("Display version information.", helpText, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        // Tests a fix for issue #414
+        public void Help_screen_does_not_show_version_option_if_AutoVersion_is_disabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoVersion = false; config.HelpWriter = output; });
+
+            sut.ParseArguments<Simple_Options_With_HelpText_Set>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.DoesNotContain("--version", helpText, StringComparison.InvariantCulture);
+            Assert.DoesNotContain("Display version information.", helpText, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        // Tests a fix for issue #414
+        public void Help_screen_shows_version_verb_if_AutoVersion_is_enabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoVersion = true; config.HelpWriter = output; });
+
+            sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.Contains("version", helpText, StringComparison.InvariantCulture);
+            Assert.Contains("Display version information.", helpText, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        // Tests a fix for issue #414
+        public void Help_screen_shows_version_option_if_AutoVersion_is_ensabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoVersion = true; config.HelpWriter = output; });
+
+            sut.ParseArguments<Simple_Options_With_HelpText_Set>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.Contains("--version", helpText, StringComparison.InvariantCulture);
+            Assert.Contains("Display version information.", helpText, StringComparison.InvariantCulture);
+        }
     }
 }

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using CommandLine.Core;
 using System.Linq;
 using System.Reflection;
@@ -700,7 +701,18 @@ namespace CommandLine.Tests.Unit.Text
             Assert.Contains("Display this help screen.", helpText, StringComparison.InvariantCulture);
             Assert.DoesNotContain("Display version information.", helpText, StringComparison.InvariantCulture);
             Assert.DoesNotContain("--version", helpText, StringComparison.InvariantCulture);
-         
+        }
+
+        [Fact]
+        public void Only_contains_one_error()
+        {
+          var helpWriter = new StringWriter();
+          var sut = new Parser(config => { config.AutoHelp = false; config.HelpWriter = helpWriter; });
+
+          sut.ParseArguments<Simple_Options_With_HelpText_Set>(new string[] {"--help"});
+          var helpText = helpWriter.ToString();
+          helpText.Contains("--help").Should().BeFalse();
+          helpText.Replace("ERROR(S)", "").Length.Should().Be(helpText.Length - 8);
         }
     }
 }

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -714,5 +714,18 @@ namespace CommandLine.Tests.Unit.Text
           helpText.Contains("--help").Should().BeFalse();
           helpText.Replace("ERROR(S)", "").Length.Should().Be(helpText.Length - 8);
         }
+
+        [Fact]
+        public void Only_contains_one_error_using_new_configuration_mechanism()
+        {
+            var helpWriter = new StringWriter();
+            var sut = Parser.Default.SetAutoHelp(false)
+                .SetTextWriter(helpWriter);
+
+            sut.ParseArguments<Simple_Options_With_HelpText_Set>(new string[] {"--help"});
+            var helpText = helpWriter.ToString();
+            helpText.Contains("--help").Should().BeFalse();
+            helpText.Replace("ERROR(S)", "").Length.Should().Be(helpText.Length - 8);
+        }
     }
 }

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -588,7 +588,10 @@ namespace CommandLine.Tests.Unit.Text
             {
                 onErrorCalled = true;
                 return ht;
-            }, ex => ex);
+            }, 
+                ex => ex,
+                HelpTextConfiguration.Default
+                );
                 
             onErrorCalled.Should().BeTrue();
             actualResult.Copyright.Should().Be(expectedCopyright);
@@ -613,7 +616,8 @@ namespace CommandLine.Tests.Unit.Text
             {
                 onErrorCalled = true;
                 return ht;
-            }, ex => ex);
+            }, ex => ex,
+            HelpTextConfiguration.Default);
 
             onErrorCalled.Should().BeTrue();
             actualResult.Heading.Should().Be(string.Format("{0} {1}", expectedTitle, expectedVersion));
@@ -637,7 +641,8 @@ namespace CommandLine.Tests.Unit.Text
             {
                 onErrorCalled = true;
                 return ht;
-            }, ex => ex);
+            }, ex => ex,
+                HelpTextConfiguration.Default);
 
             onErrorCalled.Should().BeFalse(); // Other attributes have fallback logic
             actualResult.Copyright.Should().Be(string.Format("Copyright (C) {0} {1}", DateTime.Now.Year, expectedCompany));

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -658,5 +658,49 @@ namespace CommandLine.Tests.Unit.Text
 
             Assert.Equal("T" + Environment.NewLine + "e" + Environment.NewLine + "s" + Environment.NewLine + "t", b.ToString());
         }
+
+        [Fact]
+        public void AutoBuild_without_settings_contains_help_and_version()
+        {
+            var parserResult = new NotParsed<object>(TypeInfo.Create(typeof(NullInstance)), new[] { new BadFormatConversionError(new NameInfo("f", "foo")) });
+
+            var helpText = HelpText.AutoBuild(parserResult);
+
+            var text = helpText.ToString();
+            Assert.Contains("--help", helpText, StringComparison.InvariantCulture);
+            Assert.Contains("Display version information.", helpText, StringComparison.InvariantCulture);
+            Assert.Contains("--version", helpText, StringComparison.InvariantCulture);
+            Assert.Contains("Display this help screen.", helpText, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        public void AutoBuild_can_disable_autohelp()
+        {
+            var parserResult = new NotParsed<object>(TypeInfo.Create(typeof(NullInstance)), new[] { new BadFormatConversionError(new NameInfo("f", "foo")) });
+            var settings = HelpTextConfiguration.Default.WithAutoHelp(false);
+            var helpText = HelpText.AutoBuild(parserResult, settings);
+
+            var text = helpText.ToString();
+            Assert.DoesNotContain("--help", helpText, StringComparison.InvariantCulture);
+            Assert.DoesNotContain("Display this help screen.", helpText, StringComparison.InvariantCulture);
+            Assert.Contains("Display version information.", helpText, StringComparison.InvariantCulture);
+            Assert.Contains("--version", helpText, StringComparison.InvariantCulture);
+         
+        }
+
+        [Fact]
+        public void AutoBuild_can_disable_autoversion()
+        {
+            var parserResult = new NotParsed<object>(TypeInfo.Create(typeof(NullInstance)), new[] { new BadFormatConversionError(new NameInfo("f", "foo")) });
+            var settings = HelpTextConfiguration.Default.WithAutoVersion(false);
+            var helpText = HelpText.AutoBuild(parserResult, settings);
+
+            var text = helpText.ToString();
+            Assert.Contains("--help", helpText, StringComparison.InvariantCulture);
+            Assert.Contains("Display this help screen.", helpText, StringComparison.InvariantCulture);
+            Assert.DoesNotContain("Display version information.", helpText, StringComparison.InvariantCulture);
+            Assert.DoesNotContain("--version", helpText, StringComparison.InvariantCulture);
+         
+        }
     }
 }


### PR DESCRIPTION
The purpose of this change is to simplify configuration of the help-text output.  

The HelpText class has lots of useful flags for controlling the way output is displayed but they are currently cumbersome to access.  This PR allows you to write code such as...
```

  var parser= Parser.Default
                      .SetHelpTextConfiguration(h => 
                        {
                           helptext .AddEnumValuesToHelpText = true;
                           helptext .AddDashesToOption= true;
                         }
                         );
          
)
```

In addition, the old MaximumDisplayWidth and TextWriter properties have been moved into the HelpTextConfiguration and exposed via a fluent API in Parser to avoid clients having to access too many of the class internals so you can write..

```
 var p = Parser.Default
                .SetDisplayWidth(80,WidthPolicy.FitToScreen)
                .SetTextWriter(help)
                .SetHelpTextConfiguration(h => h.AddEnumValuesToHelpText = true);
 
```

The old config accessors are still provided as a backwards compatibility measure. but should be deprecated IMHO.

      
