### PR TITLE
Fix issues  for HelpText.AutoBuild configuration (issues #224 , # 259)

### DIFF
--- a/src/CommandLine/ErrorExtensions.cs
+++ b/src/CommandLine/ErrorExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using CommandLine.Core;
@@ -22,6 +23,32 @@ namespace CommandLine
                 .Where(e => !e.StopsProcessing)
                 .Where(e => !(e.Tag == ErrorType.UnknownOptionError
                     && ((UnknownOptionError)e).Token.EqualsOrdinalIgnoreCase("help")));
+        }
+        /// <summary>
+        ///  return true when errors contain HelpXXXError
+        /// </summary>
+        public static bool  IsHelp  (this IEnumerable<Error> errs)
+        {
+            if (errs.Any(x=>x.Tag == ErrorType.HelpRequestedError || 
+                            x.Tag == ErrorType.HelpVerbRequestedError))
+                return true;
+            //when  AutoHelp=false in parser, help is disabled  and Parser raise UnknownOptionError
+            if(  errs.Any(x=> (x is UnknownOptionError ee ? ee.Token:"") == "help"))
+                return true;
+            return false;
+        }
+
+        /// <summary>
+        ///  return true when errors contain VersionXXXError
+        /// </summary>
+        public static bool  IsVersion  (this IEnumerable<Error> errs)
+        {
+            if (errs.Any(x=>x.Tag == ErrorType.VersionRequestedError ))
+                return true;
+            //when  AutoVersion=false in parser, Version is disabled  and Parser raise UnknownOptionError
+            if(  errs.Any(x=> (x is UnknownOptionError ee ? ee.Token:"") == "version"))
+                return true;
+            return false;
         }
     }
 }

--- a/src/CommandLine/ErrorExtensions.cs
+++ b/src/CommandLine/ErrorExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using CommandLine.Core;
@@ -24,31 +23,6 @@ namespace CommandLine
                 .Where(e => !(e.Tag == ErrorType.UnknownOptionError
                     && ((UnknownOptionError)e).Token.EqualsOrdinalIgnoreCase("help")));
         }
-        /// <summary>
-        ///  return true when errors contain HelpXXXError
-        /// </summary>
-        public static bool  IsHelp  (this IEnumerable<Error> errs)
-        {
-            if (errs.Any(x=>x.Tag == ErrorType.HelpRequestedError || 
-                            x.Tag == ErrorType.HelpVerbRequestedError))
-                return true;
-            //when  AutoHelp=false in parser, help is disabled  and Parser raise UnknownOptionError
-            if(  errs.Any(x=> (x is UnknownOptionError ee ? ee.Token:"") == "help"))
-                return true;
-            return false;
-        }
-
-        /// <summary>
-        ///  return true when errors contain VersionXXXError
-        /// </summary>
-        public static bool  IsVersion  (this IEnumerable<Error> errs)
-        {
-            if (errs.Any(x=>x.Tag == ErrorType.VersionRequestedError ))
-                return true;
-            //when  AutoVersion=false in parser, Version is disabled  and Parser raise UnknownOptionError
-            if(  errs.Any(x=> (x is UnknownOptionError ee ? ee.Token:"") == "version"))
-                return true;
-            return false;
-        }
+       
     }
 }

--- a/src/CommandLine/HelpTextExtensions.cs
+++ b/src/CommandLine/HelpTextExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CommandLine
+{
+    public static class HelpTextExtensions
+    {
+        /// <summary>
+        ///  return true when errors contain HelpXXXError
+        /// </summary>
+        public static bool IsHelp(this IEnumerable<Error> errs)
+        {
+            if (errs.Any(x => x.Tag == ErrorType.HelpRequestedError ||
+                            x.Tag == ErrorType.HelpVerbRequestedError))
+                return true;
+            //when  AutoHelp=false in parser, help is disabled  and Parser raise UnknownOptionError
+            return errs.Any(x => (x is UnknownOptionError ee ? ee.Token : "") == "help");
+        }
+
+        /// <summary>
+        ///  return true when errors contain VersionXXXError
+        /// </summary>
+        public static bool IsVersion(this IEnumerable<Error> errs)
+        {
+            if (errs.Any(x => x.Tag == ErrorType.VersionRequestedError))
+                return true;
+            //when  AutoVersion=false in parser, Version is disabled  and Parser raise UnknownOptionError
+            return errs.Any(x => (x is UnknownOptionError ee ? ee.Token : "") == "version");
+        }
+    }
+}
+ 
+

