### PR TITLE
Fix #600 - better handling of --help and --version options

### DIFF
--- a/src/CommandLine/Core/ArgumentsExtensions.cs
+++ b/src/CommandLine/Core/ArgumentsExtensions.cs
@@ -10,9 +10,9 @@ namespace CommandLine.Core
     static class ArgumentsExtensions
     {
         public static IEnumerable<Error> Preprocess(
-            this IEnumerable<string> arguments,
+            this IEnumerable<Token> arguments,
             IEnumerable<
-                    Func<IEnumerable<string>, IEnumerable<Error>>
+                    Func<IEnumerable<Token>, IEnumerable<Error>>
                 > preprocessorLookup)
         {
             return preprocessorLookup.TryHead().MapValueOrDefault(

--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -32,7 +32,9 @@ namespace CommandLine.Core
                 ignoreValueCase,
                 parsingCulture,
                 autoHelp,
+                false,
                 autoVersion,
+                false,
                 false,
                 nonFatalErrors);
         }
@@ -45,7 +47,9 @@ namespace CommandLine.Core
             bool ignoreValueCase,
             CultureInfo parsingCulture,
             bool autoHelp,
+            bool autoHelpShortName,
             bool autoVersion,
+            bool autoVersionShortName,
             bool allowMultiInstance,
             IEnumerable<ErrorType> nonFatalErrors)
         {

--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -89,14 +89,14 @@ namespace CommandLine.Core
                     OptionMapper.MapValues(
                         (from pt in specProps where pt.Specification.IsOption() select pt),
                         optionsPartition,
-                        (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, parsingCulture, ignoreValueCase),
+                        (vals, type, isScalar, isFlag) => TypeConverter.ChangeType(vals, type, isScalar, isFlag, parsingCulture, ignoreValueCase),
                         nameComparer);
 
                 var valueSpecPropsResult =
                     ValueMapper.MapValues(
                         (from pt in specProps where pt.Specification.IsValue() orderby ((ValueSpecification)pt.Specification).Index select pt),
                         valuesPartition,
-                        (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, parsingCulture, ignoreValueCase));
+                        (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, false, parsingCulture, ignoreValueCase));
 
                 var missingValueErrors = from token in errorsPartition
                                          select

--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -24,6 +24,31 @@ namespace CommandLine.Core
             bool autoVersion,
             IEnumerable<ErrorType> nonFatalErrors)
         {
+            return Build(
+                factory,
+                tokenizer,
+                arguments,
+                nameComparer,
+                ignoreValueCase,
+                parsingCulture,
+                autoHelp,
+                autoVersion,
+                false,
+                nonFatalErrors);
+        }
+
+        public static ParserResult<T> Build<T>(
+            Maybe<Func<T>> factory,
+            Func<IEnumerable<string>, IEnumerable<OptionSpecification>, Result<IEnumerable<Token>, Error>> tokenizer,
+            IEnumerable<string> arguments,
+            StringComparer nameComparer,
+            bool ignoreValueCase,
+            CultureInfo parsingCulture,
+            bool autoHelp,
+            bool autoVersion,
+            bool allowMultiInstance,
+            IEnumerable<ErrorType> nonFatalErrors)
+        {
             var typeInfo = factory.MapValueOrDefault(f => f().GetType(), typeof(T));
 
             var specProps = typeInfo.GetSpecifications(pi => SpecificationProperty.Create(
@@ -70,7 +95,7 @@ namespace CommandLine.Core
                 var valueSpecPropsResult =
                     ValueMapper.MapValues(
                         (from pt in specProps where pt.Specification.IsValue() orderby ((ValueSpecification)pt.Specification).Index select pt),
-                        valuesPartition,    
+                        valuesPartition,
                         (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, parsingCulture, ignoreValueCase));
 
                 var missingValueErrors = from token in errorsPartition
@@ -86,7 +111,7 @@ namespace CommandLine.Core
 
                 //build the instance, determining if the type is mutable or not.
                 T instance;
-                if(typeInfo.IsMutable() == true)
+                if (typeInfo.IsMutable() == true)
                 {
                     instance = BuildMutable(factory, specPropsWithValue, setPropertyErrors);
                 }
@@ -95,7 +120,7 @@ namespace CommandLine.Core
                     instance = BuildImmutable(typeInfo, factory, specProps, specPropsWithValue, setPropertyErrors);
                 }
 
-                var validationErrors = specPropsWithValue.Validate(SpecificationPropertyRules.Lookup(tokens));
+                var validationErrors = specPropsWithValue.Validate(SpecificationPropertyRules.Lookup(tokens, allowMultiInstance));
 
                 var allErrors =
                     tokenizerResult.SuccessMessages()

--- a/src/CommandLine/Core/InstanceChooser.cs
+++ b/src/CommandLine/Core/InstanceChooser.cs
@@ -69,11 +69,11 @@ namespace CommandLine.Core
                         nameComparer.Equals(command, firstArg) ||
                         nameComparer.Equals(string.Concat("--", command), firstArg);
 
-                return (autoHelp && preprocCompare("help"))
+                return (autoHelp && preprocCompare("help")) || (autoHelp && autoHelpShortName && nameComparer.Equals("-h", firstArg))
                     ? MakeNotParsed(types,
                         MakeHelpVerbRequestedError(verbs,
                             arguments.Skip(1).FirstOrDefault() ?? string.Empty, nameComparer))
-                    : (autoVersion && preprocCompare("version"))
+                    : (autoVersion && preprocCompare("version")) || (autoVersion && autoVersionShortName && nameComparer.Equals("-V", firstArg))
                         ? MakeNotParsed(types, new VersionRequestedError())
                         : MatchVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoHelpShortName, autoVersion, autoVersionShortName, allowMultiInstance, nonFatalErrors);
             };

--- a/src/CommandLine/Core/InstanceChooser.cs
+++ b/src/CommandLine/Core/InstanceChooser.cs
@@ -31,7 +31,9 @@ namespace CommandLine.Core
                 ignoreValueCase,
                 parsingCulture,
                 autoHelp,
+                false,
                 autoVersion,
+                false,
                 false,
                 nonFatalErrors);
         }
@@ -44,7 +46,9 @@ namespace CommandLine.Core
             bool ignoreValueCase,
             CultureInfo parsingCulture,
             bool autoHelp,
+            bool autoHelpShortName,
             bool autoVersion,
+            bool autoVersionShortName,
             bool allowMultiInstance,
             IEnumerable<ErrorType> nonFatalErrors)
         {
@@ -71,13 +75,13 @@ namespace CommandLine.Core
                             arguments.Skip(1).FirstOrDefault() ?? string.Empty, nameComparer))
                     : (autoVersion && preprocCompare("version"))
                         ? MakeNotParsed(types, new VersionRequestedError())
-                        : MatchVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoVersion, allowMultiInstance, nonFatalErrors);
+                        : MatchVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoHelpShortName, autoVersion, autoVersionShortName, allowMultiInstance, nonFatalErrors);
             };
 
             return arguments.Any()
                 ? choose()
                 : (defaultVerbCount == 1
-                    ? MatchDefaultVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoVersion, nonFatalErrors)
+                    ? MatchDefaultVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoHelpShortName, autoVersion, autoVersionShortName, allowMultiInstance, nonFatalErrors)
                     : MakeNotParsed(types, new NoVerbSelectedError()));
         }
 
@@ -90,7 +94,10 @@ namespace CommandLine.Core
             bool ignoreValueCase,
             CultureInfo parsingCulture,
             bool autoHelp,
+            bool autoHelpShortName,
             bool autoVersion,
+            bool autoVersionShortName,
+            bool allowMultiInstance,
             IEnumerable<ErrorType> nonFatalErrors)
         {
             return !(defaultVerb is null)
@@ -102,7 +109,10 @@ namespace CommandLine.Core
                     ignoreValueCase,
                     parsingCulture,
                     autoHelp,
+                    autoHelpShortName,
                     autoVersion,
+                    autoVersionShortName,
+                    allowMultiInstance,
                     nonFatalErrors)
                 : MakeNotParsed(verbs.Select(v => v.Item2), new BadVerbSelectedError(arguments.First()));
         }
@@ -116,7 +126,9 @@ namespace CommandLine.Core
             bool ignoreValueCase,
             CultureInfo parsingCulture,
             bool autoHelp,
+            bool autoHelpShortName,
             bool autoVersion,
+            bool autoVersionShortName,
             bool allowMultiInstance,
             IEnumerable<ErrorType> nonFatalErrors)
         {
@@ -131,10 +143,12 @@ namespace CommandLine.Core
                     ignoreValueCase,
                     parsingCulture,
                     autoHelp,
+                    autoHelpShortName,
                     autoVersion,
+                    autoVersionShortName,
                     allowMultiInstance,
                     nonFatalErrors)
-                : MatchDefaultVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoVersion, nonFatalErrors);
+                : MatchDefaultVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoHelpShortName, autoVersion, autoVersionShortName, allowMultiInstance, nonFatalErrors);
         }
 
         private static HelpVerbRequestedError MakeHelpVerbRequestedError(

--- a/src/CommandLine/Core/InstanceChooser.cs
+++ b/src/CommandLine/Core/InstanceChooser.cs
@@ -23,6 +23,31 @@ namespace CommandLine.Core
             bool autoVersion,
             IEnumerable<ErrorType> nonFatalErrors)
         {
+            return Choose(
+                tokenizer,
+                types,
+                arguments,
+                nameComparer,
+                ignoreValueCase,
+                parsingCulture,
+                autoHelp,
+                autoVersion,
+                false,
+                nonFatalErrors);
+        }
+
+        public static ParserResult<object> Choose(
+            Func<IEnumerable<string>, IEnumerable<OptionSpecification>, Result<IEnumerable<Token>, Error>> tokenizer,
+            IEnumerable<Type> types,
+            IEnumerable<string> arguments,
+            StringComparer nameComparer,
+            bool ignoreValueCase,
+            CultureInfo parsingCulture,
+            bool autoHelp,
+            bool autoVersion,
+            bool allowMultiInstance,
+            IEnumerable<ErrorType> nonFatalErrors)
+        {
             var verbs = Verb.SelectFromTypes(types);
             var defaultVerbs = verbs.Where(t => t.Item1.IsDefault);
             
@@ -46,7 +71,7 @@ namespace CommandLine.Core
                             arguments.Skip(1).FirstOrDefault() ?? string.Empty, nameComparer))
                     : (autoVersion && preprocCompare("version"))
                         ? MakeNotParsed(types, new VersionRequestedError())
-                        : MatchVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoVersion, nonFatalErrors);
+                        : MatchVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoVersion, allowMultiInstance, nonFatalErrors);
             };
 
             return arguments.Any()
@@ -92,6 +117,7 @@ namespace CommandLine.Core
             CultureInfo parsingCulture,
             bool autoHelp,
             bool autoVersion,
+            bool allowMultiInstance,
             IEnumerable<ErrorType> nonFatalErrors)
         {
             return verbs.Any(a => nameComparer.Equals(a.Item1.Name, arguments.First()))
@@ -106,6 +132,7 @@ namespace CommandLine.Core
                     parsingCulture,
                     autoHelp,
                     autoVersion,
+                    allowMultiInstance,
                     nonFatalErrors)
                 : MatchDefaultVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoVersion, nonFatalErrors);
         }

--- a/src/CommandLine/Core/NameLookup.cs
+++ b/src/CommandLine/Core/NameLookup.cs
@@ -10,7 +10,7 @@ namespace CommandLine.Core
     enum NameLookupResult
     {
         NoOptionFound,
-        BooleanOptionFound,
+        FlagOptionFound,
         OtherOptionFound
     }
 
@@ -20,8 +20,8 @@ namespace CommandLine.Core
         {
             var option = specifications.FirstOrDefault(a => name.MatchName(a.ShortName, a.LongName, comparer));
             if (option == null) return NameLookupResult.NoOptionFound;
-            return option.ConversionType == typeof(bool)
-                ? NameLookupResult.BooleanOptionFound
+            return option.ConversionType == typeof(bool) || option.FlagCounter
+                ? NameLookupResult.FlagOptionFound
                 : NameLookupResult.OtherOptionFound;
         }
 

--- a/src/CommandLine/Core/OptionSpecification.cs
+++ b/src/CommandLine/Core/OptionSpecification.cs
@@ -20,7 +20,7 @@ namespace CommandLine.Core
             char separator, Maybe<object> defaultValue, string helpText, string metaValue, IEnumerable<string> enumValues,
             Type conversionType, TargetType targetType, string group, bool flagCounter, bool hidden)
             : base(SpecificationType.Option,
-                 required, min, max, defaultValue, helpText, metaValue, enumValues, conversionType, targetType, hidden)
+                 required, min, max, defaultValue, helpText, metaValue, enumValues, conversionType, conversionType == typeof(int) && flagCounter ? TargetType.Switch : targetType, hidden)
         {
             this.shortName = shortName;
             this.longName = longName;

--- a/src/CommandLine/Core/OptionSpecification.cs
+++ b/src/CommandLine/Core/OptionSpecification.cs
@@ -14,10 +14,11 @@ namespace CommandLine.Core
         private readonly char separator;
         private readonly string setName;
         private readonly string group;
+        private readonly bool flagCounter;
 
         public OptionSpecification(string shortName, string longName, bool required, string setName, Maybe<int> min, Maybe<int> max,
             char separator, Maybe<object> defaultValue, string helpText, string metaValue, IEnumerable<string> enumValues,
-            Type conversionType, TargetType targetType, string group, bool hidden = false)
+            Type conversionType, TargetType targetType, string group, bool flagCounter, bool hidden)
             : base(SpecificationType.Option,
                  required, min, max, defaultValue, helpText, metaValue, enumValues, conversionType, targetType, hidden)
         {
@@ -26,6 +27,7 @@ namespace CommandLine.Core
             this.separator = separator;
             this.setName = setName;
             this.group = group;
+            this.flagCounter = flagCounter;
         }
 
         public static OptionSpecification FromAttribute(OptionAttribute attribute, Type conversionType, IEnumerable<string> enumValues)
