### PR TITLE
Propagate parser-settings to HelpText (fix #414 and #455)

### DIFF
--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -194,16 +194,15 @@ namespace CommandLine
         {
             return DisplayHelp(
                 parserResult,
-                settings.HelpWriter,
-                settings.MaximumDisplayWidth);
+                settings);
         }
 
-        private static ParserResult<T> DisplayHelp<T>(ParserResult<T> parserResult, TextWriter helpWriter, int maxDisplayWidth)
+        private static ParserResult<T> DisplayHelp<T>(ParserResult<T> parserResult, ParserSettings settings)
         {
             parserResult.WithNotParsed(
                 errors =>
-                    Maybe.Merge(errors.ToMaybe(), helpWriter.ToMaybe())
-                        .Do((_, writer) => writer.Write(HelpText.AutoBuild(parserResult, maxDisplayWidth)))
+                    Maybe.Merge(errors.ToMaybe(), settings.HelpWriter.ToMaybe())
+                        .Do((_, writer) => writer.Write(HelpText.AutoBuild(parserResult, settings)))
                 );
 
             return parserResult;

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -860,5 +860,117 @@ namespace CommandLine.Tests.Unit
                     Assert.Equal("two", args.Arg2);
                 });
         }
+
+        [Fact]
+        // Tests a fix for issue #455
+        public void Help_screen_does_not_show_help_verb_if_AutoHelp_is_disabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoHelp = false; config.HelpWriter = output; });
+
+            sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.DoesNotContain("help", helpText, StringComparison.InvariantCulture);
+            Assert.DoesNotContain("Display more information on a specific command", helpText, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        // Tests a fix for issue #455
+        public void Help_screen_does_not_show_help_option_if_AutoHelp_is_disabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoHelp = false; config.HelpWriter = output; });
+
+            sut.ParseArguments<Simple_Options_With_HelpText_Set>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.DoesNotContain("--help", helpText, StringComparison.InvariantCulture);
+            Assert.DoesNotContain("Display this help screen.", helpText, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        // Tests a fix for issue #455
+        public void Help_screen_shows_help_verb_if_AutoHelp_is_enabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoHelp = true; config.HelpWriter = output; });
+
+            sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.Contains("help", helpText, StringComparison.InvariantCulture);
+            Assert.Contains("Display more information on a specific command", helpText, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        // Tests a fix for issue #455
+        public void Help_screen_shows_help_option_if_AutoHelp_is_enabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoHelp = true; config.HelpWriter = output; });
+
+            sut.ParseArguments<Simple_Options_With_HelpText_Set>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.Contains("help", helpText, StringComparison.InvariantCulture);
+            Assert.Contains("Display this help screen.", helpText, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        // Tests a fix for issue #414
+        public void Help_screen_does_not_show_version_verb_if_AutoVersion_is_disabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoVersion = false; config.HelpWriter = output; });
+
+            sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.DoesNotContain("version", helpText, StringComparison.InvariantCulture);
+            Assert.DoesNotContain("Display version information.", helpText, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        // Tests a fix for issue #414
+        public void Help_screen_does_not_show_version_option_if_AutoVersion_is_disabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoVersion = false; config.HelpWriter = output; });
+
+            sut.ParseArguments<Simple_Options_With_HelpText_Set>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.DoesNotContain("--version", helpText, StringComparison.InvariantCulture);
+            Assert.DoesNotContain("Display version information.", helpText, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        // Tests a fix for issue #414
+        public void Help_screen_shows_version_verb_if_AutoVersion_is_enabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoVersion = true; config.HelpWriter = output; });
+
+            sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.Contains("version", helpText, StringComparison.InvariantCulture);
+            Assert.Contains("Display version information.", helpText, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        // Tests a fix for issue #414
+        public void Help_screen_shows_version_option_if_AutoVersion_is_ensabled()
+        {
+            var output = new StringWriter();
+            var sut = new Parser(config => { config.AutoVersion = true; config.HelpWriter = output; });
+
+            sut.ParseArguments<Simple_Options_With_HelpText_Set>(new string[] { });
+
+            var helpText = output.ToString();
+            Assert.Contains("--version", helpText, StringComparison.InvariantCulture);
+            Assert.Contains("Display version information.", helpText, StringComparison.InvariantCulture);
+        }
     }
 }


### PR DESCRIPTION
This fixes issues #414 and #455 (value of `AutoHelp` and `AutoVersion` are ignored by `HelpText`)
This fix does not change the public interface. It is achieved by overloading `HelpText.AutoBuild`. If a `ParameterSettings` object is passed, the values it contains are used. If no `ParameterSettings` are passed to `AutoBuild`, help and version are always displayed.