### PR TITLE
Allow BaseAttribute HelpText localization to use internal classes and properties.

### DIFF
--- a/src/CommandLine/Infrastructure/LocalizableAttributeProperty.cs
+++ b/src/CommandLine/Infrastructure/LocalizableAttributeProperty.cs
@@ -43,10 +43,9 @@ namespace CommandLine.Infrastructure
                 return _value;
             if (_localizationPropertyInfo == null)
             {
-                // Static class IsAbstract 
-                if (!_type.IsVisible)
-                    throw new ArgumentException("Invalid resource type", _propertyName);
-                PropertyInfo propertyInfo = _type.GetProperty(_value, BindingFlags.Public | BindingFlags.GetProperty | BindingFlags.Static);
+                PropertyInfo propertyInfo = _type.GetProperty(
+                    _value,
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.GetProperty | BindingFlags.Static);
                 if (propertyInfo == null || !propertyInfo.CanRead || propertyInfo.PropertyType != typeof(string))
                     throw new ArgumentException("Invalid resource property name", _propertyName);
                 _localizationPropertyInfo = propertyInfo;

--- a/tests/CommandLine.Tests/Fakes/ResourceFakes.cs
+++ b/tests/CommandLine.Tests/Fakes/ResourceFakes.cs
@@ -9,23 +9,19 @@ namespace CommandLine.Tests.Fakes
     public static class StaticResource
     {
         public static string HelpText { get { return "Localized HelpText"; } }
+        internal static string InternalText { get { return "Internal Text"; } }
+        private static string PrivateText { get { return "Private Text"; } }
     }
 
     public class NonStaticResource
     {
         public static string HelpText { get { return "Localized HelpText"; } }
-        public static string WriteOnlyText { set { value?.ToString(); } }
-        private static string PrivateHelpText { get { return "Localized HelpText"; } }
-    }
-
-    public class NonStaticResource_WithNonStaticProperty
-    {
-        public string HelpText { get { return "Localized HelpText"; } }
+        public static string WriteOnlyText { set { } }
+        public string InstanceText { get { return "Instance Text"; } }
     }
 
     internal class InternalResource
     {
-        public static string HelpText { get { return "Localized HelpText"; } }
+        public static string Text { get { return "Localized Text"; } }
     }
-
 }

--- a/tests/CommandLine.Tests/Unit/BaseAttributeTests.cs
+++ b/tests/CommandLine.Tests/Unit/BaseAttributeTests.cs
@@ -11,8 +11,10 @@ namespace CommandLine.Tests.Unit
         [InlineData(1)]
         public static void Default(object defaultValue)
         {
-            TestBaseAttribute baseAttribute = new TestBaseAttribute();
-            baseAttribute.Default = defaultValue;
+            TestBaseAttribute baseAttribute = new TestBaseAttribute
+            {
+                Default = defaultValue
+            };
             Assert.Equal(defaultValue, baseAttribute.Default);
         }
 
@@ -20,30 +22,36 @@ namespace CommandLine.Tests.Unit
         [InlineData("", null, "")]
         [InlineData("", typeof(Fakes.StaticResource), "")]
         [InlineData("Help text", null, "Help text")]
-        [InlineData("HelpText", typeof(Fakes.StaticResource), "Localized HelpText")]
-        [InlineData("HelpText", typeof(Fakes.NonStaticResource), "Localized HelpText")]
+        [InlineData(nameof(Fakes.StaticResource.HelpText), typeof(Fakes.StaticResource), "Localized HelpText")]
+        [InlineData(nameof(Fakes.StaticResource.InternalText), typeof(Fakes.StaticResource), "Internal Text")]
+        [InlineData("PrivateText", typeof(Fakes.StaticResource), "Private Text")]
+        [InlineData(nameof(Fakes.NonStaticResource.HelpText), typeof(Fakes.NonStaticResource), "Localized HelpText")]
+        [InlineData(nameof(Fakes.InternalResource.Text), typeof(Fakes.InternalResource), "Localized Text")]
         public static void HelpText(string helpText, Type resourceType, string expected)
         {
-            TestBaseAttribute baseAttribute = new TestBaseAttribute();
-            baseAttribute.HelpText = helpText;
-            baseAttribute.ResourceType = resourceType;
-            
+            TestBaseAttribute baseAttribute = new TestBaseAttribute
+            {
+                HelpText = helpText,
+                ResourceType = resourceType
+            };
+
             Assert.Equal(expected, baseAttribute.HelpText);
         }
 
         [Theory]