@@ -45,13 +47,14 @@ namespace CommandLine.Core
                 conversionType,
                 conversionType.ToTargetType(),
                 attribute.Group,
+                attribute.FlagCounter,
                 attribute.Hidden);
         }
 
-        public static OptionSpecification NewSwitch(string shortName, string longName, bool required, string helpText, string metaValue, bool hidden = false)
+        public static OptionSpecification NewSwitch(string shortName, string longName, bool required, string helpText, string metaValue, bool flagCounter, bool hidden)
         {
             return new OptionSpecification(shortName, longName, required, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(),
-                '\0', Maybe.Nothing<object>(), helpText, metaValue, Enumerable.Empty<string>(), typeof(bool), TargetType.Switch, string.Empty, hidden);
+                '\0', Maybe.Nothing<object>(), helpText, metaValue, Enumerable.Empty<string>(), typeof(bool), TargetType.Switch, string.Empty, flagCounter, hidden);
         }
 
         public string ShortName
@@ -77,6 +80,11 @@ namespace CommandLine.Core
         public string Group
         {
             get { return group; }
+        }
+
+        public bool FlagCounter
+        {
+            get { return flagCounter; }
         }
     }
 }

--- a/src/CommandLine/Core/PreprocessorGuards.cs
+++ b/src/CommandLine/Core/PreprocessorGuards.cs
@@ -8,31 +8,53 @@ namespace CommandLine.Core
 {
     static class PreprocessorGuards
     {
-        public static IEnumerable<Func<IEnumerable<string>, IEnumerable<Error>>>
-            Lookup(StringComparer nameComparer, bool autoHelp, bool autoVersion)
+        public static IEnumerable<Func<IEnumerable<Token>, IEnumerable<Error>>>
+            Lookup(StringComparer nameComparer, bool autoHelp, bool autoHelpShortName, bool autoVersion, bool autoVersionShortName)
         {
-            var list = new List<Func<IEnumerable<string>, IEnumerable<Error>>>();
+            var list = new List<Func<IEnumerable<Token>, IEnumerable<Error>>>();
             if (autoHelp)
                 list.Add(HelpCommand(nameComparer));
+            if (autoHelp && autoHelpShortName)
+                list.Add(ShortHelpCommand(nameComparer));
             if (autoVersion)
                 list.Add(VersionCommand(nameComparer));
+            if (autoVersion && autoVersionShortName)
+                list.Add(ShortVersionCommand(nameComparer));
             return list;
         }
 
-        public static Func<IEnumerable<string>, IEnumerable<Error>> HelpCommand(StringComparer nameComparer)
+        public static Func<IEnumerable<Token>, IEnumerable<Error>> HelpCommand(StringComparer nameComparer)
         {
             return
                 arguments =>
-                    nameComparer.Equals("--help", arguments.First())
+                    arguments.OfType<Name>().Any(arg => nameComparer.Equals("help", arg.Text))
                         ? new Error[] { new HelpRequestedError() }
                         : Enumerable.Empty<Error>();
         }
 
-        public static Func<IEnumerable<string>, IEnumerable<Error>> VersionCommand(StringComparer nameComparer)
+        public static Func<IEnumerable<Token>, IEnumerable<Error>> ShortHelpCommand(StringComparer nameComparer)
         {
             return
                 arguments =>
-                    nameComparer.Equals("--version", arguments.First())
+                    arguments.OfType<Name>().Any(arg => nameComparer.Equals("h", arg.Text))
+                        ? new Error[] { new HelpRequestedError() }
+                        : Enumerable.Empty<Error>();
+        }
+
+        public static Func<IEnumerable<Token>, IEnumerable<Error>> VersionCommand(StringComparer nameComparer)
+        {
+            return
+                arguments =>
+                    arguments.OfType<Name>().Any(arg => nameComparer.Equals("version", arg.Text))
+                        ? new Error[] { new VersionRequestedError() }
+                        : Enumerable.Empty<Error>();
+        }
+
+        public static Func<IEnumerable<Token>, IEnumerable<Error>> ShortVersionCommand(StringComparer nameComparer)
+        {
+            return
+                arguments =>
+                    arguments.OfType<Name>().Any(arg => nameComparer.Equals("V", arg.Text))  // Uppercase V
                         ? new Error[] { new VersionRequestedError() }
                         : Enumerable.Empty<Error>();
         }

--- a/src/CommandLine/Core/Scalar.cs
+++ b/src/CommandLine/Core/Scalar.cs
@@ -16,7 +16,7 @@ namespace CommandLine.Core
         {
             return from tseq in tokens.Pairwise(
                 (f, s) =>
-                        f.IsName() && s.IsValue()
+                        f.IsName() && s.IsValueUnforced()
                             ? typeLookup(f.Text).MapValueOrDefault(info =>
                                     info.TargetType == TargetType.Scalar ? new[] { f, s } : new Token[] { }, new Token[] { })
                                     : new Token[] { })

--- a/src/CommandLine/Core/Sequence.cs
+++ b/src/CommandLine/Core/Sequence.cs
@@ -14,30 +14,141 @@ namespace CommandLine.Core
             IEnumerable<Token> tokens,
             Func<string, Maybe<TypeDescriptor>> typeLookup)
         {
-            return from tseq in tokens.Pairwise(
-                (f, s) =>
-                        f.IsName() && s.IsValue()
-                            ? typeLookup(f.Text).MapValueOrDefault(info =>
-                                   info.TargetType == TargetType.Sequence
-                                        ? new[] { f }.Concat(tokens.OfSequence(f, info))
-                                        : new Token[] { }, new Token[] { })
-                            : new Token[] { })
-                   from t in tseq
-                   select t;
+            var sequences = new Dictionary<Token, IList<Token>>();
+            var state = SequenceState.TokenSearch;
+            Token nameToken = default;
+            foreach (var token in tokens)
+            {
+                switch (state)
+                {
+                    case SequenceState.TokenSearch:
+                        if (token.IsName())
+                        {
+                            if (typeLookup(token.Text).MatchJust(out var info) && info.TargetType == TargetType.Sequence)
+                            {
+                                nameToken = token;
+                                state = SequenceState.TokenFound;
+                            }
+                        }
+                        break;
+
+                    case SequenceState.TokenFound:
+                        if (token.IsValue())
+                        {
+                            if (sequences.TryGetValue(nameToken, out var sequence))
+                            {
+                                sequence.Add(token);
+                            }
+                            else
+                            {
+                                sequences[nameToken] = new List<Token>(new[] { token });
+                            }
+                        }
+                        else if (token.IsName())
+                        {
+                            if (typeLookup(token.Text).MatchJust(out var info) && info.TargetType == TargetType.Sequence)
+                            {
+                                nameToken = token;
+                                state = SequenceState.TokenFound;
+                            }
+                            else
+                            {
+                                state = SequenceState.TokenSearch;
+                            }
+                        }
+                        else
+                        {
+                            state = SequenceState.TokenSearch;
+                        }
+                        break;
+                }
+            }
+
+            foreach (var kvp in sequences)
+            {
+                yield return kvp.Key;
+                foreach (var value in kvp.Value)
+                {
+                    yield return value;
+                }
+            }
+
+                //return from tseq in tokens.Pairwise(
+                //(f, s) =>
+                //        f.IsName() && s.IsValue()
+                //            ? typeLookup(f.Text).MapValueOrDefault(info =>
+                //                   info.TargetType == TargetType.Sequence
+                //                        ? new[] { f }.Concat(tokens.OfSequence(f, info))
+                //                        : new Token[] { }, new Token[] { })
+                //            : new Token[] { })
+                //   from t in tseq
+                //   select t;
         }
 
-        private static IEnumerable<Token> OfSequence(this IEnumerable<Token> tokens, Token nameToken, TypeDescriptor info)
+        //private static IEnumerable<Token> OfSequence(this IEnumerable<Token> tokens, Token nameToken, TypeDescriptor info)
+        //{
+        //    var state = SequenceState.TokenSearch;
+        //    var count = 0;
+        //    var max = info.MaxItems.GetValueOrDefault(int.MaxValue);
+        //    var values = max != int.MaxValue
+        //        ? new List<Token>(max)
+        //        : new List<Token>();
+
+        //    foreach (var token in tokens)
+        //    {
+        //        if (count == max)
+        //        {
+        //            break;
+        //        }
+
+        //        switch (state)
+        //        {
+        //            case SequenceState.TokenSearch:
+        //                if (token.IsName() && token.Text.Equals(nameToken.Text))
+        //                {
+        //                    state = SequenceState.TokenFound;
+        //                }
+        //                break;
+
+        //            case SequenceState.TokenFound:
+        //                if (token.IsValue())
+        //                {
+        //                    state = SequenceState.ValueFound;
+        //                    count++;
+        //                    values.Add(token);
+        //                }
+        //                else
+        //                {
+        //                    // Invalid to provide option without value
+        //                    return Enumerable.Empty<Token>();
+        //                }
+        //                break;
+
+        //            case SequenceState.ValueFound:
+        //                if (token.IsValue())
+        //                {
+        //                    count++;
+        //                    values.Add(token);
+        //                }
+        //                else if (token.IsName() && token.Text.Equals(nameToken.Text))
+        //                {
+        //                    state = SequenceState.TokenFound;
+        //                }
+        //                else
+        //                {
+        //                    state = SequenceState.TokenSearch;
+        //                }
+        //                break;
+        //        }
+        //    }
+
+        //    return values;
+        //}
+
+        private enum SequenceState
         {
-            var nameIndex = tokens.IndexOf(t => t.Equals(nameToken));
-            if (nameIndex >= 0)
-            {
-                return info.NextValue.MapValueOrDefault(
-                    _ => info.MaxItems.MapValueOrDefault(
-                            n => tokens.Skip(nameIndex + 1).Take(n),
-                                 tokens.Skip(nameIndex + 1).TakeWhile(v => v.IsValue())),
-                    tokens.Skip(nameIndex + 1).TakeWhile(v => v.IsValue()));
-            }
-            return new Token[] { };
+            TokenSearch,
+            TokenFound,
         }
     }
 }

--- a/src/CommandLine/Core/Sequence.cs
+++ b/src/CommandLine/Core/Sequence.cs
@@ -33,7 +33,7 @@ namespace CommandLine.Core
                         break;
 
                     case SequenceState.TokenFound:
-                        if (token.IsValue())
+                        if (token.IsValueUnforced())
                         {
                             if (sequences.TryGetValue(nameToken, out var sequence))
                             {

--- a/src/CommandLine/Core/SpecificationExtensions.cs
+++ b/src/CommandLine/Core/SpecificationExtensions.cs
@@ -35,6 +35,7 @@ namespace CommandLine.Core
                 specification.ConversionType,
                 specification.TargetType,
                 specification.Group,
+                specification.FlagCounter,
                 specification.Hidden);
         }
 

--- a/src/CommandLine/Core/SpecificationPropertyRules.cs
+++ b/src/CommandLine/Core/SpecificationPropertyRules.cs
@@ -14,6 +14,14 @@ namespace CommandLine.Core
             Lookup(
                 IEnumerable<Token> tokens)
         {
+            return Lookup(tokens, false);
+        }
+
+        public static IEnumerable<Func<IEnumerable<SpecificationProperty>, IEnumerable<Error>>>
+            Lookup(
+                IEnumerable<Token> tokens,
+                bool allowMultiInstance)
+        {
             return new List<Func<IEnumerable<SpecificationProperty>, IEnumerable<Error>>>
                 {
                     EnforceMutuallyExclusiveSet(),
@@ -21,7 +29,7 @@ namespace CommandLine.Core
                     EnforceMutuallyExclusiveSetAndGroupAreNotUsedTogether(),
                     EnforceRequired(),
                     EnforceRange(),
-                    EnforceSingle(tokens)
+                    EnforceSingle(tokens, allowMultiInstance)
                 };
         }
 
@@ -173,10 +181,15 @@ namespace CommandLine.Core
                 };
         }
 
-        private static Func<IEnumerable<SpecificationProperty>, IEnumerable<Error>> EnforceSingle(IEnumerable<Token> tokens)
+        private static Func<IEnumerable<SpecificationProperty>, IEnumerable<Error>> EnforceSingle(IEnumerable<Token> tokens, bool allowMultiInstance)
         {
             return specProps =>
                 {
+                    if (allowMultiInstance)
+                    {
+                        return Enumerable.Empty<Error>();
+                    }
+
                     var specs = from sp in specProps
                                 where sp.Specification.IsOption()
                                 where sp.Value.IsJust()

--- a/src/CommandLine/Core/Token.cs
+++ b/src/CommandLine/Core/Token.cs
@@ -27,9 +27,14 @@ namespace CommandLine.Core
             return new Value(text);
         }
 
-        public static Token Value(string text, bool explicitlyAssigned)
+        public static Token Value(string text, bool forced)
         {
-            return new Value(text, explicitlyAssigned);
+            return new Value(text, forced);
+        }
+
+        public static Token ValueForced(string text)
+        {
+            return new Value(text, true);
         }
 
         public TokenType Tag
@@ -79,22 +84,22 @@ namespace CommandLine.Core
 
     class Value : Token, IEquatable<Value>
     {
-        private readonly bool explicitlyAssigned;
+        private readonly bool forced;
 
         public Value(string text)
             : this(text, false)
         {
         }
 
-        public Value(string text, bool explicitlyAssigned)
+        public Value(string text, bool forced)
             : base(TokenType.Value, text)
         {
-            this.explicitlyAssigned = explicitlyAssigned;
+            this.forced = forced;
         }
 
-        public bool ExplicitlyAssigned
+        public bool Forced
         {
-            get { return explicitlyAssigned; }
+            get { return forced; }
         }
 
         public override bool Equals(object obj)
@@ -110,7 +115,7 @@ namespace CommandLine.Core
 
         public override int GetHashCode()
         {
-            return new { Tag, Text }.GetHashCode();
+            return new { Tag, Text, Forced }.GetHashCode();
         }
 
         public bool Equals(Value other)
@@ -120,7 +125,7 @@ namespace CommandLine.Core
                 return false;
             }
 
-            return Tag.Equals(other.Tag) && Text.Equals(other.Text);
+            return Tag.Equals(other.Tag) && Text.Equals(other.Text) && this.Forced == other.Forced;
         }
     }
 
