### PR TITLE
Fix Warning the 'PackageIconUrl'/'iconUrl' element is deprecated.

### DIFF
--- a/src/CommandLine/CommandLine.csproj
+++ b/src/CommandLine/CommandLine.csproj
@@ -20,8 +20,8 @@
     <Description Condition="'$(BuildTarget)' == 'fsharp'">Terse syntax C# command line parser for .NET with F# support. The Command Line Parser Library offers to CLR applications a clean and concise API for manipulating command line arguments and related tasks.</Description>
     <Copyright>Copyright (c) 2005 - 2018 Giacomo Stelluti Scala &amp; Contributors</Copyright>
 	<PackageLicenseFile>License.md</PackageLicenseFile>
+	<PackageIcon>CommandLine20.png</PackageIcon>
     <PackageProjectUrl>https://github.com/commandlineparser/commandline</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/commandlineparser/commandline/master/art/CommandLine20.png</PackageIconUrl>
     <PackageTags>command line;commandline;argument;option;parser;parsing;library;syntax;shell</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>7.3</LangVersion>
@@ -46,5 +46,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="$(SolutionDir)LICENSE.md" Pack="true" PackagePath=""/>
+    <None Include="$(SolutionDir)art\CommandLine20.png" Pack="true" PackagePath=""/>
   </ItemGroup>
 </Project>

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -304,7 +304,6 @@ namespace CommandLine.Text
         /// <param name='onExample'>A delegate used to customize <see cref="CommandLine.Text.Example"/> model used to render text block of usage examples.</param>
         /// <param name="verbsIndex">If true the output style is consistent with verb commands (no dashes), otherwise it outputs options.</param>
         /// <param name="maxDisplayWidth">The maximum width of the display.</param>
-        /// <param name="comparison">a comparison lambda to order options in help text</param>
         /// <remarks>The parameter <paramref name="verbsIndex"/> is not ontly a metter of formatting, it controls whether to handle verbs or options.</remarks>
         public static HelpText AutoBuild<T>(
             ParserResult<T> parserResult,


### PR DESCRIPTION

Fix Compiler Warning: NU5048	The 'PackageIconUrl'/'iconUrl' element is deprecated. Consider using the 'PackageIcon'/'icon' element instead
