### PR TITLE
Allow for Examples with just text or just sample

### DIFF
--- a/src/CommandLine/Text/Example.cs
+++ b/src/CommandLine/Text/Example.cs
@@ -23,9 +23,9 @@ namespace CommandLine.Text
         /// <param name="sample">A sample instance.</param>
         public Example(string helpText, IEnumerable<UnParserSettings> formatStyles, object sample)
         {
-            if (string.IsNullOrEmpty(helpText)) throw new ArgumentException("helpText can't be null or empty", "helpText");
             if (formatStyles == null) throw new ArgumentNullException("formatStyles");
-            if (sample == null) throw new ArgumentNullException("sample");
+            if (string.IsNullOrEmpty(helpText) && sample == null)
+                throw new ArgumentException("Either helpText or sample must be provided");
 
             this.helpText = helpText;
             this.formatStyles = formatStyles;

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -679,23 +679,31 @@ namespace CommandLine.Text
             foreach (var e in examples)
             {
                 var example = mapperFunc(e);
-                var exampleText = new StringBuilder(example.HelpText)
-                    .Append(':');
-                yield return exampleText.ToString();
-                var styles = example.GetFormatStylesOrDefault();
-                foreach (var s in styles)
+                if (!String.IsNullOrWhiteSpace(example.HelpText))
                 {
-                    var commandLine = new StringBuilder(OptionPrefixWidth.Spaces())
-                        .Append(appAlias)
-                        .Append(' ')
-                        .Append(Parser.Default.FormatCommandLine(example.Sample,
-                            config =>
-                            {
-                                config.PreferShortName = s.PreferShortName;
-                                config.GroupSwitches = s.GroupSwitches;
-                                config.UseEqualToken = s.UseEqualToken;
-                            }));
-                    yield return commandLine.ToString();
+                    var exampleText = new StringBuilder(example.HelpText);
+                    if (example.Sample != null)
+                        exampleText.Append(':');
+                    yield return exampleText.ToString();
+                }
+
+                if (example.Sample != null)
+                {
+                    var styles = example.GetFormatStylesOrDefault();
+                    foreach (var s in styles)
+                    {
+                        var commandLine = new StringBuilder(OptionPrefixWidth.Spaces())
+                            .Append(appAlias)
+                            .Append(' ')
+                            .Append(Parser.Default.FormatCommandLine(example.Sample,
+                                config =>
+                                {
+                                    config.PreferShortName = s.PreferShortName;
+                                    config.GroupSwitches = s.GroupSwitches;
+                                    config.UseEqualToken = s.UseEqualToken;
+                                }));
+                        yield return commandLine.ToString();
+                    }
                 }
             }
         }

--- a/tests/CommandLine.Tests/Fakes/Help_Fakes.cs
+++ b/tests/CommandLine.Tests/Fakes/Help_Fakes.cs
@@ -93,6 +93,20 @@ namespace CommandLine.Tests.Fakes
         }
     }
 
+    class Options_With_Partial_Usage
+    {
+        [Option('o', "Operation", HelpText = "Operation to carry out.")]
+        public string Operation { get; set; }
+
+        [Usage(ApplicationAlias = "foobar")]
+        public static IEnumerable<Example> Examples => new[]
+        {
+            new Example("Complete example", new Options_With_Partial_Usage() { Operation = "add" }),
+            new Example("Text with no example", null),
+            new Example(null, new Options_With_Partial_Usage() { Operation = "delete" })
+        };
+    }
+
     [Verb("secert", Hidden = true, HelpText = "This is a secert hidden verb that should never be visible to the user via help text.")]
     public class Secert_Verb
     {

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -467,6 +467,26 @@ namespace CommandLine.Tests.Unit.Text
         }
 
         [Fact]
+        public static void RenderUsageText_with_partial_options_returns_properly_formatted_text()
+        {
+            // Fixture setup
+            ParserResult<Options_With_Partial_Usage> result =
+                new NotParsed<Options_With_Partial_Usage>(
+                    TypeInfo.Create(typeof(Options_With_Partial_Usage)), Enumerable.Empty<Error>());
+
+            // Exercize system
+            var text = HelpText.RenderUsageText(result);
+
+            // Verify outcome
+            var lines = text.ToNotEmptyLines();
+
+            lines[0].Should().BeEquivalentTo("Complete example:");
+            lines[1].Should().BeEquivalentTo("  foobar --operation add");
+            lines[2].Should().BeEquivalentTo("Text with no example");
+            lines[3].Should().BeEquivalentTo("  foobar --operation delete");            
+        }
+
+        [Fact]
         public void Invoke_AutoBuild_for_Options_with_Usage_returns_appropriate_formatted_text()
         {
             // Fixture setup


### PR DESCRIPTION
I've had occasions where I want to output usage lines that have either text or a sample, but not both. This PR modified the `Example` constructors so that at least one of `helpText` and `sample` is required, rather than both.

This means that both of these are legitimate:
```csharp
new Example("Some text", null);
new Example(null, new Options() { Foo = "bar" });
```
An `Example` with text only will render the text without the trailing colon.