@@ -134,6 +139,16 @@ namespace CommandLine.Core
         public static bool IsValue(this Token token)
         {
             return token.Tag == TokenType.Value;
+        }
+
+        public static bool IsValueForced(this Token token)
+        {
+            return token.IsValue() && ((Value)token).Forced;
+        }
+
+        public static bool IsValueUnforced(this Token token)
+        {
+            return token.IsValue() && ! ((Value)token).Forced;
         }
     }
 }

--- a/src/CommandLine/Core/TokenPartitioner.cs
+++ b/src/CommandLine/Core/TokenPartitioner.cs
@@ -21,10 +21,11 @@ namespace CommandLine.Core
             var switches = new HashSet<Token>(Switch.Partition(tokenList, typeLookup), tokenComparer);
             var scalars = new HashSet<Token>(Scalar.Partition(tokenList, typeLookup), tokenComparer);
             var sequences = new HashSet<Token>(Sequence.Partition(tokenList, typeLookup), tokenComparer);
+            var dedupedSequences = new HashSet<Token>(sequences);
             var nonOptions = tokenList
                 .Where(t => !switches.Contains(t))
                 .Where(t => !scalars.Contains(t))
-                .Where(t => !sequences.Contains(t)).Memoize();
+                .Where(t => !dedupedSequences.Contains(t)).Memoize();
             var values = nonOptions.Where(v => v.IsValue()).Memoize();
             var errors = nonOptions.Except(values, (IEqualityComparer<Token>)ReferenceEqualityComparer.Default).Memoize();
 

--- a/src/CommandLine/Core/Tokenizer.cs
+++ b/src/CommandLine/Core/Tokenizer.cs
@@ -16,50 +16,184 @@ namespace CommandLine.Core
             IEnumerable<string> arguments,
             Func<string, NameLookupResult> nameLookup)
         {
-            return Tokenizer.Tokenize(arguments, nameLookup, tokens => tokens);
+            return Tokenizer.Tokenize(arguments, nameLookup, ignoreUnknownArguments:false, allowDashDash:true);
         }
 
         public static Result<IEnumerable<Token>, Error> Tokenize(
             IEnumerable<string> arguments,
             Func<string, NameLookupResult> nameLookup,
-            Func<IEnumerable<Token>, IEnumerable<Token>> normalize)
+            bool ignoreUnknownArguments,
+            bool allowDashDash)
         {
             var errors = new List<Error>();
             Action<Error> onError = errors.Add;
 
-            var tokens = (from arg in arguments
-                          from token in !arg.StartsWith("-", StringComparison.Ordinal)
-                               ? new[] { Token.Value(arg) }
-                               : arg.StartsWith("--", StringComparison.Ordinal)
-                                     ? TokenizeLongName(arg, onError)
-                                     : TokenizeShortName(arg, nameLookup)
-                          select token)
-                            .Memoize();
+            int consumeNext = 0;
+            var tokens = new List<Token>();
+            Action<string> addValue = (s => tokens.Add(new Value(s)));
+            Action<string> addName = (s => tokens.Add(new Name(s)));
 
-            var normalized = normalize(tokens).Memoize();
-
-            var unkTokens = (from t in normalized where t.IsName() && nameLookup(t.Text) == NameLookupResult.NoOptionFound select t).Memoize();
-
-            return Result.Succeed(normalized.Where(x => !unkTokens.Contains(x)), errors.Concat(from t in unkTokens select new UnknownOptionError(t.Text)));
-        }
-
-        public static Result<IEnumerable<Token>, Error> PreprocessDashDash(
-            IEnumerable<string> arguments,
-            Func<IEnumerable<string>, Result<IEnumerable<Token>, Error>> tokenizer)
-        {
-            if (arguments.Any(arg => arg.EqualsOrdinal("--")))
+            var enumerator = arguments.GetEnumerator();
+            while (enumerator.MoveNext())
             {
-                var tokenizerResult = tokenizer(arguments.TakeWhile(arg => !arg.EqualsOrdinal("--")));
-                var values = arguments.SkipWhile(arg => !arg.EqualsOrdinal("--")).Skip(1).Select(Token.Value);
-                return tokenizerResult.Map(tokens => tokens.Concat(values));
+                string arg = enumerator.Current;
+                // TODO: Turn this into a switch statement with pattern matching
+                if (arg == null)
+                {
+                    continue;
+                }
+
+                if (consumeNext > 0)
+                {
+                    addValue(arg);
+                    consumeNext = consumeNext - 1;
+                    continue;
+                }
+
+                if (arg == "--")
+                {
+                    if (allowDashDash)
+                    {
+                        consumeNext = System.Int32.MaxValue;
+                        continue;
+                    }
+                    else
+                    {
+                        addValue(arg);
+                        continue;
+                    }
+                }
+
+                if (arg.StartsWith("--"))
+                {
+                    if (arg.Contains("="))
+                    {
+                        string[] parts = arg.Substring(2).Split(new char[] { '=' }, 2);
+                        if (String.IsNullOrWhiteSpace(parts[0]) || parts[0].Contains(" "))
+                        {
+                            onError(new BadFormatTokenError(arg));
+                            continue;
+                        }
+                        else
+                        {
+                            var name = parts[0];
+                            var tokenType = nameLookup(name);
+                            if (tokenType == NameLookupResult.NoOptionFound)
+                            {
+                                if (ignoreUnknownArguments)
+                                {
+                                    continue;
+                                }
+                                else
+                                {
+                                    onError(new UnknownOptionError(name));
+                                    continue;
+                                }
+                            }
+                            addName(parts[0]);
+                            addValue(parts[1]);
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        var name = arg.Substring(2);
+                        var tokenType = nameLookup(name);
+                        if (tokenType == NameLookupResult.OtherOptionFound)
+                        {
+                            addName(name);
+                            consumeNext = 1;
+                            continue;
+                        }
+                        else if (tokenType == NameLookupResult.NoOptionFound)
+                        {
+                            if (ignoreUnknownArguments)
+                            {
+                                // When ignoreUnknownArguments is true and AutoHelp is true, calling code is responsible for
+                                // setting up nameLookup so that it will return a known name for --help, so that we don't skip it here
+                                continue;
+                            }
+                            else
+                            {
+                                onError(new UnknownOptionError(name));
+                                continue;
+                            }
+                        }
+                        else
+                        {
+                            addName(name);
+                            continue;
+                        }
+                    }
+                }
+
+                if (arg == "-")
+                {
+                    // A single hyphen is always a value (it usually means "read from stdin" or "write to stdout")
+                    addValue(arg);
+                    continue;
+                }
+
+                if (arg.StartsWith("-"))
+                {
+                    // First option char that requires a value means we swallow the rest of the string as the value
+                    // But if there is no rest of the string, then instead we swallow the next argument
+                    string chars = arg.Substring(1);
+                    int len = chars.Length;
+                    if (len > 0 && Char.IsDigit(chars[0]))
+                    {
+                        // Assume it's a negative number
+                        addValue(arg);
+                        continue;
+                    }
+                    for (int i = 0; i < len; i++)
+                    {
+                        var s = new String(chars[i], 1);
+                        var tokenType = nameLookup(s);
+                        if (tokenType == NameLookupResult.OtherOptionFound)
+                        {
+                            addName(s);
+                            if (i+1 < len)
+                            {
+                                addValue(chars.Substring(i+1));
+                                break;
+                            }
+                            else
+                            {
+                                consumeNext = 1;
+                            }
+                        }
+                        else if (tokenType == NameLookupResult.NoOptionFound)
+                        {
+                            if (ignoreUnknownArguments)
+                            {
+                                continue;
+                            }
+                            else
+                            {
+                                onError(new UnknownOptionError(s));
+                            }
+                        }
+                        else
+                        {
+                            addName(s);
+                        }
+                    }
+                    continue;
+                }
+
+                // If we get this far, it's a plain value
+                addValue(arg);
             }
-            return tokenizer(arguments);
+
+            return Result.Succeed<IEnumerable<Token>, Error>(tokens.AsEnumerable(), errors.AsEnumerable());
         }
 
         public static Result<IEnumerable<Token>, Error> ExplodeOptionList(
             Result<IEnumerable<Token>, Error> tokenizerResult,
             Func<string, Maybe<char>> optionSequenceWithSeparatorLookup)
         {
+            // TODO: I don't like how this works. I don't want "-s foo;bar baz" to put three values into -s. Let's instead have a third token type, List, besides Name and Value.
             var tokens = tokenizerResult.SucceededWith().Memoize();
 
             var replaces = tokens.Select((t, i) =>
@@ -77,33 +211,6 @@ namespace CommandLine.Core
             return Result.Succeed(flattened, tokenizerResult.SuccessMessages());
         }
 
-        public static IEnumerable<Token> Normalize(
-            IEnumerable<Token> tokens, Func<string, bool> nameLookup)
-        {
-            var indexes =
-                from i in
-                    tokens.Select(
-                        (t, i) =>
-                        {
-                            var prev = tokens.ElementAtOrDefault(i - 1).ToMaybe();
-                            return t.IsValue() && ((Value)t).ExplicitlyAssigned
-                                   && prev.MapValueOrDefault(p => p.IsName() && !nameLookup(p.Text), false)
-                                ? Maybe.Just(i)
-                                : Maybe.Nothing<int>();
-                        }).Where(i => i.IsJust())
-                select i.FromJustOrFail();
-
-            var toExclude =
-                from t in
-                    tokens.Select((t, i) => indexes.Contains(i) ? Maybe.Just(t) : Maybe.Nothing<Token>())
-                        .Where(t => t.IsJust())
-                select t.FromJustOrFail();
-
-            var normalized = tokens.Where(t => toExclude.Contains(t) == false);
-
-            return normalized;
-        }
-
         public static Func<
                     IEnumerable<string>,
                     IEnumerable<OptionSpecification>,
@@ -115,94 +222,10 @@ namespace CommandLine.Core
         {
             return (arguments, optionSpecs) =>
                 {
-                    var normalize = ignoreUnknownArguments
-                        ? toks => Tokenizer.Normalize(toks,
-                            name => NameLookup.Contains(name, optionSpecs, nameComparer) != NameLookupResult.NoOptionFound)
-                        : new Func<IEnumerable<Token>, IEnumerable<Token>>(toks => toks);
-
-                    var tokens = enableDashDash
-                        ? Tokenizer.PreprocessDashDash(
-                                arguments,
-                                args =>
-                                    Tokenizer.Tokenize(args, name => NameLookup.Contains(name, optionSpecs, nameComparer), normalize))
-                        : Tokenizer.Tokenize(arguments, name => NameLookup.Contains(name, optionSpecs, nameComparer), normalize);
+                    var tokens = Tokenizer.Tokenize(arguments, name => NameLookup.Contains(name, optionSpecs, nameComparer), ignoreUnknownArguments, enableDashDash);
                     var explodedTokens = Tokenizer.ExplodeOptionList(tokens, name => NameLookup.HavingSeparator(name, optionSpecs, nameComparer));
                     return explodedTokens;
                 };
-        }
-
-        private static IEnumerable<Token> TokenizeShortName(
-            string value,
-            Func<string, NameLookupResult> nameLookup)
-        {
-            if (value.Length > 1 && value[0] == '-' && value[1] != '-')
-            {
-                var text = value.Substring(1);
-
-                if (char.IsDigit(text[0]))
-                {
-                    yield return Token.Value(value);
-                    yield break;
-                }
-
-                if (value.Length == 2)
-                {
-                    yield return Token.Name(text);
-                    yield break;
-                }
-
-                var i = 0;
-                foreach (var c in text)
-                {
-                    var n = new string(c, 1);
-                    var r = nameLookup(n);
-                    // Assume first char is an option
-                    if (i > 0 && r == NameLookupResult.NoOptionFound) break;
-                    i++;
-                    yield return Token.Name(n);
-                    // If option expects a value (other than a boolean), assume following chars are that value
-                    if (r == NameLookupResult.OtherOptionFound) break;
-                }
-
-                if (i < text.Length)
-                {
-                    yield return Token.Value(text.Substring(i));
-                }
-            }
-        }
-
-        private static IEnumerable<Token> TokenizeLongName(
-            string value,
-            Action<Error> onError)
-        {
-            if (value.Length > 2 && value.StartsWith("--", StringComparison.Ordinal))
-            {
-                var text = value.Substring(2);
-                var equalIndex = text.IndexOf('=');
-                if (equalIndex <= 0)
-                {
-                    yield return Token.Name(text);
-                    yield break;
-                }
-                if (equalIndex == 1) // "--="
-                {
-                    onError(new BadFormatTokenError(value));
-                    yield break;
-                }
-
-                var tokenMatch = Regex.Match(text, "^([^=]+)=([^ ].*)$");
-
-                if (tokenMatch.Success)
-                {
-                    yield return Token.Name(tokenMatch.Groups[1].Value);
-                    yield return Token.Value(tokenMatch.Groups[2].Value, true);
-                }
-                else
-                {
-                    onError(new BadFormatTokenError(value));
-                    yield break;
-                }
-            }
         }
     }
 }

--- a/src/CommandLine/Core/Tokenizer.cs
+++ b/src/CommandLine/Core/Tokenizer.cs
@@ -34,6 +34,8 @@ namespace CommandLine.Core
             int consumeNext = 0;
             Action<int> onConsumeNext = (n => consumeNext = consumeNext + n);
 
+            bool isForced = false;
+
             var tokens = new List<Token>();
 
             var enumerator = arguments.GetEnumerator();
@@ -44,21 +46,22 @@ namespace CommandLine.Core
                         break;
 
                     case string arg when consumeNext > 0:
-                        tokens.Add(new Value(arg));
+                        tokens.Add(new Value(arg, isForced));
                         consumeNext = consumeNext - 1;
                         break;
 
                     case "--" when allowDashDash:
                         consumeNext = System.Int32.MaxValue;
+                        isForced = true;
                         break;
 
                     case "--":
-                        tokens.Add(new Value("--"));
+                        tokens.Add(new Value("--", isForced));
                         break;
 
                     case "-":
                         // A single hyphen is always a value (it usually means "read from stdin" or "write to stdout")
-                        tokens.Add(new Value("-"));
+                        tokens.Add(new Value("-", isForced));
                         break;
 
                     case string arg when arg.StartsWith("--"):
@@ -71,7 +74,7 @@ namespace CommandLine.Core
 
                     case string arg:
                         // If we get this far, it's a plain value
-                        tokens.Add(new Value(arg));
+                        tokens.Add(new Value(arg, isForced));
                         break;
                 }
             }

--- a/src/CommandLine/Core/TypeConverter.cs
+++ b/src/CommandLine/Core/TypeConverter.cs
@@ -13,11 +13,13 @@ namespace CommandLine.Core
 {
     static class TypeConverter
     {
-        public static Maybe<object> ChangeType(IEnumerable<string> values, Type conversionType, bool scalar, CultureInfo conversionCulture, bool ignoreValueCase)
+        public static Maybe<object> ChangeType(IEnumerable<string> values, Type conversionType, bool scalar, bool isFlag, CultureInfo conversionCulture, bool ignoreValueCase)
         {
-            return scalar
-                ? ChangeTypeScalar(values.Last(), conversionType, conversionCulture, ignoreValueCase)
-                : ChangeTypeSequence(values, conversionType, conversionCulture, ignoreValueCase);
+            return isFlag
+                ? ChangeTypeFlagCounter(values, conversionType, conversionCulture, ignoreValueCase)
+                : scalar
+                    ? ChangeTypeScalar(values.Last(), conversionType, conversionCulture, ignoreValueCase)
+                    : ChangeTypeSequence(values, conversionType, conversionCulture, ignoreValueCase);
         }
 
         private static Maybe<object> ChangeTypeSequence(IEnumerable<string> values, Type conversionType, CultureInfo conversionCulture, bool ignoreValueCase)
@@ -44,6 +46,14 @@ namespace CommandLine.Core
             result.Match((_,__) => { }, e => e.First().RethrowWhenAbsentIn(
                 new[] { typeof(InvalidCastException), typeof(FormatException), typeof(OverflowException) }));
             return result.ToMaybe();
+        }
+
+        private static Maybe<object> ChangeTypeFlagCounter(IEnumerable<string> values, Type conversionType, CultureInfo conversionCulture, bool ignoreValueCase)
+        {
+            var converted = values.Select(value => ChangeTypeScalar(value, typeof(bool), conversionCulture, ignoreValueCase));
+            return converted.Any(maybe => maybe.MatchNothing())
+                ? Maybe.Nothing<object>()
+                : Maybe.Just((object)converted.Count(value => value.IsJust()));
         }
 
         private static object ConvertString(string value, Type type, CultureInfo conversionCulture)

--- a/src/CommandLine/Core/TypeConverter.cs
+++ b/src/CommandLine/Core/TypeConverter.cs
@@ -16,7 +16,7 @@ namespace CommandLine.Core
         public static Maybe<object> ChangeType(IEnumerable<string> values, Type conversionType, bool scalar, CultureInfo conversionCulture, bool ignoreValueCase)
         {
             return scalar
-                ? ChangeTypeScalar(values.Single(), conversionType, conversionCulture, ignoreValueCase)
+                ? ChangeTypeScalar(values.Last(), conversionType, conversionCulture, ignoreValueCase)
                 : ChangeTypeSequence(values, conversionType, conversionCulture, ignoreValueCase);
         }
 

--- a/src/CommandLine/ErrorExtensions.cs
+++ b/src/CommandLine/ErrorExtensions.cs
@@ -19,9 +19,7 @@ namespace CommandLine
         public static IEnumerable<Error> OnlyMeaningfulOnes(this IEnumerable<Error> errors)
         {
             return errors
-                .Where(e => !e.StopsProcessing)
-                .Where(e => !(e.Tag == ErrorType.UnknownOptionError
-                    && ((UnknownOptionError)e).Token.EqualsOrdinalIgnoreCase("help")));
+                .Where(e => !e.StopsProcessing);
         }
        
     }

--- a/src/CommandLine/OptionAttribute.cs
+++ b/src/CommandLine/OptionAttribute.cs
@@ -17,6 +17,7 @@ namespace CommandLine
         private string setName;
         private char separator;
         private string group=string.Empty;
+        private bool flagCounter;
 
         private OptionAttribute(string shortName, string longName) : base()
         {
@@ -27,6 +28,7 @@ namespace CommandLine
             this.longName = longName;
             setName = string.Empty;
             separator = '\0';
+            flagCounter = false;
         }
 
         /// <summary>
@@ -113,6 +115,15 @@ namespace CommandLine
         {
             get { return group; }
             set { group = value; }
+        }
+
+        /// <summary>
+        /// When applied to an int property, turns that property into a count of how many times a boolean flag was applied (e.g., -vvv would become 3)
+        /// </summary>
+        public bool FlagCounter
+        {
+            get { return flagCounter; }
+            set { flagCounter = value; }
         }
     }
 }

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -100,7 +100,9 @@ namespace CommandLine
                     settings.CaseInsensitiveEnumValues,
                     settings.ParsingCulture,
                     settings.AutoHelp,
+                    settings.AutoHelpShortName,
                     settings.AutoVersion,
+                    settings.AutoVersionShortName,
                     settings.AllowMultiInstance,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
@@ -131,7 +133,9 @@ namespace CommandLine
                     settings.CaseInsensitiveEnumValues,
                     settings.ParsingCulture,
                     settings.AutoHelp,
+                    settings.AutoHelpShortName,
                     settings.AutoVersion,
+                    settings.AutoVersionShortName,
                     settings.AllowMultiInstance,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
@@ -164,7 +168,9 @@ namespace CommandLine
                     settings.CaseInsensitiveEnumValues,
                     settings.ParsingCulture,
                     settings.AutoHelp,
+                    settings.AutoHelpShortName,
                     settings.AutoVersion,
+                    settings.AutoVersionShortName,
                     settings.AllowMultiInstance,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -101,6 +101,7 @@ namespace CommandLine
                     settings.ParsingCulture,
                     settings.AutoHelp,
                     settings.AutoVersion,
+                    settings.AllowMultiInstance,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }
@@ -131,6 +132,7 @@ namespace CommandLine
                     settings.ParsingCulture,
                     settings.AutoHelp,
                     settings.AutoVersion,
+                    settings.AllowMultiInstance,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }
@@ -163,6 +165,7 @@ namespace CommandLine
                     settings.ParsingCulture,
                     settings.AutoHelp,
                     settings.AutoVersion,
+                    settings.AllowMultiInstance,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -21,7 +21,9 @@ namespace CommandLine
         private TextWriter helpWriter;
         private bool ignoreUnknownArguments;
         private bool autoHelp;
+        private bool autoHelpShortName;
         private bool autoVersion;
+        private bool autoVersionShortName;
         private CultureInfo parsingCulture;
         private bool enableDashDash;
         private int maximumDisplayWidth;
@@ -35,7 +37,9 @@ namespace CommandLine
             caseSensitive = true;
             caseInsensitiveEnumValues = false;
             autoHelp = true;
+            autoHelpShortName = false;
             autoVersion = true;
+            autoVersionShortName = false;
             parsingCulture = CultureInfo.InvariantCulture;
             maximumDisplayWidth = GetWindowWidth();
         }
