### PR TITLE
Improve spacing in HelpText

### DIFF
--- a/src/CommandLine/Infrastructure/StringBuilderExtensions.cs
+++ b/src/CommandLine/Infrastructure/StringBuilderExtensions.cs
@@ -113,5 +113,23 @@ namespace CommandLine.Infrastructure
             }
             return c;
         }
+
+        public static bool SafeStartsWith(this StringBuilder builder, string s)
+        {
+            if (string.IsNullOrEmpty(s))
+                return false;
+
+            return builder?.Length >= s.Length
+                && builder.ToString(0, s.Length) == s;
+        }
+
+        public static bool SafeEndsWith(this StringBuilder builder, string s)
+        {
+            if (string.IsNullOrEmpty(s))
+                return false;
+
+            return builder?.Length >= s.Length
+                && builder.ToString(builder.Length - s.Length, s.Length) == s;
+        }
     }
 }

--- a/src/CommandLine/Infrastructure/StringBuilderExtensions.cs
+++ b/src/CommandLine/Infrastructure/StringBuilderExtensions.cs
@@ -114,6 +114,14 @@ namespace CommandLine.Infrastructure
             return c;
         }
 
+        /// <summary>
+        /// Indicates whether the string value of a <see cref="System.Text.StringBuilder"/>
+        /// starts with the input <see cref="System.String"/> parameter. Returns false if either 
+        /// the StringBuilder or input string is null or empty.
+        /// </summary>
+        /// <param name="builder">The <see cref="System.Text.StringBuilder"/> to test.</param>
+        /// <param name="s">The <see cref="System.String"/> to look for.</param>
+        /// <returns></returns>
         public static bool SafeStartsWith(this StringBuilder builder, string s)
         {
             if (string.IsNullOrEmpty(s))
@@ -123,6 +131,14 @@ namespace CommandLine.Infrastructure
                 && builder.ToString(0, s.Length) == s;
         }
 
