### PR TITLE
Add multi-instance option support

### DIFF
--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -24,6 +24,31 @@ namespace CommandLine.Core
             bool autoVersion,
             IEnumerable<ErrorType> nonFatalErrors)
         {
+            return Build(
+                factory,
+                tokenizer,
+                arguments,
+                nameComparer,
+                ignoreValueCase,
+                parsingCulture,
+                autoHelp,
+                autoVersion,
+                false,
+                nonFatalErrors);
+        }
+
+        public static ParserResult<T> Build<T>(
+            Maybe<Func<T>> factory,
+            Func<IEnumerable<string>, IEnumerable<OptionSpecification>, Result<IEnumerable<Token>, Error>> tokenizer,
+            IEnumerable<string> arguments,
+            StringComparer nameComparer,
+            bool ignoreValueCase,
+            CultureInfo parsingCulture,
+            bool autoHelp,
+            bool autoVersion,
+            bool allowMultiInstance,
+            IEnumerable<ErrorType> nonFatalErrors)
+        {
             var typeInfo = factory.MapValueOrDefault(f => f().GetType(), typeof(T));
 
             var specProps = typeInfo.GetSpecifications(pi => SpecificationProperty.Create(
@@ -70,7 +95,7 @@ namespace CommandLine.Core
                 var valueSpecPropsResult =
                     ValueMapper.MapValues(
                         (from pt in specProps where pt.Specification.IsValue() orderby ((ValueSpecification)pt.Specification).Index select pt),
-                        valuesPartition,    
+                        valuesPartition,
                         (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, parsingCulture, ignoreValueCase));
 
                 var missingValueErrors = from token in errorsPartition
@@ -86,7 +111,7 @@ namespace CommandLine.Core
 
                 //build the instance, determining if the type is mutable or not.
                 T instance;
-                if(typeInfo.IsMutable() == true)
+                if (typeInfo.IsMutable() == true)
                 {
                     instance = BuildMutable(factory, specPropsWithValue, setPropertyErrors);
                 }
@@ -95,7 +120,7 @@ namespace CommandLine.Core
                     instance = BuildImmutable(typeInfo, factory, specProps, specPropsWithValue, setPropertyErrors);
                 }
 
-                var validationErrors = specPropsWithValue.Validate(SpecificationPropertyRules.Lookup(tokens));
+                var validationErrors = specPropsWithValue.Validate(SpecificationPropertyRules.Lookup(tokens, allowMultiInstance));
 
                 var allErrors =
                     tokenizerResult.SuccessMessages()

--- a/src/CommandLine/Core/InstanceChooser.cs
+++ b/src/CommandLine/Core/InstanceChooser.cs
@@ -23,6 +23,31 @@ namespace CommandLine.Core
             bool autoVersion,
             IEnumerable<ErrorType> nonFatalErrors)
         {
+            return Choose(
+                tokenizer,
+                types,
+                arguments,
+                nameComparer,
+                ignoreValueCase,
+                parsingCulture,
+                autoHelp,
+                autoVersion,
+                false,
+                nonFatalErrors);
+        }
+
+        public static ParserResult<object> Choose(
+            Func<IEnumerable<string>, IEnumerable<OptionSpecification>, Result<IEnumerable<Token>, Error>> tokenizer,
+            IEnumerable<Type> types,
+            IEnumerable<string> arguments,
+            StringComparer nameComparer,
+            bool ignoreValueCase,
+            CultureInfo parsingCulture,
+            bool autoHelp,
+            bool autoVersion,
+            bool allowMultiInstance,
+            IEnumerable<ErrorType> nonFatalErrors)
+        {
             var verbs = Verb.SelectFromTypes(types);
             var defaultVerbs = verbs.Where(t => t.Item1.IsDefault);
             
@@ -46,7 +71,7 @@ namespace CommandLine.Core
                             arguments.Skip(1).FirstOrDefault() ?? string.Empty, nameComparer))
                     : (autoVersion && preprocCompare("version"))
                         ? MakeNotParsed(types, new VersionRequestedError())