--- a/src/CommandLine/HelpTextExtensions.cs
+++ b/src/CommandLine/HelpTextExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
-
+using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -28,6 +29,15 @@ namespace CommandLine
                 return true;
             //when  AutoVersion=false in parser, Version is disabled  and Parser raise UnknownOptionError
             return errs.Any(x => (x is UnknownOptionError ee ? ee.Token : "") == "version");
+        }
+		 /// <summary>
+        ///  redirect errs to Console.Error, and to Console.Out for help/version error
+        /// </summary>
+		 public static TextWriter Output(this IEnumerable<Error> errs)
+        {
+           if (errs.IsHelp() || errs.IsVersion())
+			   return Console.Out;
+		   return Console.Error;
         }
     }
 }

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -269,11 +269,13 @@ namespace CommandLine.Text
 
             var errors = Enumerable.Empty<Error>();
 
+         
             if (onError != null && parserResult.Tag == ParserResultType.NotParsed)
             {
                 errors = ((NotParsed<T>)parserResult).Errors;
-
-                if (errors.OnlyMeaningfulOnes().Any())
+                if (errors.IsHelp())
+                    auto = onError(auto);
+                else if (errors.OnlyMeaningfulOnes().Any())
                     auto = onError(auto);
             }
 

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -273,9 +273,7 @@ namespace CommandLine.Text
             if (onError != null && parserResult.Tag == ParserResultType.NotParsed)
             {
                 errors = ((NotParsed<T>)parserResult).Errors;
-                if (errors.IsHelp())
-                    auto = onError(auto);
-                else if (errors.OnlyMeaningfulOnes().Any())
+                if (errors.IsHelp() || errors.OnlyMeaningfulOnes().Any())
                     auto = onError(auto);
             }
 

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextAutoBuildFix.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextAutoBuildFix.cs
@@ -1,164 +1,93 @@
-﻿using CommandLine.Tests.Fakes;
+﻿using System;
+using System.Linq;
+using CommandLine.Tests.Fakes;
 using CommandLine.Text;
 using FluentAssertions;
 using Xunit;
 
 namespace CommandLine.Tests.Unit.Text
 {
-    public class HelpTextTests2
+    public class HelpTextAutoBuildFix
     {
+
         [Fact]
-        public static void error_ishelp()
+        public void HelpText_wit_AdditionalNewLineAfterOption_true_should_have_newline()
         {
             // Fixture setup
-            // Exercize system
-            var parser = new Parser(x => x.HelpWriter = null);
-            var result = parser.ParseArguments<Simple_Options>(new[]{"--help"});
+            // Exercize system 
+            var sut = new HelpText { AdditionalNewLineAfterOption = true }
+                .AddOptions(new NotParsed<Simple_Options>(TypeInfo.Create(typeof(Simple_Options)),
+                    Enumerable.Empty<Error>()));
 
-            result .WithNotParsed(errs =>
-            {
-                errs.IsHelp().Should().BeTrue();
-                errs.IsVersion().Should().BeFalse();
-            });
-        }
-        [Fact]
-        public static void error_isVersion()
-        {
-            // Fixture setup
-            // Exercize system
-            var parser = new Parser(x => x.HelpWriter = null);
-            var result = parser.ParseArguments<Simple_Options>(new[]{"--version"});
+            // Verify outcome
 
-            result .WithNotParsed(errs =>
-            {
-                errs.IsHelp().Should().BeFalse();
-                errs.IsVersion().Should().BeTrue();
-            });
-        }
-        
-        [Fact]
-        public static void custom_helptext_with_AdditionalNewLineAfterOption_false()
-        {
-            // Fixture setup
-            // Exercize system
-            var parser = new Parser(x => x.HelpWriter = null);
-            var result = parser.ParseArguments<Simple_Options>(new[]{"--help"});
+            var lines = sut.ToString().ToLines();
 
-            result .WithNotParsed(errs =>
-            {
-               
-                var sut = HelpText.AutoBuild(result,
-                    h =>
-                    {
-                        h.AdditionalNewLineAfterOption = false;
-                        return h;
-                    }
-                    , e => e);
-                //Assert
-                var expected = new[]
-                {
-                    "  --help                Display this help screen.",
-                    "  --version             Display version information."
-                };
-                var lines = sut.ToString().ToLines();
-                lines.Should().ContainInOrder(expected);
-            });
+            lines[2].Should().BeEquivalentTo("  stringvalue        Define a string value here.");
+            lines[3].Should().BeEquivalentTo(String.Empty);
+            lines[4].Should().BeEquivalentTo("  s, shortandlong    Example with both short and long name.");
+            lines[5].Should().BeEquivalentTo(String.Empty);
+            lines[7].Should().BeEquivalentTo(String.Empty);
+            lines[9].Should().BeEquivalentTo(String.Empty);
+            lines[11].Should().BeEquivalentTo(String.Empty);
+            lines[13].Should().BeEquivalentTo(String.Empty);
+            lines[14].Should().BeEquivalentTo("  value pos. 0       Define a long value here.");
+            // Teardown
         }
 
         [Fact]
-        public static void custom_helptext_with_AdditionalNewLineAfterOption_true()
+        public void HelpText_wit_AdditionalNewLineAfterOption_false_should_not_have_newline()
         {
             // Fixture setup
-            // Exercize system
-            var parser = new Parser(x => x.HelpWriter = null);
-            var result = parser.ParseArguments<Simple_Options>(new[]{"--help"});
+            // Exercize system 
+            var sut = new HelpText { AdditionalNewLineAfterOption = false }
+                .AddOptions(new NotParsed<Simple_Options>(TypeInfo.Create(typeof(Simple_Options)),
+                    Enumerable.Empty<Error>()));
 
-            result .WithNotParsed(errs =>
-            {
-               
-                var sut = HelpText.AutoBuild(result,
-                    h =>h //AdditionalNewLineAfterOption =true by default
-                    , e => e);
-               
-                //Assert
-                var expected = new[]
-                {
-                    string.Empty,
-                    "  --help                Display this help screen.",
-                    string.Empty, 
-                    "  --version             Display version information."
-                };
-                var lines = sut.ToString().ToLines();
-                lines.Should().ContainInOrder(expected);
-            });
+            // Verify outcome
+
+            var lines = sut.ToString().ToLines();
+
+            lines[2].Should().BeEquivalentTo("  stringvalue        Define a string value here.");
+
+            lines[3].Should().BeEquivalentTo("  s, shortandlong    Example with both short and long name.");
+            lines[8].Should().BeEquivalentTo("  value pos. 0       Define a long value here.");
+            // Teardown
         }
-
-       
         [Fact]
-        public static void custom_helptext_with_parser_autohelp_false_and_AdditionalNewLineAfterOption_false()
+        public void HelpText_wit_by_default_should_include_help_version_option()
         {
             // Fixture setup
-            // Exercize system
-            var parser = new Parser(x =>
-            {
-                x.HelpWriter = null;
-                x.AutoHelp=false;
-                //x.AutoVersion=false;
-            });
-            var result = parser.ParseArguments<Simple_Options>(new[]{"--help"});
-            //you could generate help even parser.AutoHelp is disabled
-            result .WithNotParsed(errs =>
-            {
-                errs.IsHelp().Should().BeTrue();
-                var sut = HelpText.AutoBuild(result,
-                    h =>
-                    {
-                        h.AdditionalNewLineAfterOption = false;
-                        return h;
-                    }
-                    , e => e);
-              
-                //Assert
-                var expected = new[]
-                {
-                    "  --help                Display this help screen.",
-                    "  --version             Display version information."
-                };
-                var lines = sut.ToString().ToLines();
-                lines.Should().ContainInOrder(expected);
-            });
+            // Exercize system 
+            var sut = new HelpText ()
+                .AddOptions(new NotParsed<Simple_Options>(TypeInfo.Create(typeof(Simple_Options)),
+                    Enumerable.Empty<Error>()));
+
+            // Verify outcome
+
+            var lines = sut.ToString().ToNotEmptyLines();
+            lines.Should().HaveCount(c => c ==7);
+            lines.Should().Contain("  help               Display more information on a specific command.");
+            lines.Should().Contain("  version            Display version information.");
+            // Teardown
         }
 
         [Fact]
-        public static void custom_helptext_with_autohelp_false()
+        public void HelpText_wit_AutoHelp_false_should_hide_help_option()
         {
             // Fixture setup
-            // Exercize system
-            var parser = new Parser(x =>
-            {
-                x.HelpWriter = null;
-                x.AutoHelp=false;
-                //x.AutoVersion=false;
-            });
-            var result = parser.ParseArguments<Simple_Options>(new[]{"--help"});
+            // Exercize system 
+            var sut = new HelpText { AutoHelp = false,AutoVersion = false}
+                .AddOptions(new NotParsed<Simple_Options>(TypeInfo.Create(typeof(Simple_Options)),
+                    Enumerable.Empty<Error>()));
 
-            result .WithNotParsed(errs =>
-            {
-                errs.IsHelp().Should().BeTrue();
-                var sut = HelpText.AutoBuild(result,
-                    h =>h,e => e);
-             
-                //Assert
-                var expected = new[]
-                {
-                    string.Empty,
-                    "  --help                Display this help screen.",
-                    string.Empty, 
-                    "  --version             Display version information."
-                };
-                var lines = sut.ToString().ToLines();
-                lines.Should().ContainInOrder(expected);
-            });
+            // Verify outcome
+
+            var lines = sut.ToString().ToNotEmptyLines();
+            lines.Should().HaveCount(c => c ==5);
+            lines.Should().NotContain("  help               Display more information on a specific command.");
+            lines.Should().NotContain("  version            Display version information.");
+            // Teardown
         }
     }
 }

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextAutoBuildFix.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextAutoBuildFix.cs
@@ -1,0 +1,164 @@
+﻿using CommandLine.Tests.Fakes;
+using CommandLine.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace CommandLine.Tests.Unit.Text
+{
+    public class HelpTextTests2
+    {
+        [Fact]
+        public static void error_ishelp()
+        {
+            // Fixture setup
+            // Exercize system
+            var parser = new Parser(x => x.HelpWriter = null);
+            var result = parser.ParseArguments<Simple_Options>(new[]{"--help"});
+
+            result .WithNotParsed(errs =>
+            {
+                errs.IsHelp().Should().BeTrue();
+                errs.IsVersion().Should().BeFalse();
+            });
+        }
+        [Fact]
+        public static void error_isVersion()
+        {
+            // Fixture setup
+            // Exercize system
+            var parser = new Parser(x => x.HelpWriter = null);
+            var result = parser.ParseArguments<Simple_Options>(new[]{"--version"});
+
+            result .WithNotParsed(errs =>
+            {
+                errs.IsHelp().Should().BeFalse();
+                errs.IsVersion().Should().BeTrue();
+            });
+        }
+        
+        [Fact]
+        public static void custom_helptext_with_AdditionalNewLineAfterOption_false()
+        {
+            // Fixture setup
+            // Exercize system
+            var parser = new Parser(x => x.HelpWriter = null);
+            var result = parser.ParseArguments<Simple_Options>(new[]{"--help"});
+
+            result .WithNotParsed(errs =>
+            {
+               
+                var sut = HelpText.AutoBuild(result,
+                    h =>
+                    {
+                        h.AdditionalNewLineAfterOption = false;
+                        return h;
+                    }
+                    , e => e);
+                //Assert
+                var expected = new[]
+                {
+                    "  --help                Display this help screen.",
+                    "  --version             Display version information."
+                };
+                var lines = sut.ToString().ToLines();
+                lines.Should().ContainInOrder(expected);
+            });
+        }
+
+        [Fact]
+        public static void custom_helptext_with_AdditionalNewLineAfterOption_true()
+        {
+            // Fixture setup
+            // Exercize system
+            var parser = new Parser(x => x.HelpWriter = null);
+            var result = parser.ParseArguments<Simple_Options>(new[]{"--help"});
+
+            result .WithNotParsed(errs =>
+            {
+               
+                var sut = HelpText.AutoBuild(result,
+                    h =>h //AdditionalNewLineAfterOption =true by default
+                    , e => e);
+               
+                //Assert
+                var expected = new[]
+                {
+                    string.Empty,
+                    "  --help                Display this help screen.",
+                    string.Empty, 
+                    "  --version             Display version information."
+                };
+                var lines = sut.ToString().ToLines();
+                lines.Should().ContainInOrder(expected);
+            });
+        }
+
+       
+        [Fact]
+        public static void custom_helptext_with_parser_autohelp_false_and_AdditionalNewLineAfterOption_false()
+        {
+            // Fixture setup
+            // Exercize system
+            var parser = new Parser(x =>
+            {
+                x.HelpWriter = null;
+                x.AutoHelp=false;
+                //x.AutoVersion=false;
+            });
+            var result = parser.ParseArguments<Simple_Options>(new[]{"--help"});
+            //you could generate help even parser.AutoHelp is disabled
+            result .WithNotParsed(errs =>
+            {
+                errs.IsHelp().Should().BeTrue();
+                var sut = HelpText.AutoBuild(result,
+                    h =>
+                    {
+                        h.AdditionalNewLineAfterOption = false;
+                        return h;
+                    }
+                    , e => e);
+              
+                //Assert
+                var expected = new[]
+                {
+                    "  --help                Display this help screen.",
+                    "  --version             Display version information."
+                };
+                var lines = sut.ToString().ToLines();
+                lines.Should().ContainInOrder(expected);
+            });
+        }
+
+        [Fact]
+        public static void custom_helptext_with_autohelp_false()
+        {
+            // Fixture setup
+            // Exercize system
+            var parser = new Parser(x =>
+            {
+                x.HelpWriter = null;
+                x.AutoHelp=false;
+                //x.AutoVersion=false;
+            });
+            var result = parser.ParseArguments<Simple_Options>(new[]{"--help"});
+
+            result .WithNotParsed(errs =>
+            {
+                errs.IsHelp().Should().BeTrue();
+                var sut = HelpText.AutoBuild(result,
+                    h =>h,e => e);
+             
+                //Assert
+                var expected = new[]
+                {
+                    string.Empty,
+                    "  --help                Display this help screen.",
+                    string.Empty, 
+                    "  --version             Display version information."
+                };
+                var lines = sut.ToString().ToLines();
+                lines.Should().ContainInOrder(expected);
+            });
+        }
+    }
+}


### PR DESCRIPTION
HelpText.AutoBuild can't apply setting on HelpText to add AdditionalNewLineAfterOption and other setting. 
These setting are applied only when parser raise parsing errors.
This PR fix this bug and fix issue #224 , #259 .
You have a complete control on HelpText configuration in custom help.
Also, new extension methods IsHelp() /IsVersion() is added to simplify checking errors if it have help/version option.


            var parser = new Parser(x =>
            {
                x.HelpWriter = null;               
            });
            var result = parser.ParseArguments<Simple_Options>(new[]{"--help"});
            //generate custom help 
            result .WithNotParsed(errs =>
            {               
                var helpText = HelpText.AutoBuild(result,
                    h =>
                    {
					    //configure help
                        h.AdditionalNewLineAfterOption = false;
                        return h;
                    }
                    , e => e);
                 //print help screen
                Console.WriteLine(helpText);
                 
            });