### PR TITLE
Add generalized implementation of MapResult which supports infinite p…

### DIFF
--- a/tests/CommandLine.Tests/Fakes/Verb_Fakes.cs
+++ b/tests/CommandLine.Tests/Fakes/Verb_Fakes.cs
@@ -119,4 +119,22 @@ namespace CommandLine.Tests.Fakes
         [Option('t', "test")]
         public bool TestValue { get; set; }
     }
+    
+    [Verb("Verb1")] public class Option1 { }
+    [Verb("Verb2")] public class Option2 { }
+    [Verb("Verb3")] public class Option3 { }
+    [Verb("Verb4")] public class Option4 { }
+    [Verb("Verb5")] public class Option5 { }
+    [Verb("Verb6")] public class Option6 { }
+    [Verb("Verb7")] public class Option7 { }
+    [Verb("Verb8")] public class Option8 { }
+    [Verb("Verb9")] public class Option9 { }
+    [Verb("Verb10")] public class Option10 { }
+    [Verb("Verb11")] public class Option11 { }
+    [Verb("Verb12")] public class Option12 { }
+    [Verb("Verb13")] public class Option13 { }
+    [Verb("Verb14")] public class Option14 { }
+    [Verb("Verb15")] public class Option15 { }
+    [Verb("Verb16")] public class Option16 { }
+    [Verb("Verb17")] public class Option17 { }
 }

--- a/tests/CommandLine.Tests/Unit/ParserResultExtensionsTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserResultExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
 
+using System;
 using System.Linq;
 using Xunit;
 using FluentAssertions;
@@ -251,6 +252,34 @@ namespace CommandLine.Tests.Unit
                     errs => 5);
 
             4.Should().Be(expected);
+        }
+
+        [Fact]
+        public static void Turn_successful_parsing_into_exit_code_for_verbs_using_generalized_map_result()
+        {
+            var expected = Parser.Default.ParseArguments<Add_Verb, Commit_Verb, Clone_Verb>(
+                    new[] {"undefined", "-xyz"})
+                .MapResult(errs => 3,
+                    (Func<Add_Verb, int>) (opts => 0),
+                    (Func<Commit_Verb, int>) (opts => 1),
+                    (Func<Clone_Verb, int>) (opts => 3)
+                );
+
+            3.Should().Be(expected);
+        }
+
+        [Fact]
+        public static void Turn_sucessful_parsing_into_exit_code_for_multiple_base_verbs_using_generalized_map_result()
+        {
+            var expected = Parser.Default.ParseArguments<Add_Verb, Commit_Verb, Clone_Verb, Derived_Verb>(
+                    new[] {"derivedadd", "dummy.bin"})
+                .MapResult(errs => 5,
+                    (Func<Add_Verb, int>) (opts => 0),
+                    (Func<Commit_Verb, int>) (opts => 1),
+                    (Func<Clone_Verb, int>) (opts => 2),
+                    (Func<Derived_Verb, int>) (opts => 3));
+
+            3.Should().Be(expected);
         }
     }
 }

--- a/tests/CommandLine.Tests/Unit/ParserResultExtensionsTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserResultExtensionsTests.cs
@@ -262,7 +262,7 @@ namespace CommandLine.Tests.Unit
                 .MapResult(errs => 3,
                     (Func<Add_Verb, int>) (opts => 0),
                     (Func<Commit_Verb, int>) (opts => 1),
-                    (Func<Clone_Verb, int>) (opts => 3)
+                    (Func<Clone_Verb, int>) (opts => 2)
                 );
 
             3.Should().Be(expected);

--- a/tests/CommandLine.Tests/Unit/ParserResultExtensionsTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserResultExtensionsTests.cs
@@ -269,7 +269,7 @@ namespace CommandLine.Tests.Unit
         }
 
         [Fact]
-        public static void Turn_sucessful_parsing_into_exit_code_for_multiple_base_verbs_using_generalized_map_result()
+        public static void Turn_successful_parsing_into_exit_code_for_multiple_base_verbs_using_generalized_map_result()
         {
             var expected = Parser.Default.ParseArguments<Add_Verb, Commit_Verb, Clone_Verb, Derived_Verb>(
                     new[] {"derivedadd", "dummy.bin"})
@@ -280,6 +280,34 @@ namespace CommandLine.Tests.Unit
                     (Func<Derived_Verb, int>) (opts => 3));
 
             3.Should().Be(expected);
+        }
+
+        [Fact]
+        public static void Invoke_generalized_map_result_with_more_than_16_verbs()
+        {
+            var expected = Parser.Default.ParseArguments(new[] {"Verb17", "test.bin"},
+                typeof(Option1), typeof(Option2), typeof(Option3), typeof(Option4), typeof(Option5), typeof(Option6),
+                typeof(Option7), typeof(Option8), typeof(Option9), typeof(Option10), typeof(Option11), typeof(Option12),
+                typeof(Option13), typeof(Option14), typeof(Option15), typeof(Option16), typeof(Option17)).MapResult(
+                errs => 100,
+                (Func<Option1, int>) (opts => 1),
+                (Func<Option2, int>) (opts => 2),
+                (Func<Option3, int>) (opts => 3),
+                (Func<Option4, int>) (opts => 4),
+                (Func<Option5, int>) (opts => 5),
+                (Func<Option6, int>) (opts => 6),
+                (Func<Option7, int>) (opts => 7),
+                (Func<Option8, int>) (opts => 8),
+                (Func<Option9, int>) (opts => 9),
+                (Func<Option10, int>) (opts => 10),
+                (Func<Option11, int>) (opts => 11),
+                (Func<Option12, int>) (opts => 12),
+                (Func<Option13, int>) (opts => 13),
+                (Func<Option14, int>) (opts => 14),
+                (Func<Option15, int>) (opts => 15),
+                (Func<Option16, int>) (opts => 16),
+                (Func<Option17, int>) (opts => 17));
+            17.Should().Be(expected);
         }
     }
 }


### PR DESCRIPTION
As `MapResult` was not supporting more than 16 verbs in its generic templates, I patched this which supports infinite number of verbs. I think it can be a more generalized implementation.