-                        : MatchVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoVersion, nonFatalErrors);
+                        : MatchVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoVersion, allowMultiInstance, nonFatalErrors);
             };
 
             return arguments.Any()
@@ -92,6 +117,7 @@ namespace CommandLine.Core
             CultureInfo parsingCulture,
             bool autoHelp,
             bool autoVersion,
+            bool allowMultiInstance,
             IEnumerable<ErrorType> nonFatalErrors)
         {
             return verbs.Any(a => nameComparer.Equals(a.Item1.Name, arguments.First()))
@@ -106,6 +132,7 @@ namespace CommandLine.Core
                     parsingCulture,
                     autoHelp,
                     autoVersion,
+                    allowMultiInstance,
                     nonFatalErrors)
                 : MatchDefaultVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoVersion, nonFatalErrors);
         }

--- a/src/CommandLine/Core/Sequence.cs
+++ b/src/CommandLine/Core/Sequence.cs
@@ -14,30 +14,141 @@ namespace CommandLine.Core
             IEnumerable<Token> tokens,
             Func<string, Maybe<TypeDescriptor>> typeLookup)
         {
-            return from tseq in tokens.Pairwise(
-                (f, s) =>
-                        f.IsName() && s.IsValue()
-                            ? typeLookup(f.Text).MapValueOrDefault(info =>
-                                   info.TargetType == TargetType.Sequence
-                                        ? new[] { f }.Concat(tokens.OfSequence(f, info))
-                                        : new Token[] { }, new Token[] { })
-                            : new Token[] { })
-                   from t in tseq
-                   select t;
+            var sequences = new Dictionary<Token, IList<Token>>();
+            var state = SequenceState.TokenSearch;
+            Token nameToken = default;
+            foreach (var token in tokens)
+            {
+                switch (state)
+                {
+                    case SequenceState.TokenSearch:
+                        if (token.IsName())
+                        {
+                            if (typeLookup(token.Text).MatchJust(out var info) && info.TargetType == TargetType.Sequence)
+                            {
+                                nameToken = token;
+                                state = SequenceState.TokenFound;
+                            }
+                        }
+                        break;
+
+                    case SequenceState.TokenFound:
+                        if (token.IsValue())
+                        {
+                            if (sequences.TryGetValue(nameToken, out var sequence))
+                            {
+                                sequence.Add(token);
+                            }
+                            else
+                            {
+                                sequences[nameToken] = new List<Token>(new[] { token });
+                            }
+                        }
+                        else if (token.IsName())
+                        {
+                            if (typeLookup(token.Text).MatchJust(out var info) && info.TargetType == TargetType.Sequence)
+                            {
+                                nameToken = token;
+                                state = SequenceState.TokenFound;
+                            }
+                            else
+                            {
+                                state = SequenceState.TokenSearch;
+                            }
+                        }
+                        else
+                        {
+                            state = SequenceState.TokenSearch;
+                        }
+                        break;
+                }
+            }
+
+            foreach (var kvp in sequences)
+            {
+                yield return kvp.Key;
+                foreach (var value in kvp.Value)
+                {
+                    yield return value;
+                }
+            }
+
+                //return from tseq in tokens.Pairwise(
+                //(f, s) =>
+                //        f.IsName() && s.IsValue()
+                //            ? typeLookup(f.Text).MapValueOrDefault(info =>
+                //                   info.TargetType == TargetType.Sequence
+                //                        ? new[] { f }.Concat(tokens.OfSequence(f, info))
+                //                        : new Token[] { }, new Token[] { })
+                //            : new Token[] { })
+                //   from t in tseq
+                //   select t;
         }
 
