### PR TITLE
fix issue #606 (#606)

### DIFF
--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -151,7 +151,6 @@ namespace CommandLine
         {
             if (args == null) throw new ArgumentNullException("args");
             if (types == null) throw new ArgumentNullException("types");
-            if (types.Length == 0) throw new ArgumentOutOfRangeException("types");
 
             return MakeParserResult(
                 InstanceChooser.Choose(

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -576,7 +576,6 @@ namespace CommandLine.Text
         public HelpText AddVerbs(params Type[] types)
         {
             if (types == null) throw new ArgumentNullException("types");
-            if (types.Length == 0) throw new ArgumentOutOfRangeException("types");
 
             return AddOptionsImpl(
                 AdaptVerbsToSpecifications(types),


### PR DESCRIPTION
I think checking for types count > 0 is an error since they are optional parameters...

 `public ParserResult<object> ParseArguments(IEnumerable<string> args, params Type[] types)`