### PR TITLE
Remove constraint on T for ParseArguments with factory

### DIFF
--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -39,7 +39,7 @@ namespace CommandLine.Core
 
             Func<T> makeDefault = () =>
                 typeof(T).IsMutable()
-                    ? factory.MapValueOrDefault(f => f(), Activator.CreateInstance<T>())
+                    ? factory.MapValueOrDefault(f => f(), () => Activator.CreateInstance<T>())
                     : ReflectionHelper.CreateDefaultImmutableInstance<T>(
                         (from p in specProps select p.Specification.ConversionType).ToArray());
 
@@ -128,7 +128,7 @@ namespace CommandLine.Core
 
         private static T BuildMutable<T>(Maybe<Func<T>> factory, IEnumerable<SpecificationProperty> specPropsWithValue, List<Error> setPropertyErrors )
         {
-            var mutable = factory.MapValueOrDefault(f => f(), Activator.CreateInstance<T>());
+            var mutable = factory.MapValueOrDefault(f => f(), () => Activator.CreateInstance<T>());
 
             setPropertyErrors.AddRange(
                 mutable.SetProperties(

--- a/src/CommandLine/Core/ReflectionExtensions.cs
+++ b/src/CommandLine/Core/ReflectionExtensions.cs
@@ -133,10 +133,21 @@ namespace CommandLine.Core
             if(type == typeof(object))
                 return true;
 
-            var props = type.GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.Instance).Any(p => p.CanWrite);
-            var fields = type.GetTypeInfo().GetFields(BindingFlags.Public | BindingFlags.Instance).Any();
+            // Find all inherited defined properties and fields on the type
+            var inheritedTypes = type.GetTypeInfo().FlattenHierarchy().Select(i => i.GetTypeInfo());
 
-            return props || fields;
+            foreach (var inheritedType in inheritedTypes) 
+            {
+                if (
+                    inheritedType.GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.Instance).Any(p => p.CanWrite) ||
+                    inheritedType.GetTypeInfo().GetFields(BindingFlags.Public | BindingFlags.Instance).Any()
+                    )
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public static object CreateDefaultForImmutable(this Type type)

--- a/src/CommandLine/Infrastructure/CSharpx/Maybe.cs
+++ b/src/CommandLine/Infrastructure/CSharpx/Maybe.cs
@@ -372,6 +372,14 @@ namespace CSharpx
         }
 
         /// <summary>
+        /// If contains a values executes a mapping function over it, otherwise returns the value from <paramref name="noneValueFactory"/>.
+        /// </summary>
+        public static T2 MapValueOrDefault<T1, T2>(this Maybe<T1> maybe, Func<T1, T2> func, Func<T2> noneValueFactory) {
+            T1 value1;
+            return maybe.MatchJust(out value1) ? func(value1) : noneValueFactory();
+        }
+
+        /// <summary>
         /// Returns an empty list when given <see cref="CSharpx.Nothing{T}"/> or a singleton list when given a <see cref="CSharpx.Just{T}"/>.
         /// </summary>
         public static IEnumerable<T> ToEnumerable<T>(this Maybe<T> maybe)

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -116,7 +116,6 @@ namespace CommandLine
         /// and a sequence of <see cref="CommandLine.Error"/>.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown if one or more arguments are null.</exception>
         public ParserResult<T> ParseArguments<T>(Func<T> factory, IEnumerable<string> args)
-            where T : new()
         {
             if (factory == null) throw new ArgumentNullException("factory");
             if (!typeof(T).IsMutable()) throw new ArgumentException("factory");

--- a/tests/CommandLine.Tests/Fakes/Mutable_Without_Empty_Constructor.cs
+++ b/tests/CommandLine.Tests/Fakes/Mutable_Without_Empty_Constructor.cs
@@ -1,0 +1,19 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+namespace CommandLine.Tests.Fakes 
+{
+    class Mutable_Without_Empty_Constructor 
+    {
+        [Option("amend", HelpText = "Used to amend the tip of the current branch.")]
+        public bool Amend { get; set; }
+
+        private Mutable_Without_Empty_Constructor() 
+        {
+        }
+
+        public static Mutable_Without_Empty_Constructor Create() 
+        {
+            return new Mutable_Without_Empty_Constructor();
+        }
+    }
+}

--- a/tests/CommandLine.Tests/Fakes/Options_With_Only_Explicit_Interface.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_Only_Explicit_Interface.cs
@@ -1,0 +1,9 @@
+﻿namespace CommandLine.Tests.Fakes
+{
+    class Options_With_Only_Explicit_Interface : IInterface_With_Two_Scalar_Options
+    {
+        bool IInterface_With_Two_Scalar_Options.Verbose { get; set; }
+
+        string IInterface_With_Two_Scalar_Options.InputFile { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
@@ -790,6 +790,20 @@ namespace CommandLine.Tests.Unit.Core
         [Theory]
         [InlineData(new[] { "--inputfile=file1.bin" }, "file1.bin")]
         [InlineData(new[] { "--inputfile", "file2.txt" }, "file2.txt")]
+        public void Can_define_options_on_explicit_interface_properties(string[] arguments, string expected) 
+            {
+            // Exercize system
+            var result = InvokeBuild<Options_With_Only_Explicit_Interface>(
+                arguments);
+
+            // Verify outcome
+            expected.Should().BeEquivalentTo(((IInterface_With_Two_Scalar_Options)((Parsed<Options_With_Only_Explicit_Interface>)result).Value).InputFile);
+        }
+
+
+        [Theory]
+        [InlineData(new[] { "--inputfile=file1.bin" }, "file1.bin")]
+        [InlineData(new[] { "--inputfile", "file2.txt" }, "file2.txt")]
         public void Can_define_options_on_interface_properties(string[] arguments, string expected)
         {
             // Exercize system

--- a/tests/CommandLine.Tests/Unit/Issue591ests.cs
+++ b/tests/CommandLine.Tests/Unit/Issue591ests.cs
@@ -1,0 +1,29 @@
+﻿using System.Linq;
+using CommandLine.Tests.Fakes;
+using CommandLine.Text;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+//Issue #591
+//When options class is only having explicit interface declarations, it should be detected as mutable.
+
+namespace CommandLine.Tests.Unit
+{
+    public class Issue591ests
+    {
+        [Fact]
+        public void Parse_option_with_only_explicit_interface_implementation()
+        {
+            string actual = string.Empty;
+
+            var arguments = new[] { "--inputfile", "file2.txt" };
+            var result = Parser.Default.ParseArguments<Options_With_Only_Explicit_Interface>(arguments);
+            result.WithParsed(options => {
+                actual = ((IInterface_With_Two_Scalar_Options)options).InputFile;
+            });
+
+            actual.Should().Be("file2.txt");
+        }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/Issue70Tests.cs
+++ b/tests/CommandLine.Tests/Unit/Issue70Tests.cs
@@ -1,0 +1,29 @@
+﻿using System.Linq;
+using CommandLine.Tests.Fakes;
+using CommandLine.Text;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+//Issue #70
+//When the factory overload is used for ParseArguments, there should be no constraint not having an empty constructor.
+
+namespace CommandLine.Tests.Unit
+{
+    public class Issue70Tests
+    {
+        [Fact]
+        public void Create_instance_with_factory_method_should_not_fail()
+        {
+            bool actual = false;
+
+            var arguments = new[] { "--amend" };
+            var result = Parser.Default.ParseArguments(() => Mutable_Without_Empty_Constructor.Create(), arguments);
+            result.WithParsed(options => {
+                actual = options.Amend;
+            });
+
+            actual.Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
Fix for https://github.com/commandlineparser/commandline/issues/70 and https://github.com/commandlineparser/commandline/issues/591

This makes it possible to have mutable types without empty constructor that only does explicit implementation of interfaces, like this (the IsMutable() check would fail previously in this particular case):
```
public interface IFoo {
    [Option("foobar")]
    string FooBar { get; set; }
}
public interface IBar {
    [Option("barfoo")]
    string BarFoo { get; set; }
}

public class FooBarOptions : IFoo, IBar {
    public FooBarOptions(string nonEmptyConstructor) { }
    IBar.BarFoo { get; set; }
    IFoo.FooBar { get; set; }
}

var result = Parser.Default.ParseArguments<FooBarOptions>(() => new FooBarOptions("foo"), args)
```