-        private static IEnumerable<Token> OfSequence(this IEnumerable<Token> tokens, Token nameToken, TypeDescriptor info)
+        //private static IEnumerable<Token> OfSequence(this IEnumerable<Token> tokens, Token nameToken, TypeDescriptor info)
+        //{
+        //    var state = SequenceState.TokenSearch;
+        //    var count = 0;
+        //    var max = info.MaxItems.GetValueOrDefault(int.MaxValue);
+        //    var values = max != int.MaxValue
+        //        ? new List<Token>(max)
+        //        : new List<Token>();
+
+        //    foreach (var token in tokens)
+        //    {
+        //        if (count == max)
+        //        {
+        //            break;
+        //        }
+
+        //        switch (state)
+        //        {
+        //            case SequenceState.TokenSearch:
+        //                if (token.IsName() && token.Text.Equals(nameToken.Text))
+        //                {
+        //                    state = SequenceState.TokenFound;
+        //                }
+        //                break;
+
+        //            case SequenceState.TokenFound:
+        //                if (token.IsValue())
+        //                {
+        //                    state = SequenceState.ValueFound;
+        //                    count++;
+        //                    values.Add(token);
+        //                }
+        //                else
+        //                {
+        //                    // Invalid to provide option without value
+        //                    return Enumerable.Empty<Token>();
+        //                }
+        //                break;
+
+        //            case SequenceState.ValueFound:
+        //                if (token.IsValue())
+        //                {
+        //                    count++;
+        //                    values.Add(token);
+        //                }
+        //                else if (token.IsName() && token.Text.Equals(nameToken.Text))
+        //                {
+        //                    state = SequenceState.TokenFound;
+        //                }
+        //                else
+        //                {
+        //                    state = SequenceState.TokenSearch;
+        //                }
+        //                break;
+        //        }
+        //    }
+
+        //    return values;
+        //}
+
+        private enum SequenceState
         {
-            var nameIndex = tokens.IndexOf(t => t.Equals(nameToken));
-            if (nameIndex >= 0)
-            {
-                return info.NextValue.MapValueOrDefault(
-                    _ => info.MaxItems.MapValueOrDefault(
-                            n => tokens.Skip(nameIndex + 1).Take(n),
-                                 tokens.Skip(nameIndex + 1).TakeWhile(v => v.IsValue())),
-                    tokens.Skip(nameIndex + 1).TakeWhile(v => v.IsValue()));
-            }
-            return new Token[] { };
+            TokenSearch,
+            TokenFound,
         }
     }
 }

--- a/src/CommandLine/Core/SpecificationPropertyRules.cs
+++ b/src/CommandLine/Core/SpecificationPropertyRules.cs
@@ -14,6 +14,14 @@ namespace CommandLine.Core
             Lookup(
                 IEnumerable<Token> tokens)
         {
+            return Lookup(tokens, false);
+        }
+
+        public static IEnumerable<Func<IEnumerable<SpecificationProperty>, IEnumerable<Error>>>
+            Lookup(
+                IEnumerable<Token> tokens,
+                bool allowMultiInstance)
+        {
             return new List<Func<IEnumerable<SpecificationProperty>, IEnumerable<Error>>>
                 {
                     EnforceMutuallyExclusiveSet(),
@@ -21,7 +29,7 @@ namespace CommandLine.Core
                     EnforceMutuallyExclusiveSetAndGroupAreNotUsedTogether(),
                     EnforceRequired(),
                     EnforceRange(),
-                    EnforceSingle(tokens)
+                    EnforceSingle(tokens, allowMultiInstance)
                 };
         }
 
@@ -173,10 +181,15 @@ namespace CommandLine.Core
                 };
         }
 
