### PR TITLE
Fix issue #409 to avoid IOException break  in Debug mode in WPF app.

### DIFF
--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -36,18 +36,29 @@ namespace CommandLine
             autoHelp = true;
             autoVersion = true;
             parsingCulture = CultureInfo.InvariantCulture;
+            maximumDisplayWidth = GetWindowWidth();
+        }
+
+        private int GetWindowWidth()
+        {
+
+#if !NET40
+            if (Console.IsOutputRedirected) return DefaultMaximumLength;
+#endif
+            var width = 1;
             try
             {
-                maximumDisplayWidth = Console.WindowWidth;
-                if (maximumDisplayWidth < 1)
+                width = Console.WindowWidth;
+                if (width < 1)
                 {
-                    maximumDisplayWidth = DefaultMaximumLength;
+                    width = DefaultMaximumLength;
                 }
-            }
-            catch (IOException)
+            }           
+            catch (Exception e) when (e is IOException || e is PlatformNotSupportedException || e is ArgumentOutOfRangeException)
             {
-                maximumDisplayWidth = DefaultMaximumLength;
+               width = DefaultMaximumLength;
             }
+            return width;
         }
 
         /// <summary>

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -892,5 +892,17 @@ namespace CommandLine.Tests.Unit
                     Assert.True(args.TestValue);
                 });
         }
+        //Fix Issue #409 for WPF
+        [Fact]
+        public void When_HelpWriter_is_null_it_should_not_fire_exception()
+        {
+            // Arrange
+            
+            //Act
+            var sut = new Parser(config => config.HelpWriter = null);
+            sut.ParseArguments<Simple_Options>(new[] {"--dummy"});
+            //Assert
+            sut.Settings.MaximumDisplayWidth.Should().Be(80);
+        }
     }
 }


### PR DESCRIPTION
Fix #409 IOException break in Debug when ParserSettings loaded in WPF App
and also Exception `PlatformNotSupportedException` in MONO
