### PR TITLE
Properly assign arguments after a double dash to values

### DIFF
--- a/src/CommandLine/Core/Sequence.cs
+++ b/src/CommandLine/Core/Sequence.cs
@@ -34,8 +34,8 @@ namespace CommandLine.Core
                 return info.NextValue.MapValueOrDefault(
                     _ => info.MaxItems.MapValueOrDefault(
                             n => tokens.Skip(nameIndex + 1).Take(n),
-                                 tokens.Skip(nameIndex + 1).TakeWhile(v => v.IsValue())),
-                    tokens.Skip(nameIndex + 1).TakeWhile(v => v.IsValue()));
+                                 tokens.Skip(nameIndex + 1).TakeWhile(v => v.IsValue() && !v.IsValueForced())),
+                    tokens.Skip(nameIndex + 1).TakeWhile(v => v.IsValue() && !v.IsValueForced()));
             }
             return new Token[] { };
         }

--- a/src/CommandLine/Core/Token.cs
+++ b/src/CommandLine/Core/Token.cs
@@ -32,6 +32,11 @@ namespace CommandLine.Core
             return new Value(text, explicitlyAssigned);
         }
 
+        public static Token ValueForced(string text)
+        {
+            return new Value(text, false, true);
+        }
+
         public TokenType Tag
         {
             get { return tag; }
@@ -80,21 +85,33 @@ namespace CommandLine.Core
     class Value : Token, IEquatable<Value>
     {
         private readonly bool explicitlyAssigned;
+        private readonly bool forced;
 
         public Value(string text)
-            : this(text, false)
+            : this(text, false, false)
         {
         }
 
         public Value(string text, bool explicitlyAssigned)
+            : this(text, explicitlyAssigned, false)
+        {
+        }
+
+        public Value(string text, bool explicitlyAssigned, bool forced)
             : base(TokenType.Value, text)
         {
             this.explicitlyAssigned = explicitlyAssigned;
+            this.forced = forced;
         }
 
         public bool ExplicitlyAssigned
         {
             get { return explicitlyAssigned; }
+        }
+
+        public bool Forced
+        {
+            get { return forced; }
         }
 
         public override bool Equals(object obj)
@@ -120,7 +137,7 @@ namespace CommandLine.Core
                 return false;
             }
 
-            return Tag.Equals(other.Tag) && Text.Equals(other.Text);
+            return Tag.Equals(other.Tag) && Text.Equals(other.Text) && this.Forced == other.Forced;
         }
     }
 
@@ -134,6 +151,11 @@ namespace CommandLine.Core
         public static bool IsValue(this Token token)
         {
             return token.Tag == TokenType.Value;
+        }
+
+        public static bool IsValueForced(this Token token)
+        {
+            return token.IsValue() && ((Value)token).Forced;
         }
     }
 }

--- a/src/CommandLine/Core/Tokenizer.cs
+++ b/src/CommandLine/Core/Tokenizer.cs
@@ -50,7 +50,7 @@ namespace CommandLine.Core
             if (arguments.Any(arg => arg.EqualsOrdinal("--")))
             {
                 var tokenizerResult = tokenizer(arguments.TakeWhile(arg => !arg.EqualsOrdinal("--")));
-                var values = arguments.SkipWhile(arg => !arg.EqualsOrdinal("--")).Skip(1).Select(Token.Value);
+                var values = arguments.SkipWhile(arg => !arg.EqualsOrdinal("--")).Skip(1).Select(Token.ValueForced);
                 return tokenizerResult.Map(tokens => tokens.Concat(values));
             }
             return tokenizer(arguments);

--- a/tests/CommandLine.Tests/Fakes/Options_With_Option_Sequence_And_Value_Sequence.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_Option_Sequence_And_Value_Sequence.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace CommandLine.Tests.Fakes
+{
+    public class Options_With_Option_Sequence_And_Value_Sequence
+    {
+        [Option('o', "option-seq")]
+        public IEnumerable<string> OptionSequence { get; set; }
+
+        [Value(0)]
+        public IEnumerable<string> ValueSequence { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -133,6 +133,26 @@ namespace CommandLine.Tests.Unit
         }
 
         [Fact]
+        public void Parse_options_with_double_dash_and_option_sequence()
+        {
+            var expectedOptions = new Options_With_Option_Sequence_And_Value_Sequence
+            {
+                OptionSequence = new[] { "option1", "option2", "option3" },
+                ValueSequence = new[] { "value1", "value2", "value3" }
+            };
+
+            var sut = new Parser(with => with.EnableDashDash = true);
+
+            // Exercize system
+            var result =
+                sut.ParseArguments<Options_With_Option_Sequence_And_Value_Sequence>(
+                    new[] { "--option-seq", "option1", "option2", "option3", "--", "value1", "value2", "value3" });
+
+            // Verify outcome
+            ((Parsed<Options_With_Option_Sequence_And_Value_Sequence>)result).Value.Should().BeEquivalentTo(expectedOptions);
+        }
+
+        [Fact]
         public void Parse_options_with_double_dash_in_verbs_scenario()
         {
             // Fixture setup


### PR DESCRIPTION
This is a working solution to issue #605, which properly assigns arguments after a double dash to values, rather than options.  However, I'm not particularly happy with the solution, so I'm looking for feedback.

I created a new token type `ValueForced`, which is only used by the `Tokenizer` when `EnableDashDash` is set and `--` is encountered.  `Sequence` will not select `ValueForced` tokens.  I think the overall pattern is fine, but I don't like the name `ValueForced` for the token.  Unfortunately, the work *Value* is already overloaded quite a bit, which is why I struggled with a better name.

I also want to add a test to verify that parsing fails if there are arguments following the double dash, but the options object doesn't include any Value properties.  If there are any other tests you'd like me to add, let me know.  Thanks!