-        [InlineData("HelpText", typeof(Fakes.NonStaticResource_WithNonStaticProperty))]
-        [InlineData("WriteOnlyText", typeof(Fakes.NonStaticResource))]
-        [InlineData("PrivateOnlyText", typeof(Fakes.NonStaticResource))]
-        [InlineData("HelpText", typeof(Fakes.InternalResource))]
+        [InlineData("NonExistantProperty", typeof(Fakes.StaticResource))]
+        [InlineData(nameof(Fakes.NonStaticResource.InstanceText), typeof(Fakes.NonStaticResource))]
+        [InlineData(nameof(Fakes.NonStaticResource.WriteOnlyText), typeof(Fakes.NonStaticResource))]
         public void ThrowsHelpText(string helpText, Type resourceType)
         {
-            TestBaseAttribute baseAttribute = new TestBaseAttribute();
-            baseAttribute.HelpText = helpText;
-            baseAttribute.ResourceType = resourceType;
+            TestBaseAttribute baseAttribute = new TestBaseAttribute
+            {
+                HelpText = helpText,
+                ResourceType = resourceType
+            };
 
             // Verify exception
-            Assert.Throws<ArgumentException>(() => baseAttribute.HelpText.ToString());
+            Assert.Throws<ArgumentException>(() => baseAttribute.HelpText);
         }
 
 

--- a/tests/CommandLine.Tests/Unit/VerbAttributeTests.cs
+++ b/tests/CommandLine.Tests/Unit/VerbAttributeTests.cs
@@ -3,48 +3,43 @@ using Xunit;
 
 namespace CommandLine.Tests
 {
-	//Test localization of VerbAttribute
-  public  class VerbAttributeTests
+    //Test localization of VerbAttribute
+    public  class VerbAttributeTests
     {
         [Theory]
         [InlineData("", null, "")]
         [InlineData("", typeof(Fakes.StaticResource), "")]
         [InlineData("Help text", null, "Help text")]
-        [InlineData("HelpText", typeof(Fakes.StaticResource), "Localized HelpText")]
-        [InlineData("HelpText", typeof(Fakes.NonStaticResource), "Localized HelpText")]
+        [InlineData(nameof(Fakes.StaticResource.HelpText), typeof(Fakes.StaticResource), "Localized HelpText")]
+        [InlineData(nameof(Fakes.StaticResource.InternalText), typeof(Fakes.StaticResource), "Internal Text")]
+        [InlineData("PrivateText", typeof(Fakes.StaticResource), "Private Text")]
+        [InlineData(nameof(Fakes.NonStaticResource.HelpText), typeof(Fakes.NonStaticResource), "Localized HelpText")]
+        [InlineData(nameof(Fakes.InternalResource.Text), typeof(Fakes.InternalResource), "Localized Text")]
         public static void VerbHelpText(string helpText, Type resourceType, string expected)
         {
-            TestVerbAttribute verbAttribute = new TestVerbAttribute
+            VerbAttribute verbAttribute = new VerbAttribute("verb")
             {
-                HelpText = helpText, 
+                HelpText = helpText,
                 ResourceType = resourceType
             };
 
             Assert.Equal(expected, verbAttribute.HelpText);
         }
+
         [Theory]
-        [InlineData("HelpText", typeof(Fakes.NonStaticResource_WithNonStaticProperty))]
-        [InlineData("WriteOnlyText", typeof(Fakes.NonStaticResource))]
-        [InlineData("PrivateOnlyText", typeof(Fakes.NonStaticResource))]
-        [InlineData("HelpText", typeof(Fakes.InternalResource))]
+        [InlineData("NonExistantProperty", typeof(Fakes.StaticResource))]
+        [InlineData(nameof(Fakes.NonStaticResource.InstanceText), typeof(Fakes.NonStaticResource))]
+        [InlineData(nameof(Fakes.NonStaticResource.WriteOnlyText), typeof(Fakes.NonStaticResource))]
         public void ThrowsHelpText(string helpText, Type resourceType)
         {
-            TestVerbAttribute verbAttribute = new TestVerbAttribute
+            VerbAttribute verbAttribute = new VerbAttribute("verb")
             {
-                HelpText = helpText, 
+                HelpText = helpText,
                 ResourceType = resourceType
             };
 
             // Verify exception
             Assert.Throws<ArgumentException>(() => verbAttribute.HelpText);
-        }
-
-        private class TestVerbAttribute : VerbAttribute
-        {
-            public TestVerbAttribute() : base("verb")
-            {
-                // Do nothing
-            }
         }
     }
 }


### PR DESCRIPTION
Fixes #477.