+        /// <summary>
+        /// Indicates whether the string value of a <see cref="System.Text.StringBuilder"/>
+        /// ends with the input <see cref="System.String"/> parameter. Returns false if either 
+        /// the StringBuilder or input string is null or empty.
+        /// </summary>
+        /// <param name="builder">The <see cref="System.Text.StringBuilder"/> to test.</param>
+        /// <param name="s">The <see cref="System.String"/> to look for.</param>
+        /// <returns></returns>
         public static bool SafeEndsWith(this StringBuilder builder, string s)
         {
             if (string.IsNullOrEmpty(s))

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -727,22 +727,28 @@ namespace CommandLine.Text
             var result = new StringBuilder(sbLength);
 
             result.Append(heading)
-                    .AppendWhen(!string.IsNullOrEmpty(copyright), Environment.NewLine, copyright)
-                    .AppendWhen(
-                        preOptionsHelp.SafeLength() > 0,
-                        Environment.NewLine,
+                    .AppendWhen(!string.IsNullOrEmpty(copyright), 
+                        Environment.NewLine, 
+                        copyright)
+                    .AppendWhen(preOptionsHelp.SafeLength() > 0,
                         NewLineIfNeededBefore(preOptionsHelp),
+                        Environment.NewLine,
                         preOptionsHelp.ToString())
-                    .AppendWhen(
-                        optionsHelp.SafeLength() > 0,
+                    .AppendWhen(optionsHelp.SafeLength() > 0,
                         Environment.NewLine,
                         Environment.NewLine,
                         optionsHelp.SafeToString())
-                    .AppendWhen(postOptionsHelp.SafeLength() > 0, Environment.NewLine, postOptionsHelp.ToString());
+                    .AppendWhen(postOptionsHelp.SafeLength() > 0, 
+                        NewLineIfNeededBefore(postOptionsHelp),
+                        Environment.NewLine,
+                        postOptionsHelp.ToString());
 
             string NewLineIfNeededBefore(StringBuilder sb)
             {
-                if (AddNewLineBetweenHelpSections && result.Length > 0 && !sb.SafeStartsWith(Environment.NewLine))
+                if (AddNewLineBetweenHelpSections 
+                        && result.Length > 0 
+                        && !result.SafeEndsWith(Environment.NewLine)
+                        && !sb.SafeStartsWith(Environment.NewLine))
                     return Environment.NewLine;
                 else
                     return null;

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -352,7 +352,7 @@ namespace CommandLine.Text
             {
                 var heading = auto.SentenceBuilder.UsageHeadingText();
                 if (heading.Length > 0)
-                    auto.AddPreOptionsLine(heading);
+                    auto.AddPreOptionsLine(string.Concat(Environment.NewLine, heading));
             }
 
             usageAttr.Do(
@@ -707,12 +707,20 @@ namespace CommandLine.Text
         public override string ToString()
         {
             const int ExtraLength = 10;
+
+            string ExtraLineIfNeeded = (heading.SafeLength() > 0 && copyright.SafeLength() > 0
+                        && preOptionsHelp.Length >= Environment.NewLine.Length
+                        && preOptionsHelp.ToString(0, Environment.NewLine.Length) != Environment.NewLine)
+                ? Environment.NewLine
+                : null;
+            
             return
                 new StringBuilder(
                     heading.SafeLength() + copyright.SafeLength() + preOptionsHelp.SafeLength() +
-                        optionsHelp.SafeLength() + ExtraLength).Append(heading)
+                        optionsHelp.SafeLength() + ExtraLength)
+                    .Append(heading)
                     .AppendWhen(!string.IsNullOrEmpty(copyright), Environment.NewLine, copyright)
-                    .AppendWhen(preOptionsHelp.Length > 0, Environment.NewLine, preOptionsHelp.ToString())
+                    .AppendWhen(preOptionsHelp.Length > 0, ExtraLineIfNeeded, Environment.NewLine, preOptionsHelp.ToString())
                     .AppendWhen(
                         optionsHelp != null && optionsHelp.Length > 0,
                         Environment.NewLine,

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -109,6 +109,7 @@ namespace CommandLine.Text
         private bool addEnumValuesToHelpText;
         private bool autoHelp;
         private bool autoVersion;
+        private bool addNewLineBetweenHelpSections;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandLine.Text.HelpText"/> class.
@@ -259,6 +260,15 @@ namespace CommandLine.Text
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to add newlines between help sections.
+        /// </summary>
+        public bool AddNewLineBetweenHelpSections
+        {
+            get {  return addNewLineBetweenHelpSections; }
+            set { addNewLineBetweenHelpSections = value; }
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to add the values of an enum after the description of the specification.
         /// </summary>
         public bool AddEnumValuesToHelpText
@@ -352,7 +362,11 @@ namespace CommandLine.Text
             {
                 var heading = auto.SentenceBuilder.UsageHeadingText();
                 if (heading.Length > 0)
-                    auto.AddPreOptionsLine(string.Concat(Environment.NewLine, heading));
+                {
+                    if (auto.AddNewLineBetweenHelpSections)
+                        heading = Environment.NewLine + heading;
+                    auto.AddPreOptionsLine(heading);
+                }
             }
 
             usageAttr.Do(
@@ -708,7 +722,8 @@ namespace CommandLine.Text
         {
             const int ExtraLength = 10;
 
-            string ExtraLineIfNeeded = (heading.SafeLength() > 0 && copyright.SafeLength() > 0
+            string ExtraLineIfNeeded = AddNewLineBetweenHelpSections
+                        && (heading.SafeLength() > 0 && copyright.SafeLength() > 0
                         && preOptionsHelp.Length >= Environment.NewLine.Length
                         && preOptionsHelp.ToString(0, Environment.NewLine.Length) != Environment.NewLine)
                 ? Environment.NewLine

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -722,27 +722,33 @@ namespace CommandLine.Text
         {
             const int ExtraLength = 10;
 
-            string ExtraLineIfNeeded = AddNewLineBetweenHelpSections
-                        && (heading.SafeLength() > 0 && copyright.SafeLength() > 0
-                        && preOptionsHelp.Length >= Environment.NewLine.Length
-                        && preOptionsHelp.ToString(0, Environment.NewLine.Length) != Environment.NewLine)
-                ? Environment.NewLine
-                : null;
-            
-            return
-                new StringBuilder(
-                    heading.SafeLength() + copyright.SafeLength() + preOptionsHelp.SafeLength() +
-                        optionsHelp.SafeLength() + ExtraLength)
-                    .Append(heading)
+            var sbLength = heading.SafeLength() + copyright.SafeLength() + preOptionsHelp.SafeLength()
+                    + optionsHelp.SafeLength() + postOptionsHelp.SafeLength() + ExtraLength;
+            var result = new StringBuilder(sbLength);
+
+            result.Append(heading)
                     .AppendWhen(!string.IsNullOrEmpty(copyright), Environment.NewLine, copyright)
-                    .AppendWhen(preOptionsHelp.Length > 0, ExtraLineIfNeeded, Environment.NewLine, preOptionsHelp.ToString())
                     .AppendWhen(
-                        optionsHelp != null && optionsHelp.Length > 0,
+                        preOptionsHelp.SafeLength() > 0,
+                        Environment.NewLine,
+                        NewLineIfNeededBefore(preOptionsHelp),
+                        preOptionsHelp.ToString())
+                    .AppendWhen(
+                        optionsHelp.SafeLength() > 0,
                         Environment.NewLine,
                         Environment.NewLine,
                         optionsHelp.SafeToString())
-                    .AppendWhen(postOptionsHelp.Length > 0, Environment.NewLine, postOptionsHelp.ToString())
-                .ToString();
+                    .AppendWhen(postOptionsHelp.SafeLength() > 0, Environment.NewLine, postOptionsHelp.ToString());
+
+            string NewLineIfNeededBefore(StringBuilder sb)
+            {
+                if (AddNewLineBetweenHelpSections && result.Length > 0 && !sb.SafeStartsWith(Environment.NewLine))
+                    return Environment.NewLine;
+                else
+                    return null;
+            }
+
+            return result.ToString();
         }
 
         internal static void AddLine(StringBuilder builder, string value, int maximumLength)

--- a/tests/CommandLine.Tests/Unit/StringBuilderExtensionsTests.cs
+++ b/tests/CommandLine.Tests/Unit/StringBuilderExtensionsTests.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using FluentAssertions;
+using CommandLine.Infrastructure;
+
+namespace CommandLine.Tests.Unit
+{
+    public class StringBuilderExtensionsTests
+    {
+        private static StringBuilder _sb = new StringBuilder("test string");
+        private static StringBuilder _emptySb = new StringBuilder();
+        private static StringBuilder _nullSb = null;
+
+        public static IEnumerable<object[]> GoodStartsWithData => new []
+        {
+            new object[] { "t" },
+            new object[] { "te" },
+            new object[] { "test " },
+            new object[] { "test string" }
+        };
+
+        public static IEnumerable<object[]> BadTestData => new []
+        {
+            new object[] { null },
+            new object[] { "" },
+            new object[] { "xyz" },
+            new object[] { "some long test string" }
+        };
+
+        public static IEnumerable<object[]> GoodEndsWithData => new[]
+        {
+            new object[] { "g" },
+            new object[] { "ng" },
+            new object[] { " string" },
+            new object[] { "test string" }
+        };
+
+        
+
+        [Theory]
+        [MemberData(nameof(GoodStartsWithData))]
+        [MemberData(nameof(BadTestData))]
+        public void StartsWith_null_builder_returns_false(string input)
+        {
+            _nullSb.SafeStartsWith(input).Should().BeFalse();
+        }
+
+        [Theory]
+        [MemberData(nameof(GoodStartsWithData))]
+        [MemberData(nameof(BadTestData))]
+        public void StartsWith_empty_builder_returns_false(string input)
+        {
+            _emptySb.SafeStartsWith(input).Should().BeFalse();
+        }
+
+        [Theory]
+        [MemberData(nameof(GoodStartsWithData))]
+        public void StartsWith_good_data_returns_true(string input)
+        {
+            _sb.SafeStartsWith(input).Should().BeTrue();
+        }
+
+        [Theory]
+        [MemberData(nameof(BadTestData))]
+        public void StartsWith_bad_data_returns_false(string input)
+        {
+            _sb.SafeStartsWith(input).Should().BeFalse();
+        }
+
+        [Theory]
+        [MemberData(nameof(GoodEndsWithData))]
+        [MemberData(nameof(BadTestData))]
+        public void EndsWith_null_builder_returns_false(string input)
+        {
+            _nullSb.SafeEndsWith(input).Should().BeFalse();
+        }
+
+        [Theory]
+        [MemberData(nameof(GoodEndsWithData))]
+        [MemberData(nameof(BadTestData))]
+        public void EndsWith_empty_builder_returns_false(string input)
+        {
+            _emptySb.SafeEndsWith(input).Should().BeFalse();
+        }
+
+        [Theory]
+        [MemberData(nameof(GoodEndsWithData))]
+        public void EndsWith_good_data_returns_true(string input)
+        {
+            _sb.SafeEndsWith(input).Should().BeTrue();
+        }
+
+        [Theory]
+        [MemberData(nameof(BadTestData))]
+        public void EndsWith_bad_data_returns_false(string input)
+        {
+            _sb.SafeEndsWith(input).Should().BeFalse();
+        }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -44,7 +44,7 @@ namespace CommandLine.Tests.Unit.Text
                     .AddPostOptionsLine("post-options line 2");
 
             // Verify outcome
-            var expected = new[]
+            var expected = new List<string>()
             {
                 "Unit-tests 2.0",
                 "Copyright (C) 2005 - 2013 Author",
@@ -54,38 +54,47 @@ namespace CommandLine.Tests.Unit.Text
                 "post-options line 2"
             };
 
-            var takeCount = newlineBetweenSections ? expected.Length + 1 : expected.Length;
-            var lines = sut.ToString().ToLines().Take(takeCount).ToArray();
-
-            lines.Should().ContainInOrder(expected);
-
             if (newlineBetweenSections)
-                lines[2].Should().BeEmpty();
+            {
+                expected.Insert(2, "");
+                expected.Insert(5, "");
+            }
+
+            var lines = sut.ToString().ToLines();
+            lines.Should().StartWith(expected);
         }
 
-        [Fact]
-        public void Create_instance_with_options()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Create_instance_with_options(bool newlineBetweenSections)
         {
             // Fixture setup
             // Exercize system 
-            var sut = new HelpText { AddDashesToOption = true }
+            var sut = new HelpText { AddDashesToOption = true, AddNewLineBetweenHelpSections = newlineBetweenSections }
                 .AddPreOptionsLine("pre-options")
                 .AddOptions(new NotParsed<Simple_Options>(TypeInfo.Create(typeof(Simple_Options)), Enumerable.Empty<Error>()))
                 .AddPostOptionsLine("post-options");
 
             // Verify outcome
+            var expected = new []
+            {
+                "",
+                "pre-options",
+                "",
+                "--stringvalue         Define a string value here.",
+                "-s, --shortandlong    Example with both short and long name.",
+                "-i                    Define a int sequence here.",
+                "-x                    Define a boolean or switch value here.",
+                "--help                Display this help screen.",
+                "--version             Display version information.",
+                "value pos. 0          Define a long value here.",
+                "",
+                "post-options"
+            };
 
-            var lines = sut.ToString().ToNotEmptyLines().TrimStringArray();
-            lines[0].Should().BeEquivalentTo("pre-options");
-            lines[1].Should().BeEquivalentTo("--stringvalue         Define a string value here.");
-            lines[2].Should().BeEquivalentTo("-s, --shortandlong    Example with both short and long name.");
-            lines[3].Should().BeEquivalentTo("-i                    Define a int sequence here.");
-            lines[4].Should().BeEquivalentTo("-x                    Define a boolean or switch value here.");
-            lines[5].Should().BeEquivalentTo("--help                Display this help screen.");
-            lines[6].Should().BeEquivalentTo("--version             Display version information.");
-            lines[7].Should().BeEquivalentTo("value pos. 0          Define a long value here.");
-            lines[8].Should().BeEquivalentTo("post-options");
-            // Teardown
+            var lines = sut.ToString().ToLines().TrimStringArray();
+            lines.Should().StartWith(expected);
         }
 
         [Fact]
@@ -514,7 +523,7 @@ namespace CommandLine.Tests.Unit.Text
             );
 
             // Verify outcome
-            var expected = new[]
+            var expected = new List<string>()
             {
                 HeadingInfo.Default.ToString(),
                 CopyrightInfo.Default.ToString(),
@@ -552,18 +561,14 @@ namespace CommandLine.Tests.Unit.Text
                 "",
                 "value pos. 0    Value."
             };
-            var takeCount = newlineBetweenSections ? expected.Length + 1 : expected.Length;
-
-            var text = helpText.ToString();
-            var lines = text.ToLines().TrimStringArray().Take(takeCount).ToArray();
-            
-            lines.Should().ContainInOrder(expected);
 
             if (newlineBetweenSections)
-                lines[5].Should().BeEmpty();
+                expected.Insert(5, "");
 
-
-            // Teardown
+            var text = helpText.ToString();
+            var lines = text.ToLines().TrimStringArray();
+            
+            lines.Should().StartWith(expected);
         }
 
         [Theory]
@@ -593,7 +598,7 @@ namespace CommandLine.Tests.Unit.Text
             );
 
             // Verify outcome
-            var expected = new[]
+            var expected = new List<string>()
             {
                 HeadingInfo.Default.ToString(),
                 CopyrightInfo.Default.ToString(),
@@ -607,15 +612,13 @@ namespace CommandLine.Tests.Unit.Text
                 "--input-file"
             };
 
-            var takeCount = newlineBetweenSections || startWithNewline ? expected.Length + 1 : expected.Length;
+            if (newlineBetweenSections || startWithNewline)
+                expected.Insert(2, "");
 
             var text = helpText.ToString();
-            var lines = text.ToLines().TrimStringArray().Take(takeCount).ToArray();
+            var lines = text.ToLines().TrimStringArray();
 
-            lines.Should().ContainInOrder(expected);
-
-            if (newlineBetweenSections || startWithNewline)
-                lines[2].Should().BeEmpty();
+            lines.Should().StartWith(expected);
         }
 
         [Fact]

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -41,14 +41,15 @@ namespace CommandLine.Tests.Unit.Text
                     .AddPostOptionsLine("post-options line 2");
 
             // Verify outcome
-            var lines = sut.ToString().ToNotEmptyLines();
+            var lines = sut.ToString().ToLines();
 
             lines[0].Should().BeEquivalentTo("Unit-tests 2.0");
             lines[1].Should().BeEquivalentTo("Copyright (C) 2005 - 2013 Author");
-            lines[2].Should().BeEquivalentTo("pre-options line 1");
-            lines[3].Should().BeEquivalentTo("pre-options line 2");
-            lines[4].Should().BeEquivalentTo("post-options line 1");
-            lines[5].Should().BeEquivalentTo("post-options line 2");
+            lines[2].Should().BeEmpty();
+            lines[3].Should().BeEquivalentTo("pre-options line 1");
+            lines[4].Should().BeEquivalentTo("pre-options line 2");
+            lines[5].Should().BeEquivalentTo("post-options line 1");
+            lines[6].Should().BeEquivalentTo("post-options line 2");
             // Teardown
         }
 
@@ -320,17 +321,23 @@ namespace CommandLine.Tests.Unit.Text
             var helpText = HelpText.AutoBuild(fakeResult);
 
             // Verify outcome
-            var lines = helpText.ToString().ToNotEmptyLines().TrimStringArray();
+            var lines = helpText.ToString().ToLines().TrimStringArray();
             lines[0].Should().Be(HeadingInfo.Default.ToString());
-            lines[1].Should().Be(CopyrightInfo.Default.ToString());			
-            lines[2].Should().BeEquivalentTo("ERROR(S):");
-            lines[3].Should().BeEquivalentTo("Token 'badtoken' is not recognized.");
-            lines[4].Should().BeEquivalentTo("A sequence option 'i' is defined with fewer or more items than required.");
-            lines[5].Should().BeEquivalentTo("--stringvalue         Define a string value here.");
-            lines[6].Should().BeEquivalentTo("-s, --shortandlong    Example with both short and long name.");
-            lines[7].Should().BeEquivalentTo("-i                    Define a int sequence here.");
-            lines[8].Should().BeEquivalentTo("-x                    Define a boolean or switch value here.");
-            lines[9].Should().BeEquivalentTo("--help                Display this help screen.");
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
+            lines[2].Should().BeEmpty();
+            lines[3].Should().BeEquivalentTo("ERROR(S):");
+            lines[4].Should().BeEquivalentTo("Token 'badtoken' is not recognized.");
+            lines[5].Should().BeEquivalentTo("A sequence option 'i' is defined with fewer or more items than required.");
+            lines[6].Should().BeEmpty();
+            lines[7].Should().BeEquivalentTo("--stringvalue         Define a string value here.");
+            lines[8].Should().BeEmpty();
+            lines[9].Should().BeEquivalentTo("-s, --shortandlong    Example with both short and long name.");
+            lines[10].Should().BeEmpty();
+            lines[11].Should().BeEquivalentTo("-i                    Define a int sequence here.");
+            lines[12].Should().BeEmpty();
+            lines[13].Should().BeEquivalentTo("-x                    Define a boolean or switch value here.");
+            lines[14].Should().BeEmpty();
+            lines[15].Should().BeEquivalentTo("--help                Display this help screen.");
             // Teardown
         }
 
@@ -349,15 +356,19 @@ namespace CommandLine.Tests.Unit.Text
             var helpText = HelpText.AutoBuild(fakeResult);
 
             // Verify outcome
-            var lines = helpText.ToString().ToNotEmptyLines().TrimStringArray();
+            var lines = helpText.ToString().ToLines().TrimStringArray();
 
             lines[0].Should().Be(HeadingInfo.Default.ToString());
-            lines[1].Should().Be(CopyrightInfo.Default.ToString());	
-            lines[2].Should().BeEquivalentTo("-p, --patch      Use the interactive patch selection interface to chose which");
-            lines[3].Should().BeEquivalentTo("changes to commit.");
-            lines[4].Should().BeEquivalentTo("--amend          Used to amend the tip of the current branch.");
-            lines[5].Should().BeEquivalentTo("-m, --message    Use the given message as the commit message.");
-            lines[6].Should().BeEquivalentTo("--help           Display this help screen.");
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
+            lines[2].Should().BeEmpty();
+            lines[3].Should().BeEquivalentTo("-p, --patch      Use the interactive patch selection interface to chose which");
+            lines[4].Should().BeEquivalentTo("changes to commit.");
+            lines[5].Should().BeEmpty();
+            lines[6].Should().BeEquivalentTo("--amend          Used to amend the tip of the current branch.");
+            lines[7].Should().BeEmpty();
+            lines[8].Should().BeEquivalentTo("-m, --message    Use the given message as the commit message.");
+            lines[9].Should().BeEmpty();
+            lines[10].Should().BeEquivalentTo("--help           Display this help screen.");
             // Teardown
         }
 
@@ -418,23 +429,26 @@ namespace CommandLine.Tests.Unit.Text
         {
             // Fixture setup
             // Exercize system 
-            var sut = new HelpText { AddDashesToOption = true }
+            var sut = new HelpText { AddDashesToOption = true, AdditionalNewLineAfterOption = false }
                 .AddPreOptionsLine("pre-options")
                 .AddOptions(new NotParsed<Options_With_HelpText_And_MetaValue>(TypeInfo.Create(typeof(Options_With_HelpText_And_MetaValue)), Enumerable.Empty<Error>()))
                 .AddPostOptionsLine("post-options");
 
             // Verify outcome
 
-            var lines = sut.ToString().ToNotEmptyLines().TrimStringArray();
-            lines[0].Should().BeEquivalentTo("pre-options");
-            lines[1].Should().BeEquivalentTo("--stringvalue=STR            Define a string value here.");
-            lines[2].Should().BeEquivalentTo("-i INTSEQ                    Define a int sequence here.");
-            lines[3].Should().BeEquivalentTo("-x                           Define a boolean or switch value here.");
-            lines[4].Should().BeEquivalentTo("--help                       Display this help screen.");
-            lines[5].Should().BeEquivalentTo("--version                    Display version information.");
-            lines[6].Should().BeEquivalentTo("number (pos. 0) NUM          Define a long value here.");
-            lines[7].Should().BeEquivalentTo("paintcolor (pos. 1) COLOR    Define a color value here.");
-            lines[8].Should().BeEquivalentTo("post-options", lines[8]);
+            var lines = sut.ToString().ToLines().TrimStringArray();
+            lines[0].Should().BeEmpty();
+            lines[1].Should().BeEquivalentTo("pre-options");
+            lines[2].Should().BeEmpty();
+            lines[3].Should().BeEquivalentTo("--stringvalue=STR            Define a string value here.");
+            lines[4].Should().BeEquivalentTo("-i INTSEQ                    Define a int sequence here.");
+            lines[5].Should().BeEquivalentTo("-x                           Define a boolean or switch value here.");
+            lines[6].Should().BeEquivalentTo("--help                       Display this help screen.");
+            lines[7].Should().BeEquivalentTo("--version                    Display version information.");
+            lines[8].Should().BeEquivalentTo("number (pos. 0) NUM          Define a long value here.");
+            lines[9].Should().BeEquivalentTo("paintcolor (pos. 1) COLOR    Define a color value here.");
+            lines[10].Should().BeEmpty();
+            lines[11].Should().BeEquivalentTo("post-options", lines[11]);
             // Teardown
         }
 
@@ -482,34 +496,84 @@ namespace CommandLine.Tests.Unit.Text
 
             // Verify outcome
             var text = helpText.ToString();
-            var lines = text.ToNotEmptyLines().TrimStringArray();
+            var lines = text.ToLines().TrimStringArray();
             lines[0].Should().Be(HeadingInfo.Default.ToString());
-            lines[1].Should().Be(CopyrightInfo.Default.ToString());	
-            lines[2].Should().BeEquivalentTo("ERROR(S):");
-            lines[3].Should().BeEquivalentTo("Token 'badtoken' is not recognized.");
-            lines[4].Should().BeEquivalentTo("USAGE:");
-            lines[5].Should().BeEquivalentTo("Normal scenario:");
-            lines[6].Should().BeEquivalentTo("mono testapp.exe --input file.bin --output out.bin");
-            lines[7].Should().BeEquivalentTo("Logging warnings:");
-            lines[8].Should().BeEquivalentTo("mono testapp.exe -w --input file.bin");
-            lines[9].Should().BeEquivalentTo("Logging errors:");
-            lines[10].Should().BeEquivalentTo("mono testapp.exe -e --input file.bin");
-            lines[11].Should().BeEquivalentTo("mono testapp.exe --errs --input=file.bin");
-            lines[12].Should().BeEquivalentTo("List:");
-            lines[13].Should().BeEquivalentTo("mono testapp.exe -l 1,2");
-            lines[14].Should().BeEquivalentTo("Value:");
-            lines[15].Should().BeEquivalentTo("mono testapp.exe value");
-            lines[16].Should().BeEquivalentTo("-i, --input     Set input file.");
-            lines[17].Should().BeEquivalentTo("-i, --output    Set output file.");
-            lines[18].Should().BeEquivalentTo("--verbose       Set verbosity level.");
-            lines[19].Should().BeEquivalentTo("-w, --warns     Log warnings.");
-            lines[20].Should().BeEquivalentTo("-e, --errs      Log errors.");
-            lines[21].Should().BeEquivalentTo("-l              List.");
-            lines[22].Should().BeEquivalentTo("--help          Display this help screen.");
-            lines[23].Should().BeEquivalentTo("--version       Display version information.");
-            lines[24].Should().BeEquivalentTo("value pos. 0    Value.");
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
+            lines[2].Should().BeEmpty();
+            lines[3].Should().BeEquivalentTo("ERROR(S):");
+            lines[4].Should().BeEquivalentTo("Token 'badtoken' is not recognized.");
+            lines[5].Should().BeEmpty();
+            lines[6].Should().BeEquivalentTo("USAGE:");
+            lines[7].Should().BeEquivalentTo("Normal scenario:");
+            lines[8].Should().BeEquivalentTo("mono testapp.exe --input file.bin --output out.bin");
+            lines[9].Should().BeEquivalentTo("Logging warnings:");
+            lines[10].Should().BeEquivalentTo("mono testapp.exe -w --input file.bin");
+            lines[11].Should().BeEquivalentTo("Logging errors:");
+            lines[12].Should().BeEquivalentTo("mono testapp.exe -e --input file.bin");
+            lines[13].Should().BeEquivalentTo("mono testapp.exe --errs --input=file.bin");
+            lines[14].Should().BeEquivalentTo("List:");
+            lines[15].Should().BeEquivalentTo("mono testapp.exe -l 1,2");
+            lines[16].Should().BeEquivalentTo("Value:");
+            lines[17].Should().BeEquivalentTo("mono testapp.exe value");
+            lines[18].Should().BeEmpty();
+            lines[19].Should().BeEquivalentTo("-i, --input     Set input file.");
+            lines[20].Should().BeEmpty();
+            lines[21].Should().BeEquivalentTo("-i, --output    Set output file.");
+            lines[22].Should().BeEmpty();
+            lines[23].Should().BeEquivalentTo("--verbose       Set verbosity level.");
+            lines[24].Should().BeEmpty();
+            lines[25].Should().BeEquivalentTo("-w, --warns     Log warnings.");
+            lines[26].Should().BeEmpty();
+            lines[27].Should().BeEquivalentTo("-e, --errs      Log errors.");
+            lines[28].Should().BeEmpty();
+            lines[29].Should().BeEquivalentTo("-l              List.");
+            lines[30].Should().BeEmpty();
+            lines[31].Should().BeEquivalentTo("--help          Display this help screen.");
+            lines[32].Should().BeEmpty();
+            lines[33].Should().BeEquivalentTo("--version       Display version information.");
+            lines[34].Should().BeEmpty();
+            lines[35].Should().BeEquivalentTo("value pos. 0    Value.");
 
             // Teardown
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AutoBuild_with_errors_and_preoptions_renders_correctly(bool startWithNewline)
+        {
+            // Fixture setup
+            var fakeResult = new NotParsed<Simple_Options_Without_HelpText>(
+                TypeInfo.Create(typeof(Simple_Options_Without_HelpText)),
+                new Error[]
+                    {
+                        new BadFormatTokenError("badtoken")
+                    });
+
+            // Exercize system
+            var helpText = HelpText.AutoBuild(fakeResult,
+                h =>
+                {
+                    h.AddPreOptionsLine((startWithNewline ? Environment.NewLine : null) + "pre-options");
+                    return HelpText.DefaultParsingErrorsHandler(fakeResult, h);
+                },
+                e => e
+            );
+
+            // Verify outcome
+            var text = helpText.ToString();
+            var lines = text.ToLines().TrimStringArray();
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
+            lines[2].Should().BeEmpty();
+            lines[3].Should().BeEquivalentTo("pre-options");
+            lines[4].Should().BeEmpty();
+            lines[5].Should().BeEquivalentTo("ERROR(S):");
+            lines[6].Should().BeEquivalentTo("Token 'badtoken' is not recognized.");
+            lines[7].Should().BeEmpty();
+            lines[8].Should().BeEquivalentTo("-v, --verbose");
+            lines[9].Should().BeEmpty();
+            lines[10].Should().BeEquivalentTo("--input-file");
         }
 
         [Fact]


### PR DESCRIPTION
Resolves #491 

The goal was to make vertical spacing consistent between sections. In `HelpText.ToString()`, things got slightly complicated because it occurred to me that some users might already be starting PreOptions with their own newline, so I didn't want to add another.

I added a test and also changed some existing tests to look at spacing (using `ToLines()` instead of `ToNotEmptyLines()`).

Some example help screens, showing before and after, are in the following comment.

**Edit:** (If it's intentional/desirable for PreOptions to start right after the copyright, with no space, then I can amend this PR to take that bit out. But I still think there should be a space before Usage.)