-        private static Func<IEnumerable<SpecificationProperty>, IEnumerable<Error>> EnforceSingle(IEnumerable<Token> tokens)
+        private static Func<IEnumerable<SpecificationProperty>, IEnumerable<Error>> EnforceSingle(IEnumerable<Token> tokens, bool allowMultiInstance)
         {
             return specProps =>
                 {
+                    if (allowMultiInstance)
+                    {
+                        return Enumerable.Empty<Error>();
+                    }
+
                     var specs = from sp in specProps
                                 where sp.Specification.IsOption()
                                 where sp.Value.IsJust()

--- a/src/CommandLine/Core/TokenPartitioner.cs
+++ b/src/CommandLine/Core/TokenPartitioner.cs
@@ -21,10 +21,11 @@ namespace CommandLine.Core
             var switches = new HashSet<Token>(Switch.Partition(tokenList, typeLookup), tokenComparer);
             var scalars = new HashSet<Token>(Scalar.Partition(tokenList, typeLookup), tokenComparer);
             var sequences = new HashSet<Token>(Sequence.Partition(tokenList, typeLookup), tokenComparer);
+            var dedupedSequences = new HashSet<Token>(sequences);
             var nonOptions = tokenList
                 .Where(t => !switches.Contains(t))
                 .Where(t => !scalars.Contains(t))
-                .Where(t => !sequences.Contains(t)).Memoize();
+                .Where(t => !dedupedSequences.Contains(t)).Memoize();
             var values = nonOptions.Where(v => v.IsValue()).Memoize();
             var errors = nonOptions.Except(values, (IEqualityComparer<Token>)ReferenceEqualityComparer.Default).Memoize();
 

--- a/src/CommandLine/Core/TypeConverter.cs
+++ b/src/CommandLine/Core/TypeConverter.cs
@@ -16,7 +16,7 @@ namespace CommandLine.Core
         public static Maybe<object> ChangeType(IEnumerable<string> values, Type conversionType, bool scalar, CultureInfo conversionCulture, bool ignoreValueCase)
         {
             return scalar
-                ? ChangeTypeScalar(values.Single(), conversionType, conversionCulture, ignoreValueCase)
+                ? ChangeTypeScalar(values.Last(), conversionType, conversionCulture, ignoreValueCase)
                 : ChangeTypeSequence(values, conversionType, conversionCulture, ignoreValueCase);
         }
 

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -101,6 +101,7 @@ namespace CommandLine
                     settings.ParsingCulture,
                     settings.AutoHelp,
                     settings.AutoVersion,
+                    settings.AllowMultiInstance,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }
@@ -131,6 +132,7 @@ namespace CommandLine
                     settings.ParsingCulture,
                     settings.AutoHelp,
                     settings.AutoVersion,
+                    settings.AllowMultiInstance,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }
@@ -163,6 +165,7 @@ namespace CommandLine
                     settings.ParsingCulture,
                     settings.AutoHelp,
                     settings.AutoVersion,
+                    settings.AllowMultiInstance,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -25,6 +25,7 @@ namespace CommandLine
         private CultureInfo parsingCulture;
         private bool enableDashDash;
         private int maximumDisplayWidth;