@@ -148,12 +152,30 @@ namespace CommandLine
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether implicit option or verb 'help' should have the shortname '-h'.
+        /// </summary>
+        public bool AutoHelpShortName
+        {
+            get { return autoHelpShortName; }
+            set { PopsicleSetter.Set(Consumed, ref autoHelpShortName, value); }
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether implicit option or verb 'version' should be supported.
         /// </summary>
         public bool AutoVersion
         {
             get { return autoVersion; }
             set { PopsicleSetter.Set(Consumed, ref autoVersion, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether implicit option or verb 'help' should have the shortname '-h'.
+        /// </summary>
+        public bool AutoVersionShortName
+        {
+            get { return autoVersionShortName; }
+            set { PopsicleSetter.Set(Consumed, ref autoVersionShortName, value); }
         }
 
         /// <summary>

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -25,6 +25,7 @@ namespace CommandLine
         private CultureInfo parsingCulture;
         private bool enableDashDash;
         private int maximumDisplayWidth;
+        private bool allowMultiInstance;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ParserSettings"/> class.
@@ -172,6 +173,15 @@ namespace CommandLine
         {
             get { return maximumDisplayWidth; }
             set { maximumDisplayWidth = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether options are allowed to be specified multiple times.
+        /// </summary>
+        public bool AllowMultiInstance
+        {
+            get => allowMultiInstance;
+            set => PopsicleSetter.Set(Consumed, ref allowMultiInstance, value);
         }
 
         internal StringComparer NameComparer

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -856,6 +856,7 @@ namespace CommandLine.Text
                                       false,
                                       verbTuple.Item1.IsDefault?  "(Default Verb) "+verbTuple.Item1.HelpText: verbTuple.Item1.HelpText,  //Default verb
                                       string.Empty,
+                                      false,
                                       verbTuple.Item1.Hidden);
             if (autoHelp)
                 optionSpecs = optionSpecs.Concat(new[] { MakeHelpEntry() });
@@ -914,6 +915,7 @@ namespace CommandLine.Text
                 false,
                 sentenceBuilder.HelpCommandText(AddDashesToOption),
                 string.Empty,
+                false,
                 false);
         }
 
@@ -925,6 +927,7 @@ namespace CommandLine.Text
                 false,
                 sentenceBuilder.VersionCommandText(AddDashesToOption),
                 string.Empty,
+                false,
                 false);
         }
 

--- a/tests/CommandLine.Tests/Fakes/Options_With_FlagCounter_Switches.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_FlagCounter_Switches.cs
@@ -1,0 +1,13 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+namespace CommandLine.Tests.Fakes
+{
+    public class Options_With_FlagCounter_Switches
+    {
+        [Option('v', FlagCounter=true)]
+        public int Verbose { get; set; }
+
+        [Option('s', FlagCounter=true)]
+        public int Silent { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Fakes/Options_With_Option_Sequence_And_Value_Sequence.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_Option_Sequence_And_Value_Sequence.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace CommandLine.Tests.Fakes
+{
+    public class Options_With_Option_Sequence_And_Value_Sequence
+    {
+        [Option('o', "option-seq")]
+        public IEnumerable<string> OptionSequence { get; set; }
+
+        [Value(0)]
+        public IEnumerable<string> ValueSequence { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Fakes/Options_With_Value_Sequence_And_Subsequent_Value.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_Value_Sequence_And_Subsequent_Value.cs
@@ -1,0 +1,15 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace CommandLine.Tests.Fakes
+{
+    class Options_With_Value_Sequence_And_Subsequent_Value
+    {
+        [Value(0)]
+        public IEnumerable<string> StringSequence { get; set; }
+
+        [Value(1)]
+        public string NeverReachedValue { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Fakes/Options_With_Value_Sequence_With_Max_And_Subsequent_Value.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_Value_Sequence_With_Max_And_Subsequent_Value.cs
@@ -1,0 +1,15 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace CommandLine.Tests.Fakes
+{
+    class Options_With_Value_Sequence_With_Max_And_Subsequent_Value
+    {
+        [Value(0, Max=2)]
+        public IEnumerable<string> StringSequence { get; set; }
+
+        [Value(1)]
+        public string NeverReachedValue { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/AutoHelpTests.cs
+++ b/tests/CommandLine.Tests/Unit/AutoHelpTests.cs
@@ -128,7 +128,7 @@ namespace CommandLine.Tests.Unit
             var help = new StringWriter();
             var sut = new Parser(config => {
                 config.AutoHelp = true;
-                // config.AutoHelpShortName = true;  // Not implemented yet
+                config.AutoHelpShortName = true;
                 config.HelpWriter = help;
             });
 
@@ -172,7 +172,7 @@ namespace CommandLine.Tests.Unit
             var help = new StringWriter();
             var sut = new Parser(config => {
                 config.AutoHelp = true;
-                // config.AutoHelpShortName = true;  // Not implemented yet
+                config.AutoHelpShortName = true;
                 config.HelpWriter = help;
             });
 
@@ -221,7 +221,7 @@ namespace CommandLine.Tests.Unit
             var help = new StringWriter();
             var sut = new Parser(config => {
                 config.AutoHelp = true;
-                // config.AutoHelpShortName = true;  // Not implemented yet
+                config.AutoHelpShortName = true;
                 config.HelpWriter = help;
             });
 
@@ -250,7 +250,7 @@ namespace CommandLine.Tests.Unit
             var help = new StringWriter();
             var sut = new Parser(config => {
                 config.AutoHelp = true;
-                // config.AutoHelpShortName = true;  // Not implemented yet
+                config.AutoHelpShortName = true;
                 config.HelpWriter = help;
             });
 
@@ -299,7 +299,7 @@ namespace CommandLine.Tests.Unit
             var help = new StringWriter();
             var sut = new Parser(config => {
                 config.AutoHelp = true;
-                // config.AutoHelpShortName = true;  // Not implemented yet
+                config.AutoHelpShortName = true;
                 config.HelpWriter = help;
             });
 
@@ -343,7 +343,7 @@ namespace CommandLine.Tests.Unit
             var help = new StringWriter();
             var sut = new Parser(config => {
                 config.AutoHelp = true;
-                // config.AutoHelpShortName = true;  // Not implemented yet
+                config.AutoHelpShortName = true;
                 config.HelpWriter = help;
             });
 

--- a/tests/CommandLine.Tests/Unit/AutoHelpTests.cs
+++ b/tests/CommandLine.Tests/Unit/AutoHelpTests.cs
@@ -1,0 +1,364 @@
+using System;
+using Xunit;
+using FluentAssertions;
+using CommandLine.Core;
+using CommandLine.Tests.Fakes;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace CommandLine.Tests.Unit
+{
+    public class AutoHelpTests
+    {
+        public AutoHelpTests()
+        {
+        }
+
+        public static object[][] ValidArgsData = new []
+        {
+            new [] { "--help" },
+            new [] { "--help", "256" },
+            new [] { "--help", "--stringvalue", "foo" },
+            new [] { "--help", "--stringvalue=foo" },
+            new [] { "--stringvalue", "foo", "--help" },
+            new [] { "--stringvalue=foo", "--help" },
+            new [] { "--help", "--stringvalue", "foo", "-x" },
+            new [] { "--help", "--stringvalue=foo", "-x" },
+            new [] { "--stringvalue", "foo", "--help", "-x" },
+            new [] { "--stringvalue=foo", "--help", "-x" },
+            new [] { "--stringvalue", "foo", "-x", "256", "--help" },
+            new [] { "--stringvalue=foo", "-x", "256", "--help" },
+            new [] { "--stringvalue", "foo", "--help", "-x", "256" },
+            new [] { "--stringvalue=foo", "--help", "-x", "256" },
+            new [] { "--help", "--stringvalue", "foo", "-x", "256" },
+            new [] { "--help", "--stringvalue=foo", "-x", "256" },
+        };
+
+        public static object[][] InvalidArgsData = new []
+        {
+            new [] { "--help", "foo" },
+            new [] { "--help", "-s" },
+            new [] { "--help", "-i", "foo" },
+            new [] {"--help", "--invalid-switch", "foo" },
+            new [] {"--invalid-switch", "foo", "--help" },
+            new [] {"--invalid-switch", "--help", "foo" },
+        };
+
+        public static object[][] ConsumedDashDashHelpValidArgsData = new []
+        {
+            new [] { "--stringvalue", "--help" },
+            new [] { "--stringvalue=--help" },
+            new [] { "--stringvalue", "--help", "-s", "--help" },
+            new [] { "--stringvalue=--help", "-s", "--help" },
+            new [] { "--stringvalue", "--help", "-s--help" },
+            new [] { "--stringvalue=--help", "-s--help" },
+        };
+
+        public static object[][] MixOfConsumedAndUnconsumedDashDashHelpValidArgsData = new []
+        {
+            new [] { "--stringvalue", "--help", "--help" },
+            new [] { "--help", "--stringvalue", "--help" },
+            new [] { "--stringvalue=--help", "--help" },
+            new [] { "--help", "--stringvalue=--help" },
+            new [] { "--stringvalue", "--help", "-s", "--help", "--help" },
+            new [] { "--stringvalue", "--help", "--help", "-s", "--help" },
+            new [] { "--help", "--stringvalue", "--help", "-s", "--help" },
+            new [] { "--stringvalue=--help", "-s", "--help", "--help" },
+            new [] { "--stringvalue=--help", "--help", "-s", "--help" },
+            new [] { "--help", "--stringvalue=--help", "-s", "--help" },
+            new [] { "--stringvalue", "--help", "-s--help", "--help" },
+            new [] { "--stringvalue", "--help", "--help", "-s--help", "--help" },
+            new [] { "--help", "--stringvalue", "--help", "-s--help" },
+            new [] { "--stringvalue=--help", "-s--help", "--help" },
+            new [] { "--stringvalue=--help", "--help", "-s--help" },
+            new [] { "--help", "--stringvalue=--help", "-s--help" },
+        };
+
+        public static object[][] ConsumedDashDashHelpInvalidArgsData = new []
+        {
+            new [] { "--stringvalue", "--help", "foo" },
+            new [] { "-s", "--help", "--stringvalue" },
+            new [] { "-s", "--help", "-i", "foo" },
+            new [] { "--stringvalue", "--help", "--invalid-switch", "256" },
+            new [] { "--stringvalue=--help", "--invalid-switch", "256" },
+            new [] { "--invalid-switch", "-s", "--help" },
+        };
+
+        public static IEnumerable<object[]> ConvertDataToShortOption(object[][] data, string search, string replacement)
+        {
+            foreach (object[] row in data)
+            {
+                var strings = row as string[];
+                if (strings != null)
+                {
+                    yield return strings.Select(item => item.Replace(search, replacement)).ToArray();
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidArgsData))]
+        public void Explicit_help_command_with_valid_args_produces_just_one_HelpRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoHelp = true;
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<HelpRequestedError>();
+        }
+
+        public static IEnumerable<object[]> ValidArgsDataWithShortOption =
+            ConvertDataToShortOption(ValidArgsData, "--help", "-h");
+
+        [Theory]
+        [MemberData(nameof(ValidArgsDataWithShortOption))]
+        public void Explicit_help_command_with_valid_args_and_short_option_produces_just_one_HelpRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoHelp = true;
+                // config.AutoHelpShortName = true;  // Not implemented yet
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<HelpRequestedError>();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidArgsData))]
+        public void Explicit_help_command_with_invalid_args_produces_just_one_HelpRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoHelp = true;
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<HelpRequestedError>();
+        }
+
+        public static IEnumerable<object[]> InvalidArgsDataWithShortOption =
+            ConvertDataToShortOption(InvalidArgsData, "--help", "-h");
+
+        [Theory]
+        [MemberData(nameof(InvalidArgsDataWithShortOption))]
+        public void Explicit_help_command_with_invalid_args_and_short_option_produces_just_one_HelpRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoHelp = true;
+                // config.AutoHelpShortName = true;  // Not implemented yet
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<HelpRequestedError>();
+        }
+
+        [Theory]
+        [MemberData(nameof(ConsumedDashDashHelpValidArgsData))]
+        public void Dash_dash_help_in_a_string_value_does_not_produce_HelpRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoHelp = true;
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            // result.Should().BeOfType<NotParsed<Simple_Options>>();
+            // result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            // result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<HelpRequestedError>();
+            result.Should().BeOfType<Parsed<Simple_Options>>();
+            string stringValue = result.As<Parsed<Simple_Options>>().Value.StringValue;
+            string shortAndLong = result.As<Parsed<Simple_Options>>().Value.ShortAndLong;
+            stringValue.Should().Be("--help");
+            shortAndLong.Should().BeOneOf("--help", null, "");
+        }
+
+        public static IEnumerable<object[]> ConsumedDashDashHelpValidArgsDataWithShortOption =
+            ConvertDataToShortOption(ConsumedDashDashHelpValidArgsData, "--help", "-h");
+
+        [Theory]
+        [MemberData(nameof(ConsumedDashDashHelpValidArgsDataWithShortOption))]
+        public void Dash_dash_help_in_a_string_value_with_short_option_does_not_produce_HelpRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoHelp = true;
+                // config.AutoHelpShortName = true;  // Not implemented yet
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            // result.Should().BeOfType<NotParsed<Simple_Options>>();
+            // result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            // result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<HelpRequestedError>();
+            result.Should().BeOfType<Parsed<Simple_Options>>();
+            string stringValue = result.As<Parsed<Simple_Options>>().Value.StringValue;
+            string shortAndLong = result.As<Parsed<Simple_Options>>().Value.ShortAndLong;
+            stringValue.Should().Be("-h");
+            shortAndLong.Should().BeOneOf("-h", null, "");
+        }
+
+        public static IEnumerable<object[]> ConsumedDashDashHelpValidArgsDataWithShortOptionInData =
+            ConvertDataToShortOption(ConsumedDashDashHelpValidArgsData, "--help", "h");
+
+        [Theory]
+        [MemberData(nameof(ConsumedDashDashHelpValidArgsDataWithShortOptionInData))]
+        public void Dash_dash_help_in_a_string_value_with_short_option_in_data_does_not_produce_HelpRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoHelp = true;
+                // config.AutoHelpShortName = true;  // Not implemented yet
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            // result.Should().BeOfType<NotParsed<Simple_Options>>();
+            // result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            // result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<HelpRequestedError>();
+            result.Should().BeOfType<Parsed<Simple_Options>>();
+            string stringValue = result.As<Parsed<Simple_Options>>().Value.StringValue;
+            string shortAndLong = result.As<Parsed<Simple_Options>>().Value.ShortAndLong;
+            stringValue.Should().Be("h");
+            shortAndLong.Should().BeOneOf("h", null, "");
+        }
+
+        [Theory]
+        [MemberData(nameof(MixOfConsumedAndUnconsumedDashDashHelpValidArgsData))]
+        public void Explicit_help_command_mixed_with_some_consumed_args_produces_just_one_HelpRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoHelp = true;
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<HelpRequestedError>();
+        }
+
+        public static IEnumerable<object[]> MixOfConsumedAndUnconsumedDashDashHelpValidArgsDataWithShortOption =
+            ConvertDataToShortOption(MixOfConsumedAndUnconsumedDashDashHelpValidArgsData, "--help", "-h");
+
+        [Theory]
+        [MemberData(nameof(MixOfConsumedAndUnconsumedDashDashHelpValidArgsDataWithShortOption))]
+        public void Explicit_short_help_command_mixed_with_some_consumed_args_produces_just_one_HelpRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoHelp = true;
+                // config.AutoHelpShortName = true;  // Not implemented yet
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<HelpRequestedError>();
+        }
+
+        [Theory]
+        [MemberData(nameof(ConsumedDashDashHelpInvalidArgsData))]
+        public void Dash_dash_help_consumed_by_valid_args_with_invalid_args_produces_no_HelpRequestedErrors(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoHelp = true;
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCountGreaterOrEqualTo(1);
+            result.As<NotParsed<Simple_Options>>().Errors.Should().NotBeOfType<HelpRequestedError>();
+        }
+
+        public static IEnumerable<object[]> ConsumedDashDashHelpInvalidArgsDataWithShortOption =
+            ConvertDataToShortOption(ConsumedDashDashHelpInvalidArgsData, "--help", "-h");
+
+        [Theory]
+        [MemberData(nameof(ConsumedDashDashHelpInvalidArgsDataWithShortOption))]
+        public void Dash_h_consumed_by_valid_args_with_invalid_args_produces_no_HelpRequestedErrors(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoHelp = true;
+                // config.AutoHelpShortName = true;  // Not implemented yet
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCountGreaterOrEqualTo(1);
+            result.As<NotParsed<Simple_Options>>().Errors.Should().NotBeOfType<HelpRequestedError>();
+        }
+
+        // Then with AutoHelp = false, we'd have UnknownArgumentError("help"), which would NOT suppress other errors. So invalid inputs would have more than 1 error.
+
+        // TODO: Write tests for https://github.com/commandlineparser/commandline/issues/596 (ensure that UnknownArgumentError("help") is produced when AutoHelp=false)
+        // Also check help text output to make sure it contains "ERROR(S): (...) Option 'help' is unknown."
+    }
+}

--- a/tests/CommandLine.Tests/Unit/AutoVersionTests.cs
+++ b/tests/CommandLine.Tests/Unit/AutoVersionTests.cs
@@ -1,0 +1,359 @@
+using System;
+using Xunit;
+using FluentAssertions;
+using CommandLine.Core;
+using CommandLine.Tests.Fakes;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace CommandLine.Tests.Unit
+{
+    public class AutoVersionTests
+    {
+        public AutoVersionTests()
+        {
+        }
+
+        public static object[][] ValidArgsData = new []
+        {
+            new [] { "--version" },
+            new [] { "--version", "256" },
+            new [] { "--version", "--stringvalue", "foo" },
+            new [] { "--version", "--stringvalue=foo" },
+            new [] { "--stringvalue", "foo", "--version" },
+            new [] { "--stringvalue=foo", "--version" },
+            new [] { "--version", "--stringvalue", "foo", "-x" },
+            new [] { "--version", "--stringvalue=foo", "-x" },
+            new [] { "--stringvalue", "foo", "--version", "-x" },
+            new [] { "--stringvalue=foo", "--version", "-x" },
+            new [] { "--stringvalue", "foo", "-x", "256", "--version" },
+            new [] { "--stringvalue=foo", "-x", "256", "--version" },
+            new [] { "--stringvalue", "foo", "--version", "-x", "256" },
+            new [] { "--stringvalue=foo", "--version", "-x", "256" },
+            new [] { "--version", "--stringvalue", "foo", "-x", "256" },
+            new [] { "--version", "--stringvalue=foo", "-x", "256" },
+        };
+
+        public static object[][] InvalidArgsData = new []
+        {
+            new [] { "--version", "foo" },
+            new [] { "--version", "-s" },
+            new [] { "--version", "-i", "foo" },
+            new [] {"--version", "--invalid-switch", "foo" },
+            new [] {"--invalid-switch", "foo", "--version" },
+            new [] {"--invalid-switch", "--version", "foo" },
+        };
+
+        public static object[][] ConsumedDashDashHelpValidArgsData = new []
+        {
+            new [] { "--stringvalue", "--version" },
+            new [] { "--stringvalue=--version" },
+            new [] { "--stringvalue", "--version", "-s", "--version" },
+            new [] { "--stringvalue=--version", "-s", "--version" },
+            new [] { "--stringvalue", "--version", "-s--version" },
+            new [] { "--stringvalue=--version", "-s--version" },
+        };
+
+        public static object[][] MixOfConsumedAndUnconsumedDashDashHelpValidArgsData = new []
+        {
+            new [] { "--stringvalue", "--version", "--version" },
+            new [] { "--version", "--stringvalue", "--version" },
+            new [] { "--stringvalue=--version", "--version" },
+            new [] { "--version", "--stringvalue=--version" },
+            new [] { "--stringvalue", "--version", "-s", "--version", "--version" },
+            new [] { "--stringvalue", "--version", "--version", "-s", "--version" },
+            new [] { "--version", "--stringvalue", "--version", "-s", "--version" },
+            new [] { "--stringvalue=--version", "-s", "--version", "--version" },
+            new [] { "--stringvalue=--version", "--version", "-s", "--version" },
+            new [] { "--version", "--stringvalue=--version", "-s", "--version" },
+            new [] { "--stringvalue", "--version", "-s--version", "--version" },
+            new [] { "--stringvalue", "--version", "--version", "-s--version", "--version" },
+            new [] { "--version", "--stringvalue", "--version", "-s--version" },
+            new [] { "--stringvalue=--version", "-s--version", "--version" },
+            new [] { "--stringvalue=--version", "--version", "-s--version" },
+            new [] { "--version", "--stringvalue=--version", "-s--version" },
+        };
+
+        public static object[][] ConsumedDashDashHelpInvalidArgsData = new []
+        {
+            new [] { "--stringvalue", "--version", "foo" },
+            new [] { "-s", "--version", "--stringvalue" },
+            new [] { "-s", "--version", "-i", "foo" },
+            new [] { "--stringvalue", "--version", "--invalid-switch", "256" },
+            new [] { "--stringvalue=--version", "--invalid-switch", "256" },
+            new [] { "--invalid-switch", "-s", "--version" },
+        };
+
+        public static IEnumerable<object[]> ConvertDataToShortOption(object[][] data, string search, string replacement)
+        {
+            foreach (object[] row in data)
+            {
+                var strings = row as string[];
+                if (strings != null)
+                {
+                    yield return strings.Select(item => item.Replace(search, replacement)).ToArray();
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidArgsData))]
+        public void Explicit_version_command_with_valid_args_produces_just_one_VersionRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoVersion = true;
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<VersionRequestedError>();
+        }
+
+        public static IEnumerable<object[]> ValidArgsDataWithShortOption =
+            ConvertDataToShortOption(ValidArgsData, "--version", "-V");
+
+        [Theory]
+        [MemberData(nameof(ValidArgsDataWithShortOption))]
+        public void Explicit_version_command_with_valid_args_and_short_option_produces_just_one_VersionRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoVersion = true;
+                // config.AutoVersionShortName = true;  // Not implemented yet
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<VersionRequestedError>();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidArgsData))]
+        public void Explicit_version_command_with_invalid_args_produces_just_one_VersionRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoVersion = true;
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<VersionRequestedError>();
+        }
+
+        public static IEnumerable<object[]> InvalidArgsDataWithShortOption =
+            ConvertDataToShortOption(InvalidArgsData, "--version", "-V");
+
+        [Theory]
+        [MemberData(nameof(InvalidArgsDataWithShortOption))]
+        public void Explicit_version_command_with_invalid_args_and_short_option_produces_just_one_VersionRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoVersion = true;
+                // config.AutoVersionShortName = true;  // Not implemented yet
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<VersionRequestedError>();
+        }
+
+        [Theory]
+        [MemberData(nameof(ConsumedDashDashHelpValidArgsData))]
+        public void Dash_dash_help_in_a_string_value_does_not_produce_VersionRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoVersion = true;
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            // result.Should().BeOfType<NotParsed<Simple_Options>>();
+            // result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            // result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<VersionRequestedError>();
+            result.Should().BeOfType<Parsed<Simple_Options>>();
+            string stringValue = result.As<Parsed<Simple_Options>>().Value.StringValue;
+            string shortAndLong = result.As<Parsed<Simple_Options>>().Value.ShortAndLong;
+            stringValue.Should().Be("--version");
+            shortAndLong.Should().BeOneOf("--version", null, "");
+        }
+
+        public static IEnumerable<object[]> ConsumedDashDashHelpValidArgsDataWithShortOption =
+            ConvertDataToShortOption(ConsumedDashDashHelpValidArgsData, "--version", "-V");
+
+        [Theory]
+        [MemberData(nameof(ConsumedDashDashHelpValidArgsDataWithShortOption))]
+        public void Dash_dash_help_in_a_string_value_with_short_option_does_not_produce_VersionRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoVersion = true;
+                // config.AutoVersionShortName = true;  // Not implemented yet
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            // result.Should().BeOfType<NotParsed<Simple_Options>>();
+            // result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            // result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<VersionRequestedError>();
+            result.Should().BeOfType<Parsed<Simple_Options>>();
+            string stringValue = result.As<Parsed<Simple_Options>>().Value.StringValue;
+            string shortAndLong = result.As<Parsed<Simple_Options>>().Value.ShortAndLong;
+            stringValue.Should().Be("-V");
+            shortAndLong.Should().BeOneOf("-V", null, "");
+        }
+
+        public static IEnumerable<object[]> ConsumedDashDashHelpValidArgsDataWithShortOptionInData =
+            ConvertDataToShortOption(ConsumedDashDashHelpValidArgsData, "--version", "h");
+
+        [Theory]
+        [MemberData(nameof(ConsumedDashDashHelpValidArgsDataWithShortOptionInData))]
+        public void Dash_dash_help_in_a_string_value_with_short_option_in_data_does_not_produce_VersionRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoVersion = true;
+                // config.AutoVersionShortName = true;  // Not implemented yet
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            // result.Should().BeOfType<NotParsed<Simple_Options>>();
+            // result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            // result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<VersionRequestedError>();
+            result.Should().BeOfType<Parsed<Simple_Options>>();
+            string stringValue = result.As<Parsed<Simple_Options>>().Value.StringValue;
+            string shortAndLong = result.As<Parsed<Simple_Options>>().Value.ShortAndLong;
+            stringValue.Should().Be("h");
+            shortAndLong.Should().BeOneOf("h", null, "");
+        }
+
+        [Theory]
+        [MemberData(nameof(MixOfConsumedAndUnconsumedDashDashHelpValidArgsData))]
+        public void Explicit_version_command_mixed_with_some_consumed_args_produces_just_one_VersionRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoVersion = true;
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<VersionRequestedError>();
+        }
+
+        public static IEnumerable<object[]> MixOfConsumedAndUnconsumedDashDashHelpValidArgsDataWithShortOption =
+            ConvertDataToShortOption(MixOfConsumedAndUnconsumedDashDashHelpValidArgsData, "--version", "-V");
+
+        [Theory]
+        [MemberData(nameof(MixOfConsumedAndUnconsumedDashDashHelpValidArgsDataWithShortOption))]
+        public void Explicit_short_version_command_mixed_with_some_consumed_args_produces_just_one_VersionRequestedError(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoVersion = true;
+                // config.AutoVersionShortName = true;  // Not implemented yet
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCount(x => x == 1);
+            result.As<NotParsed<Simple_Options>>().Errors.First().Should().BeOfType<VersionRequestedError>();
+        }
+
+        [Theory]
+        [MemberData(nameof(ConsumedDashDashHelpInvalidArgsData))]
+        public void Dash_dash_help_consumed_by_valid_args_with_invalid_args_produces_no_VersionRequestedErrors(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoVersion = true;
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCountGreaterOrEqualTo(1);
+            result.As<NotParsed<Simple_Options>>().Errors.Should().NotBeOfType<VersionRequestedError>();
+        }
+
+        public static IEnumerable<object[]> ConsumedDashDashHelpInvalidArgsDataWithShortOption =
+            ConvertDataToShortOption(ConsumedDashDashHelpInvalidArgsData, "--version", "-V");
+
+        [Theory]
+        [MemberData(nameof(ConsumedDashDashHelpInvalidArgsDataWithShortOption))]
+        public void Dash_h_consumed_by_valid_args_with_invalid_args_produces_no_VersionRequestedErrors(params string[] args)
+        {
+            // Arrange
+            var help = new StringWriter();
+            var sut = new Parser(config => {
+                config.AutoVersion = true;
+                // config.AutoVersionShortName = true;  // Not implemented yet
+                config.HelpWriter = help;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options>(args);
+
+            // Assert
+            result.Should().BeOfType<NotParsed<Simple_Options>>();
+            result.As<NotParsed<Simple_Options>>().Errors.Should().HaveCountGreaterOrEqualTo(1);
+            result.As<NotParsed<Simple_Options>>().Errors.Should().NotBeOfType<VersionRequestedError>();
+        }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/AutoVersionTests.cs
+++ b/tests/CommandLine.Tests/Unit/AutoVersionTests.cs
@@ -128,7 +128,7 @@ namespace CommandLine.Tests.Unit
             var help = new StringWriter();
             var sut = new Parser(config => {
                 config.AutoVersion = true;
-                // config.AutoVersionShortName = true;  // Not implemented yet
+                config.AutoVersionShortName = true;
                 config.HelpWriter = help;
             });
 
@@ -172,7 +172,7 @@ namespace CommandLine.Tests.Unit
             var help = new StringWriter();
             var sut = new Parser(config => {
                 config.AutoVersion = true;
-                // config.AutoVersionShortName = true;  // Not implemented yet
+                config.AutoVersionShortName = true;
                 config.HelpWriter = help;
             });
 
@@ -221,7 +221,7 @@ namespace CommandLine.Tests.Unit
             var help = new StringWriter();
             var sut = new Parser(config => {
                 config.AutoVersion = true;
-                // config.AutoVersionShortName = true;  // Not implemented yet
+                config.AutoVersionShortName = true;
                 config.HelpWriter = help;
             });
 
@@ -250,7 +250,7 @@ namespace CommandLine.Tests.Unit
             var help = new StringWriter();
             var sut = new Parser(config => {
                 config.AutoVersion = true;
-                // config.AutoVersionShortName = true;  // Not implemented yet
+                config.AutoVersionShortName = true;
                 config.HelpWriter = help;
             });
 
@@ -299,7 +299,7 @@ namespace CommandLine.Tests.Unit
             var help = new StringWriter();
             var sut = new Parser(config => {
                 config.AutoVersion = true;
-                // config.AutoVersionShortName = true;  // Not implemented yet
+                config.AutoVersionShortName = true;
                 config.HelpWriter = help;
             });
 
@@ -343,7 +343,7 @@ namespace CommandLine.Tests.Unit
             var help = new StringWriter();
             var sut = new Parser(config => {
                 config.AutoVersion = true;
-                // config.AutoVersionShortName = true;  // Not implemented yet
+                config.AutoVersionShortName = true;
                 config.HelpWriter = help;
             });
 

--- a/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
@@ -19,7 +19,10 @@ namespace CommandLine.Tests.Unit.Core
 {
     public class InstanceBuilderTests
     {
-        private static ParserResult<T> InvokeBuild<T>(string[] arguments, bool autoHelp = true, bool autoVersion = true, bool multiInstance = false)
+        private static ParserResult<T> InvokeBuild<T>(string[] arguments,
+                                                      bool autoHelp = true, bool autoHelpShortName = false,
+                                                      bool autoVersion = true, bool autoVersionShortName = false,
+                                                      bool multiInstance = false)
             where T : new()
         {
             return InstanceBuilder.Build(
@@ -30,7 +33,9 @@ namespace CommandLine.Tests.Unit.Core
                 false,
                 CultureInfo.InvariantCulture,
                 autoHelp,
+                autoHelpShortName,
                 autoVersion,
+                autoVersionShortName,
                 multiInstance,
                 Enumerable.Empty<ErrorType>());
         }

--- a/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
@@ -408,12 +408,10 @@ namespace CommandLine.Tests.Unit.Core
             };
             var arguments = new[] { "--stringvalue", "str1", "--", "10", "-a", "--bee", "-c", "20" };
 
-            // Exercize system 
+            // Exercize system
             var result = InstanceBuilder.Build(
                 Maybe.Just<Func<Simple_Options_With_Values>>(() => new Simple_Options_With_Values()),
-                (a, optionSpecs) =>
-                    Tokenizer.PreprocessDashDash(a,
-                        args => Tokenizer.Tokenize(args, name => NameLookup.Contains(name, optionSpecs, StringComparer.Ordinal))),
+                (args, optionSpecs) => Tokenizer.ConfigureTokenizer(StringComparer.Ordinal, false, true)(args, optionSpecs),
                 arguments,
                 StringComparer.Ordinal,
                 false,

--- a/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
@@ -19,7 +19,7 @@ namespace CommandLine.Tests.Unit.Core
 {
     public class InstanceBuilderTests
     {
-        private static ParserResult<T> InvokeBuild<T>(string[] arguments, bool autoHelp = true, bool autoVersion = true)
+        private static ParserResult<T> InvokeBuild<T>(string[] arguments, bool autoHelp = true, bool autoVersion = true, bool multiInstance = false)
             where T : new()
         {
             return InstanceBuilder.Build(
@@ -31,6 +31,7 @@ namespace CommandLine.Tests.Unit.Core
                 CultureInfo.InvariantCulture,
                 autoHelp,
                 autoVersion,
+                multiInstance,
                 Enumerable.Empty<ErrorType>());
         }
 
@@ -1233,6 +1234,17 @@ namespace CommandLine.Tests.Unit.Core
             var errors = ((NotParsed<Simple_Options_With_OptionGroup_MutuallyExclusiveSet>)result).Errors;
 
             errors.Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Fact]
+        public void Parse_int_sequence_with_multi_instance()
+        {
+            var expected = new[] { 1, 2, 3 };
+            var result = InvokeBuild<Options_With_Sequence>(
+                new[] { "--int-seq", "1", "2", "--int-seq", "3" },
+                multiInstance: true);
+
+            ((Parsed<Options_With_Sequence>)result).Value.IntSequence.Should().BeEquivalentTo(expected);
         }
 
         #region custom types 

--- a/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
@@ -15,7 +15,8 @@ namespace CommandLine.Tests.Unit.Core
     {
         private static ParserResult<object> InvokeChoose(
             IEnumerable<Type> types,
-            IEnumerable<string> arguments)
+            IEnumerable<string> arguments,
+            bool multiInstance = false)
         {
             return InstanceChooser.Choose(
                 (args, optionSpecs) => Tokenizer.ConfigureTokenizer(StringComparer.Ordinal, false, false)(args, optionSpecs),
@@ -26,6 +27,7 @@ namespace CommandLine.Tests.Unit.Core
                 CultureInfo.InvariantCulture,
                 true,
                 true,
+                multiInstance,
                 Enumerable.Empty<ErrorType>());
         }
 
@@ -167,6 +169,19 @@ namespace CommandLine.Tests.Unit.Core
             Assert.IsType<SequenceOptions>(((Parsed<object>)result).Value);
             expected.Should().BeEquivalentTo(((Parsed<object>)result).Value);
             // Teardown
+        }
+
+        [Fact]
+        public void Parse_sequence_verb_with_multi_instance_returns_verb_instance()
+        {
+            var expected = new SequenceOptions { LongSequence = new long[] { }, StringSequence = new[] { "s1", "s2" } };
+            var result = InvokeChoose(
+                new[] { typeof(Add_Verb), typeof(Commit_Verb), typeof(Clone_Verb), typeof(SequenceOptions) },
+                new[] { "sequence", "-s", "s1", "-s", "s2" },
+                true);
+
+            Assert.IsType<SequenceOptions>(((Parsed<object>)result).Value);
+            expected.Should().BeEquivalentTo(((Parsed<object>)result).Value);
         }
     }
 }

--- a/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
@@ -26,7 +26,9 @@ namespace CommandLine.Tests.Unit.Core
                 false,
                 CultureInfo.InvariantCulture,
                 true,
+                false,
                 true,
+                false,
                 multiInstance,
                 Enumerable.Empty<ErrorType>());
         }

