### PR TITLE
Fix issue of using custom struct having a constructor with string parameter.

### DIFF
--- a/src/CommandLine/Core/ReflectionExtensions.cs
+++ b/src/CommandLine/Core/ReflectionExtensions.cs
@@ -209,5 +209,13 @@ namespace CommandLine.Core
                    }.Contains(type)
                 || Convert.GetTypeCode(type) != TypeCode.Object;
         }
+
+        public static bool IsCustomStruct(this Type type)
+        {
+            var isStruct = type.GetTypeInfo().IsValueType && !type.GetTypeInfo().IsPrimitive && !type.GetTypeInfo().IsEnum &&  type != typeof(Guid);
+            if (!isStruct) return false;
+            var ctor = type.GetTypeInfo().GetConstructor(new[] { typeof(string) });
+            return ctor != null;
+        }
     }
 }

--- a/src/CommandLine/Core/TypeConverter.cs
+++ b/src/CommandLine/Core/TypeConverter.cs
@@ -111,6 +111,7 @@ namespace CommandLine.Core
                 }
             };
 
+            if (conversionType.IsCustomStruct()) return Result.Try(makeType);
             return Result.Try(
                 conversionType.IsPrimitiveEx() || ReflectionHelper.IsFSharpOptionType(conversionType)
                     ? changeType

--- a/tests/CommandLine.Tests/Fakes/Custom_Struct.cs
+++ b/tests/CommandLine.Tests/Fakes/Custom_Struct.cs
@@ -1,0 +1,56 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System;
+
+namespace CommandLine.Tests.Fakes
+{
+    public class CustomStructOptions
+    {
+        [Option('c', "custom", HelpText = "Custom Type")]
+        public CustomStruct Custom { get; set; }
+    }
+
+    public struct CustomStruct
+    {
+        public string Input { get; set; }
+        public string Server { get; set; }
+        public int Port { get; set; }
+        public CustomStruct(string url)
+        {
+            Input = url;
+            Server = "";
+            Port = 80;
+            var data = url.Split(':');
+            if (data.Length == 2)
+            {
+                Server = data[0];
+                Port = Convert.ToInt32(data[1]);
+            }
+        }
+    }
+
+    public class CustomClassOptions
+    {
+        [Option('c', "custom", HelpText = "Custom Type")]
+        public CustomClass Custom { get; set; }
+    }
+
+    public class CustomClass
+    {
+        public string Input { get; set; }
+        public string Server { get; set; }
+        public int Port { get; set; }
+        public CustomClass(string url)
+        {
+            Input = url;
+            Server = "";
+            Port = 80;
+            var data = url.Split(':');
+            if (data.Length == 2)
+            {
+                Server = data[0];
+                Port = Convert.ToInt32(data[1]);
+            }
+        }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
@@ -1221,6 +1221,42 @@ namespace CommandLine.Tests.Unit.Core
             errors.Should().BeEquivalentTo(expectedResult);
         }
 
+        #region custom types 
+       
+
+        [Theory]
+        [InlineData(new[] { "-c", "localhost:8080" }, "localhost", 8080)]
+        public void Parse_custom_struct_type(string[] arguments, string expectedServer, int expectedPort)
+        {
+            //Arrange
+
+            // Act
+            var result = InvokeBuild<CustomStructOptions>(arguments);
+
+            // Assert
+            var customValue = ((Parsed<CustomStructOptions>)result).Value.Custom;
+            customValue.Server.Should().Be(expectedServer);
+            customValue.Port.Should().Be(expectedPort);
+            customValue.Input.Should().Be(arguments[1]);
+        }
+
+        [Theory]
+        [InlineData(new[] { "-c", "localhost:8080" }, "localhost", 8080)]
+        public void Parse_custom_class_type(string[] arguments, string expectedServer, int expectedPort)
+        {
+            //Arrange
+
+            // Act
+            var result = InvokeBuild<CustomClassOptions>(arguments);
+
+            // Assert
+            var customValue = ((Parsed<CustomClassOptions>)result).Value.Custom;
+            customValue.Server.Should().Be(expectedServer);
+            customValue.Port.Should().Be(expectedPort);
+            customValue.Input.Should().Be(arguments[1]);
+        }
+
+        #endregion
         private class ValueWithNoSetterOptions
         {
             [Value(0, MetaName = "Test", Default = 0)]


### PR DESCRIPTION
Fix issue #339 for using custom struct having a constructor with string parameter.
