### PR TITLE
Fix #496 - Cryptic error message with immutable option class

### DIFF
--- a/tests/CommandLine.Tests/Fakes/Immutable_Simple_Options.cs
+++ b/tests/CommandLine.Tests/Fakes/Immutable_Simple_Options.cs
@@ -31,4 +31,32 @@ namespace CommandLine.Tests.Fakes
         [Value(0)]
         public long LongValue { get { return longValue; } }
     }
+   
+    public class Immutable_Simple_Options_Invalid_Ctor_Args
+    {
+        private readonly string stringValue;
+        private readonly IEnumerable<int> intSequence;
+        private readonly bool boolValue;
+        private readonly long longValue;
+
+        public Immutable_Simple_Options_Invalid_Ctor_Args(string stringValue1, IEnumerable<int> intSequence2, bool boolValue, long longValue)
+        {
+            this.stringValue = stringValue;
+            this.intSequence = intSequence;
+            this.boolValue = boolValue;
+            this.longValue = longValue;
+        }
+
+        [Option(HelpText = "Define a string value here.")]
+        public string StringValue { get { return stringValue; } }
+
+        [Option('i', Min = 3, Max = 4, HelpText = "Define a int sequence here.")]
+        public IEnumerable<int> IntSequence { get { return intSequence; } }
+
+        [Option('x', HelpText = "Define a boolean or switch value here.")]
+        public bool BoolValue { get { return boolValue; } }
+
+        [Value(0)]
+        public long LongValue { get { return longValue; } }
+    }
 }

--- a/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
@@ -901,6 +901,22 @@ namespace CommandLine.Tests.Unit.Core
             expected.Should().BeEquivalentTo(((Parsed<Immutable_Simple_Options>)result).Value);
         }
 
+        [Theory]
+        [MemberData(nameof(ImmutableInstanceData))]
+        public void Parse_to_immutable_instance_with_Invalid_Ctor_Args(string[] arguments, Immutable_Simple_Options _)
+        {
+            // Fixture setup in attributes
+
+            // Exercize system 
+            Action act = () => InvokeBuildImmutable<Immutable_Simple_Options_Invalid_Ctor_Args>(
+                arguments);
+
+            // Verify outcome
+            var expectedMsg =
+                "Type CommandLine.Tests.Fakes.Immutable_Simple_Options_Invalid_Ctor_Args appears to be Immutable with invalid constructor. Check that constructor arguments have the same name and order of their underlying Type.  Constructor Parameters can be ordered as: '(stringvalue, intsequence, boolvalue, longvalue)'";
+            act.Should().Throw<InvalidOperationException>().WithMessage(expectedMsg);
+        }
+
         [Fact]
         public void Parse_to_type_with_single_string_ctor_builds_up_correct_instance()
         {


### PR DESCRIPTION
Fix #496
The message is becoming informative as:
> Type CommandLineOptions appears to be Immutable with invalid constructor. Check that constructor arguments have the same name and order of their underlying Type.  Constructor Parameters can be ordered as: '(indexfile, outputfile)'