+        private bool allowMultiInstance;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ParserSettings"/> class.
@@ -172,6 +173,15 @@ namespace CommandLine
         {
             get { return maximumDisplayWidth; }
             set { maximumDisplayWidth = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether options are allowed to be specified multiple times.
+        /// </summary>
+        public bool AllowMultiInstance
+        {
+            get => allowMultiInstance;
+            set => PopsicleSetter.Set(Consumed, ref allowMultiInstance, value);
         }
 
         internal StringComparer NameComparer

--- a/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
@@ -19,7 +19,7 @@ namespace CommandLine.Tests.Unit.Core
 {
     public class InstanceBuilderTests
     {
-        private static ParserResult<T> InvokeBuild<T>(string[] arguments, bool autoHelp = true, bool autoVersion = true)
+        private static ParserResult<T> InvokeBuild<T>(string[] arguments, bool autoHelp = true, bool autoVersion = true, bool multiInstance = false)
             where T : new()
         {
             return InstanceBuilder.Build(
@@ -31,6 +31,7 @@ namespace CommandLine.Tests.Unit.Core
                 CultureInfo.InvariantCulture,
                 autoHelp,
                 autoVersion,
+                multiInstance,
                 Enumerable.Empty<ErrorType>());
         }
 
@@ -1233,6 +1234,17 @@ namespace CommandLine.Tests.Unit.Core
             var errors = ((NotParsed<Simple_Options_With_OptionGroup_MutuallyExclusiveSet>)result).Errors;
 
             errors.Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Fact]
+        public void Parse_int_sequence_with_multi_instance()
+        {
+            var expected = new[] { 1, 2, 3 };
+            var result = InvokeBuild<Options_With_Sequence>(
+                new[] { "--int-seq", "1", "2", "--int-seq", "3" },
+                multiInstance: true);
+
+            ((Parsed<Options_With_Sequence>)result).Value.IntSequence.Should().BeEquivalentTo(expected);
         }
 
         #region custom types 

--- a/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
@@ -15,7 +15,8 @@ namespace CommandLine.Tests.Unit.Core
     {
         private static ParserResult<object> InvokeChoose(
             IEnumerable<Type> types,
-            IEnumerable<string> arguments)
+            IEnumerable<string> arguments,
+            bool multiInstance = false)
         {
             return InstanceChooser.Choose(
                 (args, optionSpecs) => Tokenizer.ConfigureTokenizer(StringComparer.Ordinal, false, false)(args, optionSpecs),
@@ -26,6 +27,7 @@ namespace CommandLine.Tests.Unit.Core
                 CultureInfo.InvariantCulture,
                 true,
                 true,
+                multiInstance,
                 Enumerable.Empty<ErrorType>());
         }
 
@@ -167,6 +169,19 @@ namespace CommandLine.Tests.Unit.Core
             Assert.IsType<SequenceOptions>(((Parsed<object>)result).Value);
             expected.Should().BeEquivalentTo(((Parsed<object>)result).Value);
             // Teardown
+        }
+
+        [Fact]
+        public void Parse_sequence_verb_with_multi_instance_returns_verb_instance()
+        {
+            var expected = new SequenceOptions { LongSequence = new long[] { }, StringSequence = new[] { "s1", "s2" } };
+            var result = InvokeChoose(
+                new[] { typeof(Add_Verb), typeof(Commit_Verb), typeof(Clone_Verb), typeof(SequenceOptions) },
+                new[] { "sequence", "-s", "s1", "-s", "s2" },
+                true);
+
+            Assert.IsType<SequenceOptions>(((Parsed<object>)result).Value);
+            expected.Should().BeEquivalentTo(((Parsed<object>)result).Value);
         }
     }
 }

--- a/tests/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
@@ -49,5 +49,67 @@ namespace CommandLine.Tests.Unit.Core
 
             // Teardown
         }
+
+        [Fact]
+        public void Map_with_multi_instance_scalar()
+        {
+            var tokenPartitions = new[]
+            {
+                new KeyValuePair<string, IEnumerable<string>>("s", new[] { "string1" }),
+                new KeyValuePair<string, IEnumerable<string>>("shortandlong", new[] { "string2" }),
+                new KeyValuePair<string, IEnumerable<string>>("shortandlong", new[] { "string3" }),
+                new KeyValuePair<string, IEnumerable<string>>("s", new[] { "string4" }),
+            };
+
+            var specProps = new[]
+            {
+                SpecificationProperty.Create(
+                    new OptionSpecification("s", "shortandlong", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(string), TargetType.Scalar, string.Empty),
+                    typeof(Simple_Options).GetProperties().Single(p => p.Name.Equals(nameof(Simple_Options.ShortAndLong), StringComparison.Ordinal)),
+                    Maybe.Nothing<object>()),
+            };
+
+            var result = OptionMapper.MapValues(
+                specProps.Where(pt => pt.Specification.IsOption()),
+                tokenPartitions,
+                (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, CultureInfo.InvariantCulture, false),
+                StringComparer.Ordinal);
+
+            var property = result.SucceededWith().Single();
+            Assert.True(property.Specification.IsOption());
+            Assert.True(property.Value.MatchJust(out var stringVal));
+            Assert.Equal(tokenPartitions.Last().Value.Last(), stringVal);
+        }
+
+        [Fact]
+        public void Map_with_multi_instance_sequence()
+        {
+            var tokenPartitions = new[]
+            {
+                new KeyValuePair<string, IEnumerable<string>>("i", new [] { "1", "2" }),
+                new KeyValuePair<string, IEnumerable<string>>("i", new [] { "3" }),
+                new KeyValuePair<string, IEnumerable<string>>("i", new [] { "4", "5" }),
+            };
+            var specProps = new[]
+            {
+                SpecificationProperty.Create(
+                    new OptionSpecification("i", string.Empty, false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<int>), TargetType.Sequence, string.Empty),
+                    typeof(Simple_Options).GetProperties().Single(p => p.Name.Equals(nameof(Simple_Options.IntSequence), StringComparison.Ordinal)),
+                    Maybe.Nothing<object>())
+            };
+
+            var result = OptionMapper.MapValues(
+                specProps.Where(pt => pt.Specification.IsOption()),
+                tokenPartitions,
+                (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, CultureInfo.InvariantCulture, false),
+                StringComparer.Ordinal);
+
+            var property = result.SucceededWith().Single();
+            Assert.True(property.Specification.IsOption());
+            Assert.True(property.Value.MatchJust(out var sequence));
+
+            var expected = tokenPartitions.Aggregate(Enumerable.Empty<int>(), (prev, part) => prev.Concat(part.Value.Select(i => int.Parse(i))));
+            Assert.Equal(expected, sequence);
+        }
     }
 }