--- a/tests/CommandLine.Tests/Unit/Core/NameLookupTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/NameLookupTests.cs
@@ -17,7 +17,7 @@ namespace CommandLine.Tests.Unit.Core
             // Fixture setup
             var expected = Maybe.Just(".");
             var specs = new[] { new OptionSpecification(string.Empty, "string-seq",
-                false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '.', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty)};
+                false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '.', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty, flagCounter:false, hidden:false)};
 
             // Exercize system
             var result = NameLookup.HavingSeparator("string-seq", specs, StringComparer.Ordinal);
@@ -35,7 +35,7 @@ namespace CommandLine.Tests.Unit.Core
 
             // Fixture setup
             var expected = new NameInfo(ShortName, LongName);
-            var spec = new OptionSpecification(ShortName, LongName, false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '.', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty);
+            var spec = new OptionSpecification(ShortName, LongName, false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '.', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty, flagCounter:false, hidden:false);
 
             // Exercize system
             var result = spec.FromOptionSpecification();

--- a/tests/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
@@ -28,7 +28,7 @@ namespace CommandLine.Tests.Unit.Core
             var specProps = new[]
                 {
                     SpecificationProperty.Create(
-                        new OptionSpecification("x", string.Empty, false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(bool), TargetType.Switch, string.Empty),
+                        new OptionSpecification("x", string.Empty, false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(bool), TargetType.Switch, string.Empty, flagCounter: false, hidden:false),
                         typeof(Simple_Options).GetProperties().Single(p => p.Name.Equals("BoolValue", StringComparison.Ordinal)),
                         Maybe.Nothing<object>())
                 };
