### PR TITLE
Test maintainance: add missed tests and removing xUnit1013 warning

### DIFF
--- a/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
@@ -50,8 +50,8 @@ namespace CommandLine.Tests.Unit.Core
                     new object[] {((long) int.MinValue - 1).ToString(), typeof (int), true, null},
 
                     new object[] {"1", typeof (uint), false, (uint) 1},
-                    new object[] {"0", typeof (uint), false, (uint) 0},
-                    new object[] {"-1", typeof (uint), true, null},
+                   // new object[] {"0", typeof (uint), false, (uint) 0},  //cause warning: Skipping test case with duplicate ID
+                   // new object[] {"-1", typeof (uint), true, null},  //cause warning: Skipping test case with duplicate ID
                     new object[] {uint.MaxValue.ToString(), typeof (uint), false, uint.MaxValue},
                     new object[] {uint.MinValue.ToString(), typeof (uint), false, uint.MinValue},
                     new object[] {((long) uint.MaxValue + 1).ToString(), typeof (uint), true, null},

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -326,7 +326,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Explicit_version_request_generates_version_info_screen()
         {
             // Fixture setup
@@ -345,12 +345,12 @@ namespace CommandLine.Tests.Unit
             lines[0].Should().StartWithEquivalent("CommandLine");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
+            lines[0].Should().StartWithEquivalent("testhost");
 #endif
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Implicit_help_screen_in_verb_scenario()
         {
             // Fixture setup
@@ -369,8 +369,8 @@ namespace CommandLine.Tests.Unit
             lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            lines[0].Should().StartWithEquivalent("testhost");
+            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
 #endif
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("No verb selected.");
@@ -382,7 +382,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Double_dash_help_dispalys_verbs_index_in_verbs_scenario()
         {
             // Fixture setup
@@ -400,8 +400,8 @@ namespace CommandLine.Tests.Unit
             lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            lines[0].Should().StartWithEquivalent("testhost");
+            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
 #endif
             lines[2].Should().BeEquivalentTo("add        Add file contents to the index.");
             lines[3].Should().BeEquivalentTo("commit     Record changes to the repository.");
@@ -411,7 +411,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-        //[Theory]
+        [Theory]
         [InlineData("--version")]
         [InlineData("version")]
         public void Explicit_version_request_generates_version_info_screen_in_verbs_scenario(string command)
@@ -432,12 +432,12 @@ namespace CommandLine.Tests.Unit
             lines[0].Should().StartWithEquivalent("CommandLine");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
+            lines[0].Should().StartWithEquivalent("testhost");
 #endif
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Errors_of_type_MutuallyExclusiveSetError_are_properly_formatted()
         {
             // Fixture setup
@@ -455,8 +455,8 @@ namespace CommandLine.Tests.Unit
             lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            lines[0].Should().StartWithEquivalent("testhost");
+            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
 #endif
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Option: 'weburl' is not compatible with: 'ftpurl'.");
@@ -485,7 +485,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Properly_formatted_help_screen_is_displayed_when_usage_is_defined_in_verb_scenario()
         {
             // Fixture setup
@@ -508,8 +508,8 @@ namespace CommandLine.Tests.Unit
             lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            lines[0].Should().StartWithEquivalent("testhost");
+            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
 #endif
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Option 'badoption' is unknown.");
@@ -530,7 +530,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-         //[Fact]
+         [Fact]
         public void Properly_formatted_help_screen_is_displayed_when_there_is_a_hidden_verb()
         {
             // Fixture setup
@@ -548,8 +548,8 @@ namespace CommandLine.Tests.Unit
             lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            lines[0].Should().StartWithEquivalent("testhost");
+            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
 #endif
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("No verb selected.");
@@ -560,7 +560,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Properly_formatted_help_screen_is_displayed_when_there_is_a_hidden_verb_selected_usage_displays_with_hidden_option()
         {
             // Fixture setup
@@ -578,8 +578,8 @@ namespace CommandLine.Tests.Unit
             lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            lines[0].Should().StartWithEquivalent("testhost");
+            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
 #endif
             lines[2].Should().BeEquivalentTo("-f, --force    Allow adding otherwise ignored files.");
             lines[3].Should().BeEquivalentTo("--help         Display this help screen.");
@@ -627,7 +627,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Specific_verb_help_screen_should_be_displayed_regardless_other_argument()
         {
             // Fixture setup
@@ -650,8 +650,8 @@ namespace CommandLine.Tests.Unit
             lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            lines[0].Should().StartWithEquivalent("testhost");
+            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
 #endif
             lines[2].Should().BeEquivalentTo("--no-hardlinks    Optimize the cloning process from a repository on a local");
             lines[3].Should().BeEquivalentTo("filesystem by copying files.");
@@ -701,7 +701,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Properly_formatted_help_screen_excludes_help_as_unknown_option()
         {
             // Fixture setup
@@ -724,8 +724,8 @@ namespace CommandLine.Tests.Unit
             lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            lines[0].Should().StartWithEquivalent("testhost");
+            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
 #endif
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Option 'bad-arg' is unknown.");

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using CommandLine.Tests.Fakes;
 using FluentAssertions;
 using Xunit;
+using CommandLine.Text;
 
 namespace CommandLine.Tests.Unit
 {
@@ -340,13 +341,8 @@ namespace CommandLine.Tests.Unit
             // Verify outcome
             result.Length.Should().BeGreaterThan(0);
             var lines = result.ToNotEmptyLines().TrimStringArray();
-            lines.Should().HaveCount(x => x == 1);
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("testhost");
-#endif
+            lines.Should().HaveCount(x => x == 1);			
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
             // Teardown
         }
 
@@ -364,14 +360,8 @@ namespace CommandLine.Tests.Unit
             // Verify outcome
             result.Length.Should().BeGreaterThan(0);
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("testhost");
-            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("No verb selected.");
             lines[4].Should().BeEquivalentTo("add        Add file contents to the index.");
@@ -395,14 +385,8 @@ namespace CommandLine.Tests.Unit
 
             // Verify outcome
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("testhost");
-            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("add        Add file contents to the index.");
             lines[3].Should().BeEquivalentTo("commit     Record changes to the repository.");
             lines[4].Should().BeEquivalentTo("clone      Clone a repository into a new directory.");
@@ -428,12 +412,7 @@ namespace CommandLine.Tests.Unit
             result.Length.Should().BeGreaterThan(0);
             var lines = result.ToNotEmptyLines().TrimStringArray();
             lines.Should().HaveCount(x => x == 1);
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("testhost");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
             // Teardown
         }
 
@@ -450,14 +429,8 @@ namespace CommandLine.Tests.Unit
 
             // Verify outcome
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("testhost");
-            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Option: 'weburl' is not compatible with: 'ftpurl'.");
             lines[4].Should().BeEquivalentTo("Option: 'ftpurl' is not compatible with: 'weburl'.");
@@ -503,14 +476,8 @@ namespace CommandLine.Tests.Unit
 
             // Verify outcome
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("testhost");
-            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Option 'badoption' is unknown.");
             lines[4].Should().BeEquivalentTo("USAGE:");
@@ -543,14 +510,8 @@ namespace CommandLine.Tests.Unit
             
             // Verify outcome
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("testhost");
-            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("No verb selected.");
             lines[4].Should().BeEquivalentTo("add        Add file contents to the index.");
@@ -573,14 +534,8 @@ namespace CommandLine.Tests.Unit
             
             // Verify outcome
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("testhost");
-            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("-f, --force    Allow adding otherwise ignored files.");
             lines[3].Should().BeEquivalentTo("--help         Display this help screen.");
             lines[4].Should().BeEquivalentTo("--version      Display version information.");
@@ -645,14 +600,8 @@ namespace CommandLine.Tests.Unit
 
             // Verify outcome
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("testhost");
-            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("--no-hardlinks    Optimize the cloning process from a repository on a local");
             lines[3].Should().BeEquivalentTo("filesystem by copying files.");
             lines[4].Should().BeEquivalentTo("-q, --quiet       Suppress summary message.");
@@ -719,14 +668,8 @@ namespace CommandLine.Tests.Unit
 
             // Verify outcome
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("testhost");
-            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Option 'bad-arg' is unknown.");
             lines[4].Should().BeEquivalentTo("--no-hardlinks    Optimize the cloning process from a repository on a local");

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -324,14 +324,9 @@ namespace CommandLine.Tests.Unit.Text
 
             // Verify outcome
             var lines = helpText.ToString().ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().StartWithEquivalent("Copyright (c)");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("testhost");
-            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
-#endif
+			
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());			
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Token 'badtoken' is not recognized.");
             lines[4].Should().BeEquivalentTo("A sequence option 'i' is defined with fewer or more items than required.");
@@ -360,14 +355,8 @@ namespace CommandLine.Tests.Unit.Text
             // Verify outcome
             var lines = helpText.ToString().ToNotEmptyLines().TrimStringArray();
 
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().StartWithEquivalent("Copyright (c)");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("testhost");
-            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());	
             lines[2].Should().BeEquivalentTo("-p, --patch      Use the interactive patch selection interface to chose which");
             lines[3].Should().BeEquivalentTo("changes to commit.");
             lines[4].Should().BeEquivalentTo("--amend          Used to amend the tip of the current branch.");
@@ -393,14 +382,8 @@ namespace CommandLine.Tests.Unit.Text
             // Verify outcome
             var lines = helpText.ToString().ToNotEmptyLines().TrimStringArray();
 
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("testhost");
-            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());	
             lines[2].Should().BeEquivalentTo("-p, --patch      Use the interactive patch selection interface to chose which changes to commit.");
             lines[3].Should().BeEquivalentTo("--amend          Used to amend the tip of the current branch.");
             lines[4].Should().BeEquivalentTo("-m, --message    Use the given message as the commit message.");
@@ -425,14 +408,8 @@ namespace CommandLine.Tests.Unit.Text
             // Verify outcome
             var lines = helpText.ToString().ToNotEmptyLines().TrimStringArray();
 
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().StartWithEquivalent("Copyright (c)");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("testhost");
-            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());	
             lines[2].Should().BeEquivalentTo("add        Add file contents to the index.");
             lines[3].Should().BeEquivalentTo("commit     Record changes to the repository.");
             lines[4].Should().BeEquivalentTo("clone      Clone a repository into a new directory.");
@@ -510,15 +487,9 @@ namespace CommandLine.Tests.Unit.Text
 
             // Verify outcome
             var text = helpText.ToString();
-            var lines = text.ToNotEmptyLines().Select(x=>x.Trim()).ToArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().StartWithEquivalent("Copyright (c)");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("testhost");
-            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
-#endif
+            var lines = text.ToNotEmptyLines().TrimStringArray();
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());	
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Token 'badtoken' is not recognized.");
             lines[4].Should().BeEquivalentTo("USAGE:");

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -77,7 +77,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Create_instance_with_enum_options_enabled()
         {
             // Fixture setup
@@ -182,7 +182,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void When_help_text_has_hidden_option_it_should_not_be_added_to_help_text_output()
         {
             // Fixture setup
@@ -307,7 +307,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Invoke_AutoBuild_for_Options_returns_appropriate_formatted_text()
         {
             // Fixture setup
@@ -329,8 +329,8 @@ namespace CommandLine.Tests.Unit.Text
             lines[1].Should().StartWithEquivalent("Copyright (c)");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            lines[0].Should().StartWithEquivalent("testhost");
+            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
 #endif
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Token 'badtoken' is not recognized.");
@@ -343,7 +343,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Invoke_AutoBuild_for_Verbs_with_specific_verb_returns_appropriate_formatted_text()
         {
             // Fixture setup
@@ -365,8 +365,8 @@ namespace CommandLine.Tests.Unit.Text
             lines[1].Should().StartWithEquivalent("Copyright (c)");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            lines[0].Should().StartWithEquivalent("testhost");
+            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
 #endif
             lines[2].Should().BeEquivalentTo("-p, --patch      Use the interactive patch selection interface to chose which");
             lines[3].Should().BeEquivalentTo("changes to commit.");
@@ -376,7 +376,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Invoke_AutoBuild_for_Verbs_with_specific_verb_returns_appropriate_formatted_text_given_display_width_100()
         {
             // Fixture setup
@@ -398,8 +398,8 @@ namespace CommandLine.Tests.Unit.Text
             lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            lines[0].Should().StartWithEquivalent("testhost");
+            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
 #endif
             lines[2].Should().BeEquivalentTo("-p, --patch      Use the interactive patch selection interface to chose which changes to commit.");
             lines[3].Should().BeEquivalentTo("--amend          Used to amend the tip of the current branch.");
@@ -408,7 +408,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Invoke_AutoBuild_for_Verbs_with_unknown_verb_returns_appropriate_formatted_text()
         {
             // Fixture setup
@@ -430,8 +430,8 @@ namespace CommandLine.Tests.Unit.Text
             lines[1].Should().StartWithEquivalent("Copyright (c)");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            lines[0].Should().StartWithEquivalent("testhost");
+            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
 #endif
             lines[2].Should().BeEquivalentTo("add        Add file contents to the index.");
             lines[3].Should().BeEquivalentTo("commit     Record changes to the repository.");
@@ -494,7 +494,7 @@ namespace CommandLine.Tests.Unit.Text
             lines[10].Should().BeEquivalentTo("  mono testapp.exe value");
         }
 
-        //[Fact]
+        [Fact]
         public void Invoke_AutoBuild_for_Options_with_Usage_returns_appropriate_formatted_text()
         {
             // Fixture setup
@@ -510,14 +510,14 @@ namespace CommandLine.Tests.Unit.Text
 
             // Verify outcome
             var text = helpText.ToString();
-            var lines = text.ToNotEmptyLines();
+            var lines = text.ToNotEmptyLines().Select(x=>x.Trim()).ToArray();
 #if !PLATFORM_DOTNET
             lines[0].Should().StartWithEquivalent("CommandLine");
             lines[1].Should().StartWithEquivalent("Copyright (c)");
 #else
             // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
+            lines[0].Should().StartWithEquivalent("testhost");
+            lines[1].Should().StartWithEquivalent("© Microsoft Corporation");
 #endif
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Token 'badtoken' is not recognized.");
@@ -653,5 +653,6 @@ namespace CommandLine.Tests.Unit.Text
 
             Assert.Equal("T" + Environment.NewLine + "e" + Environment.NewLine + "s" + Environment.NewLine + "t", b.ToString());
         }
+        
     }
 }

--- a/tests/CommandLine.Tests/Unit/UnParserExtensionsTests.cs
+++ b/tests/CommandLine.Tests/Unit/UnParserExtensionsTests.cs
@@ -39,7 +39,7 @@ namespace CommandLine.Tests.Unit
         }
 
         [Theory]
-        [MemberData("UnParseDataHidden")]
+        [MemberData(nameof(UnParseDataHidden))]
         public static void Unparsing_hidden_option_returns_command_line(Hidden_Option options, bool showHidden, string result)
         {
             new Parser()


### PR DESCRIPTION
- Add missed tests in v2.4.3 which were [reported](https://github.com/commandlineparser/commandline/pull/307#issuecomment-412697222) by @ericnewton76 (18 test case)

- Remove the xunit test warning `xUnit1013`:
>warning xUnit1013: Public method 'XXX' on test class 'YYY' should be marked as a Fact.

- Fix Xunit warning: Skipping test case with duplicate ID

- Fix Xunit warning: xUnit1014- MemberData should use nameof operator to reference member 