--- a/tests/CommandLine.Tests/Unit/Core/SequenceTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/SequenceTests.cs
@@ -49,7 +49,7 @@ namespace CommandLine.Tests.Unit.Core
         }
 
         [Fact]
-        public void Partition_sequence_values_from_two_sequneces()
+        public void Partition_sequence_values_from_two_sequences()
         {
             var expected = new[]
                 {
@@ -92,6 +92,68 @@ namespace CommandLine.Tests.Unit.Core
                         : Maybe.Nothing<TypeDescriptor>());
 
             expected.Should().BeEquivalentTo(result);
+        }
+
+        [Fact]
+        public void Partition_sequence_multi_instance()
+        {
+            var expected = new[]
+            {
+                Token.Name("seq"),
+                Token.Value("seqval0"),
+                Token.Value("seqval1"),
+                Token.Value("seqval2"),
+                Token.Value("seqval3"),
+                Token.Value("seqval4"),
+            };
+
+            var result = Sequence.Partition(
+                new[]
+                {
+                    Token.Name("str"), Token.Value("strvalue"), Token.Value("freevalue"),
+                    Token.Name("seq"), Token.Value("seqval0"), Token.Value("seqval1"),
+                    Token.Name("x"), Token.Value("freevalue2"),
+                    Token.Name("seq"), Token.Value("seqval2"), Token.Value("seqval3"),
+                    Token.Name("seq"), Token.Value("seqval4")
+                },
+                name =>
+                    new[] { "seq" }.Contains(name)
+                        ? Maybe.Just(TypeDescriptor.Create(TargetType.Sequence, Maybe.Nothing<int>()))
+                        : Maybe.Nothing<TypeDescriptor>());
+
+            var actual = result.ToArray();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Partition_sequence_multi_instance_with_max()
+        {
+            var expected = new[]
+            {
+                Token.Name("seq"),
+                Token.Value("seqval0"),
+                Token.Value("seqval1"),
+                Token.Value("seqval2"),
+                Token.Value("seqval3"),
+                Token.Value("seqval4"),
+                Token.Value("seqval5"),
+            };
+
+            var result = Sequence.Partition(
+                new[]
+                {
+                    Token.Name("str"), Token.Value("strvalue"), Token.Value("freevalue"),
+                    Token.Name("seq"), Token.Value("seqval0"), Token.Value("seqval1"),
+                    Token.Name("x"), Token.Value("freevalue2"),
+                    Token.Name("seq"), Token.Value("seqval2"), Token.Value("seqval3"),
+                    Token.Name("seq"), Token.Value("seqval4"), Token.Value("seqval5"),
+                },
+                name =>
+                    new[] { "seq" }.Contains(name)
+                        ? Maybe.Just(TypeDescriptor.Create(TargetType.Sequence, Maybe.Just<int>(3)))
+                        : Maybe.Nothing<TypeDescriptor>());
+
+            Assert.Equal(expected, result);
         }
     }
 }