@@ -64,7 +64,7 @@ namespace CommandLine.Tests.Unit.Core
             var specProps = new[]
             {
                 SpecificationProperty.Create(
-                    new OptionSpecification("s", "shortandlong", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(string), TargetType.Scalar, string.Empty),
+                    new OptionSpecification("s", "shortandlong", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(string), TargetType.Scalar, string.Empty, flagCounter: false, hidden:false),
                     typeof(Simple_Options).GetProperties().Single(p => p.Name.Equals(nameof(Simple_Options.ShortAndLong), StringComparison.Ordinal)),
                     Maybe.Nothing<object>()),
             };
@@ -93,7 +93,7 @@ namespace CommandLine.Tests.Unit.Core
             var specProps = new[]
             {
                 SpecificationProperty.Create(
-                    new OptionSpecification("i", string.Empty, false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<int>), TargetType.Sequence, string.Empty),
+                    new OptionSpecification("i", string.Empty, false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<int>), TargetType.Sequence, string.Empty, flagCounter: false, hidden:false),
                     typeof(Simple_Options).GetProperties().Single(p => p.Name.Equals(nameof(Simple_Options.IntSequence), StringComparison.Ordinal)),
                     Maybe.Nothing<object>())
             };

--- a/tests/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
@@ -37,7 +37,7 @@ namespace CommandLine.Tests.Unit.Core
             var result = OptionMapper.MapValues(
                 specProps.Where(pt => pt.Specification.IsOption()),
                 tokenPartitions,
-                (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, CultureInfo.InvariantCulture, false),
+                (vals, type, isScalar, isFlag) => TypeConverter.ChangeType(vals, type, isScalar, isFlag, CultureInfo.InvariantCulture, false),
                 StringComparer.Ordinal
                 );
 
@@ -72,7 +72,7 @@ namespace CommandLine.Tests.Unit.Core
             var result = OptionMapper.MapValues(
                 specProps.Where(pt => pt.Specification.IsOption()),
                 tokenPartitions,
-                (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, CultureInfo.InvariantCulture, false),
+                (vals, type, isScalar, isFlag) => TypeConverter.ChangeType(vals, type, isScalar, isFlag, CultureInfo.InvariantCulture, false),
                 StringComparer.Ordinal);
 
             var property = result.SucceededWith().Single();
@@ -101,7 +101,7 @@ namespace CommandLine.Tests.Unit.Core
             var result = OptionMapper.MapValues(
                 specProps.Where(pt => pt.Specification.IsOption()),
                 tokenPartitions,
-                (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, CultureInfo.InvariantCulture, false),
+                (vals, type, isScalar, isFlag) => TypeConverter.ChangeType(vals, type, isScalar, isFlag, CultureInfo.InvariantCulture, false),
                 StringComparer.Ordinal);
 
             var property = result.SucceededWith().Single();

--- a/tests/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
@@ -49,5 +49,67 @@ namespace CommandLine.Tests.Unit.Core
 
             // Teardown
         }
+
+        [Fact]
+        public void Map_with_multi_instance_scalar()
+        {
+            var tokenPartitions = new[]
+            {
+                new KeyValuePair<string, IEnumerable<string>>("s", new[] { "string1" }),
+                new KeyValuePair<string, IEnumerable<string>>("shortandlong", new[] { "string2" }),
+                new KeyValuePair<string, IEnumerable<string>>("shortandlong", new[] { "string3" }),
+                new KeyValuePair<string, IEnumerable<string>>("s", new[] { "string4" }),
+            };
+
+            var specProps = new[]
+            {
+                SpecificationProperty.Create(
+                    new OptionSpecification("s", "shortandlong", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(string), TargetType.Scalar, string.Empty),
+                    typeof(Simple_Options).GetProperties().Single(p => p.Name.Equals(nameof(Simple_Options.ShortAndLong), StringComparison.Ordinal)),
+                    Maybe.Nothing<object>()),
+            };
+
+            var result = OptionMapper.MapValues(
+                specProps.Where(pt => pt.Specification.IsOption()),
+                tokenPartitions,
+                (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, CultureInfo.InvariantCulture, false),
+                StringComparer.Ordinal);
+
+            var property = result.SucceededWith().Single();
+            Assert.True(property.Specification.IsOption());
+            Assert.True(property.Value.MatchJust(out var stringVal));
+            Assert.Equal(tokenPartitions.Last().Value.Last(), stringVal);
+        }
+
+        [Fact]
+        public void Map_with_multi_instance_sequence()
+        {
+            var tokenPartitions = new[]
+            {
+                new KeyValuePair<string, IEnumerable<string>>("i", new [] { "1", "2" }),
+                new KeyValuePair<string, IEnumerable<string>>("i", new [] { "3" }),
+                new KeyValuePair<string, IEnumerable<string>>("i", new [] { "4", "5" }),
+            };
+            var specProps = new[]
+            {
+                SpecificationProperty.Create(
+                    new OptionSpecification("i", string.Empty, false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<int>), TargetType.Sequence, string.Empty),
+                    typeof(Simple_Options).GetProperties().Single(p => p.Name.Equals(nameof(Simple_Options.IntSequence), StringComparison.Ordinal)),
+                    Maybe.Nothing<object>())
+            };
+
+            var result = OptionMapper.MapValues(
+                specProps.Where(pt => pt.Specification.IsOption()),
+                tokenPartitions,
+                (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, CultureInfo.InvariantCulture, false),
+                StringComparer.Ordinal);
+
+            var property = result.SucceededWith().Single();
+            Assert.True(property.Specification.IsOption());
+            Assert.True(property.Value.MatchJust(out var sequence));
+
+            var expected = tokenPartitions.Aggregate(Enumerable.Empty<int>(), (prev, part) => prev.Concat(part.Value.Select(i => int.Parse(i))));
+            Assert.Equal(expected, sequence);
+        }
     }
 }

--- a/tests/CommandLine.Tests/Unit/Core/SequenceTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/SequenceTests.cs
@@ -49,7 +49,7 @@ namespace CommandLine.Tests.Unit.Core
         }
 
         [Fact]
-        public void Partition_sequence_values_from_two_sequneces()
+        public void Partition_sequence_values_from_two_sequences()
         {
             var expected = new[]
                 {
@@ -92,6 +92,68 @@ namespace CommandLine.Tests.Unit.Core
                         : Maybe.Nothing<TypeDescriptor>());
 
             expected.Should().BeEquivalentTo(result);
+        }
+
+        [Fact]
+        public void Partition_sequence_multi_instance()
+        {
+            var expected = new[]
+            {
+                Token.Name("seq"),
+                Token.Value("seqval0"),
+                Token.Value("seqval1"),
+                Token.Value("seqval2"),
+                Token.Value("seqval3"),
+                Token.Value("seqval4"),
+            };
+
+            var result = Sequence.Partition(
+                new[]
+                {
+                    Token.Name("str"), Token.Value("strvalue"), Token.Value("freevalue"),
+                    Token.Name("seq"), Token.Value("seqval0"), Token.Value("seqval1"),
+                    Token.Name("x"), Token.Value("freevalue2"),
+                    Token.Name("seq"), Token.Value("seqval2"), Token.Value("seqval3"),
+                    Token.Name("seq"), Token.Value("seqval4")
+                },
+                name =>
+                    new[] { "seq" }.Contains(name)
+                        ? Maybe.Just(TypeDescriptor.Create(TargetType.Sequence, Maybe.Nothing<int>()))
+                        : Maybe.Nothing<TypeDescriptor>());
+
+            var actual = result.ToArray();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Partition_sequence_multi_instance_with_max()
+        {
+            var expected = new[]
+            {
+                Token.Name("seq"),
+                Token.Value("seqval0"),
+                Token.Value("seqval1"),
+                Token.Value("seqval2"),
+                Token.Value("seqval3"),
+                Token.Value("seqval4"),
+                Token.Value("seqval5"),
+            };
+
+            var result = Sequence.Partition(
+                new[]
+                {
+                    Token.Name("str"), Token.Value("strvalue"), Token.Value("freevalue"),
+                    Token.Name("seq"), Token.Value("seqval0"), Token.Value("seqval1"),
+                    Token.Name("x"), Token.Value("freevalue2"),
+                    Token.Name("seq"), Token.Value("seqval2"), Token.Value("seqval3"),
+                    Token.Name("seq"), Token.Value("seqval4"), Token.Value("seqval5"),
+                },
+                name =>
+                    new[] { "seq" }.Contains(name)
+                        ? Maybe.Just(TypeDescriptor.Create(TargetType.Sequence, Maybe.Just<int>(3)))
+                        : Maybe.Nothing<TypeDescriptor>());
+
+            Assert.Equal(expected, result);
         }
     }
 }

