### PR TITLE
Add examples that I wish were there

### DIFF
--- a/tests/CommandLine.Tests/Unit/Examples/OptionWithValues.cs
+++ b/tests/CommandLine.Tests/Unit/Examples/OptionWithValues.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace CommandLine.Tests.Unit.Examples
+{
+    public class OptionWithValues
+    {
+        public class SampleOptions
+        {
+            [Option('n', "name", Separator = ',')]
+            public IEnumerable<string> Names { get; set; }
+        }
+
+        [Fact]
+        public void supply_single_value()
+        {
+            Parser.Default.ParseArguments<SampleOptions>(new [] { "Sample.exe", "--n A"}).
+                WithParsed(options =>
+                {
+                    Assert.Equal(new[] { "A" }, options.Names);
+                });
+        }
+
+        [Fact]
+        public void single_dash_produces_unexpected_result()
+        {
+            Parser.Default.ParseArguments<SampleOptions>(new[] { "Sample.exe", "-n A" }).
+                WithParsed(options =>
+                {
+                    // [!] unexpected as it prepends a space
+                    Assert.Equal(new[] { " A" }, options.Names);
+                });
+        }
+
+        [Fact]
+        public void supply_multiple_values()
+        {
+            Parser.Default.ParseArguments<SampleOptions>(new[] { "Sample.exe", "--n A,B,C" }).
+                WithParsed(options =>
+                {
+                    Assert.Equal(new[] { "A", "B", "C" }, options.Names);
+                });
+        }
+
+        [Fact]
+        public void defaults_to_empty_array()
+        {
+            Parser.Default.ParseArguments<SampleOptions>(new[] { "Sample.exe" }).
+                WithParsed(options =>
+                {
+                    Assert.Equal(new string[0], options.Names);
+                });
+        }
+
+        public class SampleOptionsMissingSeparator
+        {
+            [Option('n', "name")]
+            public IEnumerable<string> Names { get; set; }
+        }
+
+        [Fact]
+        public void you_must_supply_option_separator_otherwise_you_get_blank_results()
+        {
+            Parser.Default.ParseArguments<SampleOptionsMissingSeparator>(new[] { "Sample.exe", "--n A" }).
+                WithParsed(options =>
+                {
+                    Assert.Equal(new string[0], options.Names);
+                }).WithNotParsed(errors =>
+                {
+                    Assert.Equal(ErrorType.UnknownOptionError, errors.Single().Tag);
+                });
+        }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/Examples/TheBasics.cs
+++ b/tests/CommandLine.Tests/Unit/Examples/TheBasics.cs
@@ -1,0 +1,21 @@
+﻿using Xunit;
+
+namespace CommandLine.Tests.Unit.Examples
+{
+    public class TheBasics
+    {
+        public class SampleOptions
+        {
+            [Option('v', "verbose")]
+            public bool Verbose { get; set; }
+        }
+
+        [Fact]
+        public void obtain_parsed_options_like_this()
+        {
+            SampleOptions result = ((Parsed<SampleOptions>)Parser.Default.ParseArguments<SampleOptions>(new[] {"Sample.exe", "-v" })).Value;
+
+            Assert.True(result.Verbose);
+        }
+    }
+}


### PR DESCRIPTION
I wish this style of usage example was already around somewhere, or easier to find if they are!

These ones show how to:

* parse options and get result without having to use `WithParsed`
* make options that accept multiple values.

I tried to make these as clear as possible, in the hope they may be understood by reading just the one file.

I realise there is duplication here, but perhaps it is worth it in cases like this. (The duplication is bound to public interface members that are very stable.)