--- a/tests/CommandLine.Tests/Unit/Core/SpecificationPropertyRulesTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/SpecificationPropertyRulesTests.cs
@@ -1,0 +1,58 @@
+﻿using CommandLine.Core;
+using CommandLine.Tests.Fakes;
+using CSharpx;
+using System.Collections.Generic;
+using Xunit;
+
+namespace CommandLine.Tests.Unit.Core
+{
+
+    public class SpecificationPropertyRulesTests
+    {
+        [Fact]
+        public void Lookup_allows_multi_instance()
+        {
+            var tokens = new[]
+            {
+                Token.Name("name"),
+                Token.Value("value"),
+                Token.Name("name"),
+                Token.Value("value2"),
+            };
+
+            var specProps = new[]
+            {
+                SpecificationProperty.Create(
+                    new OptionSpecification(string.Empty, "name", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty),
+                    typeof(SequenceOptions).GetProperty(nameof(SequenceOptions.StringSequence)),
+                    Maybe.Just(new object())),
+            };
+
+            var results = specProps.Validate(SpecificationPropertyRules.Lookup(tokens, true));
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public void Lookup_fails_with_repeated_options_false_multi_instance()
+        {
+            var tokens = new[]
+            {
+                Token.Name("name"),
+                Token.Value("value"),
+                Token.Name("name"),
+                Token.Value("value2"),
+            };
+
+            var specProps = new[]
+            {
+                SpecificationProperty.Create(
+                    new OptionSpecification(string.Empty, "name", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty),
+                    typeof(SequenceOptions).GetProperty(nameof(SequenceOptions.StringSequence)),
+                    Maybe.Just(new object())),
+            };
+
+            var results = specProps.Validate(SpecificationPropertyRules.Lookup(tokens, false));
+            Assert.Contains(results, r => r.GetType() == typeof(RepeatedOptionError));
+        }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
@@ -33,6 +33,16 @@ namespace CommandLine.Tests.Unit.Core
             }
         }
 
+        [Fact]
+        public void ChangeType_Scalar_LastOneWins()
+        {
+            var values = new[] { "100", "200", "300", "400", "500" };
+            var result = TypeConverter.ChangeType(values, typeof(int), true, CultureInfo.InvariantCulture, true);
+            result.MatchJust(out var matchedValue).Should().BeTrue("should parse successfully");
+            Assert.Equal(500, matchedValue);
+
+        }
+
         public static IEnumerable<object[]> ChangeType_scalars_source
         {
             get


### PR DESCRIPTION
https://github.com/commandlineparser/commandline/issues/357 is a request for supporting multiple occurrences of the same parameter and collecting those into an enumerable, e.g. "myprog -i file1 -i file2 -i file3" would parse as having the `-i` parameter with three values, file1, file2 and file3. @tydunkel created an implementation of this feature, but never (AFAICT) created a PR for it. This PR is @tydunkel's code, rebased onto the current `develop` branch.

Note that when I run this, I get some spurious unit test failures and some real failures. The spurious failures I'm getting are caused by https://github.com/commandlineparser/commandline/issues/403, but the real failures I'm getting all have the same pattern: the "ERROR(S)" section of the output is repeated twice. E.g., [this test](https://github.com/commandlineparser/commandline/blob/017a8a21c79b223fbcd541187c7dd546c18ebdda/tests/CommandLine.Tests/Unit/ParserTests.cs#L523) expects the parser to output:

```plaintext
testhost 15.3.0
Copyright (C) 2020 author
ERROR(S):
No verb selected.
add        Add file contents to the index.
commit     Record changes to the repository.
clone      Clone a repository into a new directory.
help       Display more information on a specific command.
version    Display version information.
```

and instead it's outputting:

```plaintext
testhost 15.3.0
Copyright (C) 2020 author
ERROR(S):
No verb selected.
ERROR(S):
No verb selected.
add        Add file contents to the index.
commit     Record changes to the repository.
clone      Clone a repository into a new directory.
help       Display more information on a specific command.
version    Display version information.
```

I don't have time right now to track down why the error output is being duplicated. But all the unit test failures I could see look like they're the same thing, so once that single bug is located and fixed, the tests should all pass.

Hopefully this will be helpful to someone to be able to move forward with implementing #357 (and #522 which is a dupe of #357).