--- a/tests/CommandLine.Tests/Unit/Core/SpecificationPropertyRulesTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/SpecificationPropertyRulesTests.cs
@@ -1,0 +1,58 @@
+﻿using CommandLine.Core;
+using CommandLine.Tests.Fakes;
+using CSharpx;
+using System.Collections.Generic;
+using Xunit;
+
+namespace CommandLine.Tests.Unit.Core
+{
+
+    public class SpecificationPropertyRulesTests
+    {
+        [Fact]
+        public void Lookup_allows_multi_instance()
+        {
+            var tokens = new[]
+            {
+                Token.Name("name"),
+                Token.Value("value"),
+                Token.Name("name"),
+                Token.Value("value2"),
+            };
+
+            var specProps = new[]
+            {
+                SpecificationProperty.Create(
+                    new OptionSpecification(string.Empty, "name", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty),
+                    typeof(SequenceOptions).GetProperty(nameof(SequenceOptions.StringSequence)),
+                    Maybe.Just(new object())),
+            };
+
+            var results = specProps.Validate(SpecificationPropertyRules.Lookup(tokens, true));
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public void Lookup_fails_with_repeated_options_false_multi_instance()
+        {
+            var tokens = new[]
+            {
+                Token.Name("name"),
+                Token.Value("value"),
+                Token.Name("name"),
+                Token.Value("value2"),
+            };
+
+            var specProps = new[]
+            {
+                SpecificationProperty.Create(
+                    new OptionSpecification(string.Empty, "name", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty),
+                    typeof(SequenceOptions).GetProperty(nameof(SequenceOptions.StringSequence)),
+                    Maybe.Just(new object())),
+            };
+
+            var results = specProps.Validate(SpecificationPropertyRules.Lookup(tokens, false));
+            Assert.Contains(results, r => r.GetType() == typeof(RepeatedOptionError));
+        }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/Core/SpecificationPropertyRulesTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/SpecificationPropertyRulesTests.cs
@@ -23,7 +23,7 @@ namespace CommandLine.Tests.Unit.Core
             var specProps = new[]
             {
                 SpecificationProperty.Create(
-                    new OptionSpecification(string.Empty, "name", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty),
+                    new OptionSpecification(string.Empty, "name", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty, flagCounter: false, hidden:false),
                     typeof(SequenceOptions).GetProperty(nameof(SequenceOptions.StringSequence)),
                     Maybe.Just(new object())),
             };
@@ -46,7 +46,7 @@ namespace CommandLine.Tests.Unit.Core
             var specProps = new[]
             {
                 SpecificationProperty.Create(
-                    new OptionSpecification(string.Empty, "name", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty),
+                    new OptionSpecification(string.Empty, "name", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty, flagCounter: false, hidden:false),
                     typeof(SequenceOptions).GetProperty(nameof(SequenceOptions.StringSequence)),
                     Maybe.Just(new object())),
             };

--- a/tests/CommandLine.Tests/Unit/Core/TokenPartitionerTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TokenPartitionerTests.cs
@@ -21,8 +21,8 @@ namespace CommandLine.Tests.Unit.Core
                 };
             var specs = new[]
                 {
-                    new OptionSpecification(string.Empty, "stringvalue", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', null, string.Empty, string.Empty, new List<string>(), typeof(string), TargetType.Scalar, string.Empty),
-                    new OptionSpecification("i", string.Empty, false, string.Empty, Maybe.Just(3), Maybe.Just(4), '\0', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<int>), TargetType.Sequence, string.Empty)
+                    new OptionSpecification(string.Empty, "stringvalue", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', null, string.Empty, string.Empty, new List<string>(), typeof(string), TargetType.Scalar, string.Empty, flagCounter: false, hidden:false),
+                    new OptionSpecification("i", string.Empty, false, string.Empty, Maybe.Just(3), Maybe.Just(4), '\0', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<int>), TargetType.Sequence, string.Empty, flagCounter: false, hidden:false)
                 };
 
             // Exercize system 
@@ -48,8 +48,8 @@ namespace CommandLine.Tests.Unit.Core
                 };
             var specs = new[]
                 {
-                    new OptionSpecification(string.Empty, "stringvalue", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', null, string.Empty, string.Empty, new List<string>(), typeof(string), TargetType.Scalar, string.Empty),
-                    new OptionSpecification("i", string.Empty, false, string.Empty, Maybe.Just(3), Maybe.Just(4), '\0', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<int>), TargetType.Sequence, string.Empty)
+                    new OptionSpecification(string.Empty, "stringvalue", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', null, string.Empty, string.Empty, new List<string>(), typeof(string), TargetType.Scalar, string.Empty, flagCounter: false, hidden:false),
+                    new OptionSpecification("i", string.Empty, false, string.Empty, Maybe.Just(3), Maybe.Just(4), '\0', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<int>), TargetType.Sequence, string.Empty, flagCounter:false, hidden:false)
                 };
 
             // Exercize system 

--- a/tests/CommandLine.Tests/Unit/Core/TokenizerTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TokenizerTests.cs
@@ -21,7 +21,7 @@ namespace CommandLine.Tests.Unit.Core
             var expectedTokens = new[] { Token.Name("i"), Token.Value("10"), Token.Name("string-seq"),
                 Token.Value("aaa"), Token.Value("bb"),  Token.Value("cccc"), Token.Name("switch") };
             var specs = new[] { new OptionSpecification(string.Empty, "string-seq",
-                false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), ',', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty)};
+                false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), ',', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty, flagCounter: false, hidden:false)};
 
             // Exercize system
             var result =
@@ -44,7 +44,7 @@ namespace CommandLine.Tests.Unit.Core
             var expectedTokens = new[] { Token.Name("x"), Token.Name("string-seq"),
                 Token.Value("aaa"), Token.Value("bb"),  Token.Value("cccc"), Token.Name("switch") };
             var specs = new[] { new OptionSpecification(string.Empty, "string-seq",
-                false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), ',', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty)};
+                false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), ',', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty, flagCounter: false, hidden:false)};
 
             // Exercize system
             var result =

--- a/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
@@ -20,7 +20,7 @@ namespace CommandLine.Tests.Unit.Core
         [MemberData(nameof(ChangeType_scalars_source))]
         public void ChangeType_scalars(string testValue, Type destinationType, bool expectFail, object expectedResult)
         {
-            Maybe<object> result = TypeConverter.ChangeType(new[] {testValue}, destinationType, true, CultureInfo.InvariantCulture, true);
+            Maybe<object> result = TypeConverter.ChangeType(new[] {testValue}, destinationType, true, false, CultureInfo.InvariantCulture, true);
 
             if (expectFail)
             {
@@ -37,11 +37,13 @@ namespace CommandLine.Tests.Unit.Core
         public void ChangeType_Scalar_LastOneWins()
         {
             var values = new[] { "100", "200", "300", "400", "500" };
-            var result = TypeConverter.ChangeType(values, typeof(int), true, CultureInfo.InvariantCulture, true);
+            var result = TypeConverter.ChangeType(values, typeof(int), true, false, CultureInfo.InvariantCulture, true);
             result.MatchJust(out var matchedValue).Should().BeTrue("should parse successfully");
             Assert.Equal(500, matchedValue);
 
         }
+
+        // TODO: Write test for TypeConverter.ChangeType when isFlag = true
 
         public static IEnumerable<object[]> ChangeType_scalars_source
         {

--- a/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
@@ -33,6 +33,16 @@ namespace CommandLine.Tests.Unit.Core
             }
         }
 
+        [Fact]
+        public void ChangeType_Scalar_LastOneWins()
+        {
+            var values = new[] { "100", "200", "300", "400", "500" };
+            var result = TypeConverter.ChangeType(values, typeof(int), true, CultureInfo.InvariantCulture, true);
+            result.MatchJust(out var matchedValue).Should().BeTrue("should parse successfully");
+            Assert.Equal(500, matchedValue);
+
+        }
+
         public static IEnumerable<object[]> ChangeType_scalars_source
         {
             get

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -95,6 +95,36 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
+        [Theory]
+        [InlineData(new string[0], 0, 0)]
+        [InlineData(new[] { "-v" }, 1, 0)]
+        [InlineData(new[] { "-vv" }, 2, 0)]
+        [InlineData(new[] { "-v", "-v" }, 2, 0)]
+        [InlineData(new[] { "-v", "-v", "-v" }, 3, 0)]
+        [InlineData(new[] { "-v", "-vv" }, 3, 0)]
+        [InlineData(new[] { "-vv", "-v" }, 3, 0)]
+        [InlineData(new[] { "-vvv" }, 3, 0)]
+        [InlineData(new[] { "-v", "-s", "-v", "-v" }, 3, 1)]
+        [InlineData(new[] { "-v", "-ss", "-v", "-v" }, 3, 2)]
+        [InlineData(new[] { "-v", "-s", "-sv", "-v" }, 3, 2)]
+        [InlineData(new[] { "-vsvv" }, 3, 1)]
+        [InlineData(new[] { "-vssvv" }, 3, 2)]
+        [InlineData(new[] { "-vsvsv" }, 3, 2)]
+        public void Parse_FlagCounter_options_with_short_name(string[] args, int verboseCount, int silentCount)
+        {
+            // Fixture setup
+            var expectedOptions = new Options_With_FlagCounter_Switches { Verbose = verboseCount, Silent = silentCount };
+            var sut = new Parser(with => with.AllowMultiInstance = true);
+
+            // Exercize system
+            var result = sut.ParseArguments<Options_With_FlagCounter_Switches>(args);
+
+            // Verify outcome
+            // ((NotParsed<Options_With_FlagCounter_Switches>)result).Errors.Should().BeEmpty();
+            ((Parsed<Options_With_FlagCounter_Switches>)result).Value.Should().BeEquivalentTo(expectedOptions);
+            // Teardown
+        }
+
         [Fact]
         public void Parse_repeated_options_with_default_parser()
         {

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -813,14 +813,12 @@ namespace CommandLine.Tests.Unit
             var lines = result.ToNotEmptyLines().TrimStringArray();
             lines[0].Should().Be(HeadingInfo.Default.ToString());
             lines[1].Should().Be(CopyrightInfo.Default.ToString());
-            lines[2].Should().BeEquivalentTo("ERROR(S):");
-            lines[3].Should().BeEquivalentTo("Option 'bad-arg' is unknown.");
-            lines[4].Should().BeEquivalentTo("--no-hardlinks    Optimize the cloning process from a repository on a local");
-            lines[5].Should().BeEquivalentTo("filesystem by copying files.");
-            lines[6].Should().BeEquivalentTo("-q, --quiet       Suppress summary message.");
-            lines[7].Should().BeEquivalentTo("--help            Display this help screen.");
-            lines[8].Should().BeEquivalentTo("--version         Display version information.");
-            lines[9].Should().BeEquivalentTo("value pos. 0");
+            lines[2].Should().BeEquivalentTo("--no-hardlinks    Optimize the cloning process from a repository on a local");
+            lines[3].Should().BeEquivalentTo("filesystem by copying files.");
+            lines[4].Should().BeEquivalentTo("-q, --quiet       Suppress summary message.");
+            lines[5].Should().BeEquivalentTo("--help            Display this help screen.");
+            lines[6].Should().BeEquivalentTo("--version         Display version information.");
+            lines[7].Should().BeEquivalentTo("value pos. 0");
 
             // Teardown
         }

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -133,6 +133,26 @@ namespace CommandLine.Tests.Unit
         }
 
         [Fact]
+        public void Parse_options_with_double_dash_and_option_sequence()
+        {
+            var expectedOptions = new Options_With_Option_Sequence_And_Value_Sequence
+            {
+                OptionSequence = new[] { "option1", "option2", "option3" },
+                ValueSequence = new[] { "value1", "value2", "value3" }
+            };
+
+            var sut = new Parser(with => with.EnableDashDash = true);
+
+            // Exercize system
+            var result =
+                sut.ParseArguments<Options_With_Option_Sequence_And_Value_Sequence>(
+                    new[] { "--option-seq", "option1", "option2", "option3", "--", "value1", "value2", "value3" });
+
+            // Verify outcome
+            ((Parsed<Options_With_Option_Sequence_And_Value_Sequence>)result).Value.Should().BeEquivalentTo(expectedOptions);
+        }
+
+        [Fact]
         public void Parse_options_with_double_dash_in_verbs_scenario()
         {
             // Fixture setup

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -152,6 +152,77 @@ namespace CommandLine.Tests.Unit
             ((Parsed<Options_With_Option_Sequence_And_Value_Sequence>)result).Value.Should().BeEquivalentTo(expectedOptions);
         }
 
+        [Theory]
+        [InlineData("value1", "value2", "value3")]
+        [InlineData("--", "value1", "value2", "value3")]
+        [InlineData("value1", "--", "value2", "value3")]
+        [InlineData("value1", "value2", "--", "value3")]
+        [InlineData("value1", "value2", "value3", "--")]
+        public void Parse_options_with_double_dash_in_various_positions(params string[] args)
+        {
+            var expectedOptions = new Options_With_Sequence_And_Only_Max_Constraint_For_Value
+            {
+                StringSequence = new[] { "value1", "value2", "value3" }
+            };
+
+            var sut = new Parser(with => with.EnableDashDash = true);
+
+            // Exercize system
+            var result =
+                sut.ParseArguments<Options_With_Sequence_And_Only_Max_Constraint_For_Value>(args);
+
+            // Verify outcome
+            ((Parsed<Options_With_Sequence_And_Only_Max_Constraint_For_Value>)result).Value.Should().BeEquivalentTo(expectedOptions);
+        }
+
+        [Theory]
+        [InlineData("value1", "value2", "value3")]
+        [InlineData("--", "value1", "value2", "value3")]
+        [InlineData("value1", "--", "value2", "value3")]
+        [InlineData("value1", "value2", "--", "value3")]
+        [InlineData("value1", "value2", "value3", "--")]
+        public void Parse_options_with_double_dash_and_all_consuming_sequence_leaves_nothing_for_later_values(params string[] args)
+        {
+            var expectedOptions = new Options_With_Value_Sequence_And_Subsequent_Value
+            {
+                StringSequence = new[] { "value1", "value2", "value3" },
+                NeverReachedValue = null
+            };
+
+            var sut = new Parser(with => with.EnableDashDash = true);
+
+            // Exercize system
+            var result =
+                sut.ParseArguments<Options_With_Value_Sequence_And_Subsequent_Value>(args);
+
+            // Verify outcome
+            ((Parsed<Options_With_Value_Sequence_And_Subsequent_Value>)result).Value.Should().BeEquivalentTo(expectedOptions);
+        }
+
+        [Theory]
+        [InlineData("value1", "value2", "value3")]
+        [InlineData("--", "value1", "value2", "value3")]
+        [InlineData("value1", "--", "value2", "value3")]
+        [InlineData("value1", "value2", "--", "value3")]
+        [InlineData("value1", "value2", "value3", "--")]
+        public void Parse_options_with_double_dash_and_limited_sequence_leaves_something_for_later_values(params string[] args)
+        {
+            var expectedOptions = new Options_With_Value_Sequence_With_Max_And_Subsequent_Value
+            {
+                StringSequence = new[] { "value1", "value2" },
+                NeverReachedValue = "value3"
+            };
+
+            var sut = new Parser(with => with.EnableDashDash = true);
+
+            // Exercize system
+            var result =
+                sut.ParseArguments<Options_With_Value_Sequence_With_Max_And_Subsequent_Value>(args);
+
+            // Verify outcome
+            ((Parsed<Options_With_Value_Sequence_With_Max_And_Subsequent_Value>)result).Value.Should().BeEquivalentTo(expectedOptions);
+        }
+
         [Fact]
         public void Parse_options_with_double_dash_in_verbs_scenario()
         {


### PR DESCRIPTION
This PR builds on #607 to fix #600. Now that string values are handled by the tokenizer exactly how getopt handles them, we can also handle the special `--`, `--help` and `--version` options exactly how getopt handles them. In particular, we can respond to `--help` no matter where it appears in the argument list (the previous behavior would only respond to `--help` if it was the first parameter, and had some hacks that tried to ensure that it would be responded to elsewhere, but those hacks were incomplete and buggy, creating issues like #596 among others).

Note that because I wrote this PR on top of #607, merging this PR will automatically merge #607 as well. I did it this way because proper tokenization of `--help` (and NOT handling it if it was a string value to some other option) is essential to how this PR is supposed to work. Without #607, many of the tests I wrote for the AutoHelp and AutoVersion options would fail.