### PR TITLE
Add multi-instance option support globally and per option

### DIFF
--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -24,6 +24,31 @@ namespace CommandLine.Core
             bool autoVersion,
             IEnumerable<ErrorType> nonFatalErrors)
         {
+            return Build(
+                factory,
+                tokenizer,
+                arguments,
+                nameComparer,
+                ignoreValueCase,
+                parsingCulture,
+                autoHelp,
+                autoVersion,
+                false,
+                nonFatalErrors);
+        }
+
+        public static ParserResult<T> Build<T>(
+            Maybe<Func<T>> factory,
+            Func<IEnumerable<string>, IEnumerable<OptionSpecification>, Result<IEnumerable<Token>, Error>> tokenizer,
+            IEnumerable<string> arguments,
+            StringComparer nameComparer,
+            bool ignoreValueCase,
+            CultureInfo parsingCulture,
+            bool autoHelp,
+            bool autoVersion,
+            bool allowMultiInstance,
+            IEnumerable<ErrorType> nonFatalErrors)
+        {
             var typeInfo = factory.MapValueOrDefault(f => f().GetType(), typeof(T));
 
             var specProps = typeInfo.GetSpecifications(pi => SpecificationProperty.Create(
@@ -70,7 +95,7 @@ namespace CommandLine.Core
                 var valueSpecPropsResult =
                     ValueMapper.MapValues(
                         (from pt in specProps where pt.Specification.IsValue() orderby ((ValueSpecification)pt.Specification).Index select pt),
-                        valuesPartition,    
+                        valuesPartition,
                         (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, parsingCulture, ignoreValueCase));
 
                 var missingValueErrors = from token in errorsPartition
@@ -86,7 +111,7 @@ namespace CommandLine.Core
 
                 //build the instance, determining if the type is mutable or not.
                 T instance;
-                if(typeInfo.IsMutable() == true)
+                if (typeInfo.IsMutable() == true)
                 {
                     instance = BuildMutable(factory, specPropsWithValue, setPropertyErrors);
                 }
@@ -95,7 +120,7 @@ namespace CommandLine.Core
                     instance = BuildImmutable(typeInfo, factory, specProps, specPropsWithValue, setPropertyErrors);
                 }
 
-                var validationErrors = specPropsWithValue.Validate(SpecificationPropertyRules.Lookup(tokens));
+                var validationErrors = specPropsWithValue.Validate(SpecificationPropertyRules.Lookup(tokens, allowMultiInstance));
 
                 var allErrors =
                     tokenizerResult.SuccessMessages()

--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -46,7 +46,7 @@ namespace CommandLine.Core
             CultureInfo parsingCulture,
             bool autoHelp,
             bool autoVersion,
-            bool allowMultiInstance,
+            bool allowMultiInstanceByDefault,
             IEnumerable<ErrorType> nonFatalErrors)
         {
             var typeInfo = factory.MapValueOrDefault(f => f().GetType(), typeof(T));
@@ -120,7 +120,7 @@ namespace CommandLine.Core
                     instance = BuildImmutable(typeInfo, factory, specProps, specPropsWithValue, setPropertyErrors);
                 }
 
-                var validationErrors = specPropsWithValue.Validate(SpecificationPropertyRules.Lookup(tokens, allowMultiInstance));
+                var validationErrors = specPropsWithValue.Validate(SpecificationPropertyRules.Lookup(tokens, allowMultiInstanceByDefault));
 
                 var allErrors =
                     tokenizerResult.SuccessMessages()

--- a/src/CommandLine/Core/InstanceChooser.cs
+++ b/src/CommandLine/Core/InstanceChooser.cs
@@ -23,6 +23,31 @@ namespace CommandLine.Core
             bool autoVersion,
             IEnumerable<ErrorType> nonFatalErrors)
         {
+            return Choose(
+                tokenizer,
+                types,
+                arguments,
+                nameComparer,
+                ignoreValueCase,
+                parsingCulture,
+                autoHelp,
+                autoVersion,
+                false,
+                nonFatalErrors);
+        }
+
+        public static ParserResult<object> Choose(
+            Func<IEnumerable<string>, IEnumerable<OptionSpecification>, Result<IEnumerable<Token>, Error>> tokenizer,
+            IEnumerable<Type> types,
+            IEnumerable<string> arguments,
+            StringComparer nameComparer,
+            bool ignoreValueCase,
+            CultureInfo parsingCulture,
+            bool autoHelp,
+            bool autoVersion,
+            bool allowMultiInstance,
+            IEnumerable<ErrorType> nonFatalErrors)
+        {
             var verbs = Verb.SelectFromTypes(types);
             var defaultVerbs = verbs.Where(t => t.Item1.IsDefault);
             
@@ -46,7 +71,7 @@ namespace CommandLine.Core
                             arguments.Skip(1).FirstOrDefault() ?? string.Empty, nameComparer))
                     : (autoVersion && preprocCompare("version"))
                         ? MakeNotParsed(types, new VersionRequestedError())
-                        : MatchVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoVersion, nonFatalErrors);
+                        : MatchVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoVersion, allowMultiInstance, nonFatalErrors);
             };
 
             return arguments.Any()
@@ -92,6 +117,7 @@ namespace CommandLine.Core
             CultureInfo parsingCulture,
             bool autoHelp,
             bool autoVersion,
+            bool allowMultiInstance,
             IEnumerable<ErrorType> nonFatalErrors)
         {
             return verbs.Any(a => nameComparer.Equals(a.Item1.Name, arguments.First()))
@@ -106,6 +132,7 @@ namespace CommandLine.Core
                     parsingCulture,
                     autoHelp,
                     autoVersion,
+                    allowMultiInstance,
                     nonFatalErrors)
                 : MatchDefaultVerb(tokenizer, verbs, defaultVerb, arguments, nameComparer, ignoreValueCase, parsingCulture, autoHelp, autoVersion, nonFatalErrors);
         }

--- a/src/CommandLine/Core/OptionSpecification.cs
+++ b/src/CommandLine/Core/OptionSpecification.cs
@@ -14,10 +14,11 @@ namespace CommandLine.Core
         private readonly char separator;
         private readonly string setName;
         private readonly string group;
+        private readonly bool? allowMultiInstance;
 
         public OptionSpecification(string shortName, string longName, bool required, string setName, Maybe<int> min, Maybe<int> max,
             char separator, Maybe<object> defaultValue, string helpText, string metaValue, IEnumerable<string> enumValues,
-            Type conversionType, TargetType targetType, string group, bool hidden = false)
+            Type conversionType, TargetType targetType, string group, bool hidden = false, bool? allowMultiInstance = null)
             : base(SpecificationType.Option,
                  required, min, max, defaultValue, helpText, metaValue, enumValues, conversionType, targetType, hidden)
         {
@@ -26,6 +27,7 @@ namespace CommandLine.Core
             this.separator = separator;
             this.setName = setName;
             this.group = group;
+            this.allowMultiInstance = allowMultiInstance;
         }
 
         public static OptionSpecification FromAttribute(OptionAttribute attribute, Type conversionType, IEnumerable<string> enumValues)
@@ -45,13 +47,14 @@ namespace CommandLine.Core
                 conversionType,
                 conversionType.ToTargetType(),
                 attribute.Group,
-                attribute.Hidden);
+                attribute.Hidden,
+                attribute.AllowMultiInstance);
         }
 
-        public static OptionSpecification NewSwitch(string shortName, string longName, bool required, string helpText, string metaValue, bool hidden = false)
+        public static OptionSpecification NewSwitch(string shortName, string longName, bool required, string helpText, string metaValue, bool hidden = false, bool? allowMultiInstance = null)
         {
             return new OptionSpecification(shortName, longName, required, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(),
-                '\0', Maybe.Nothing<object>(), helpText, metaValue, Enumerable.Empty<string>(), typeof(bool), TargetType.Switch, string.Empty, hidden);
+                '\0', Maybe.Nothing<object>(), helpText, metaValue, Enumerable.Empty<string>(), typeof(bool), TargetType.Switch, string.Empty, hidden, allowMultiInstance);
         }
 
         public string ShortName
@@ -77,6 +80,11 @@ namespace CommandLine.Core
         public string Group
         {
             get { return group; }
+        }
+
+        public bool? AllowMultiInstance
+        {
+            get { return allowMultiInstance; }
         }
     }
 }

--- a/src/CommandLine/Core/Sequence.cs
+++ b/src/CommandLine/Core/Sequence.cs
@@ -14,30 +14,141 @@ namespace CommandLine.Core
             IEnumerable<Token> tokens,
             Func<string, Maybe<TypeDescriptor>> typeLookup)
         {
-            return from tseq in tokens.Pairwise(
-                (f, s) =>
-                        f.IsName() && s.IsValue()
-                            ? typeLookup(f.Text).MapValueOrDefault(info =>
-                                   info.TargetType == TargetType.Sequence
-                                        ? new[] { f }.Concat(tokens.OfSequence(f, info))
-                                        : new Token[] { }, new Token[] { })
-                            : new Token[] { })
-                   from t in tseq
-                   select t;
+            var sequences = new Dictionary<Token, IList<Token>>();
+            var state = SequenceState.TokenSearch;
+            Token nameToken = default;
+            foreach (var token in tokens)
+            {
+                switch (state)
+                {
+                    case SequenceState.TokenSearch:
+                        if (token.IsName())
+                        {
+                            if (typeLookup(token.Text).MatchJust(out var info) && info.TargetType == TargetType.Sequence)
+                            {
+                                nameToken = token;
+                                state = SequenceState.TokenFound;
+                            }
+                        }
+                        break;
+
+                    case SequenceState.TokenFound:
+                        if (token.IsValue())
+                        {
+                            if (sequences.TryGetValue(nameToken, out var sequence))
+                            {
+                                sequence.Add(token);
+                            }
+                            else
+                            {
+                                sequences[nameToken] = new List<Token>(new[] { token });
+                            }
+                        }
+                        else if (token.IsName())
+                        {
+                            if (typeLookup(token.Text).MatchJust(out var info) && info.TargetType == TargetType.Sequence)
+                            {
+                                nameToken = token;
+                                state = SequenceState.TokenFound;
+                            }
+                            else
+                            {
+                                state = SequenceState.TokenSearch;
+                            }
+                        }
+                        else
+                        {
+                            state = SequenceState.TokenSearch;
+                        }
+                        break;
+                }
+            }
+
+            foreach (var kvp in sequences)
+            {
+                yield return kvp.Key;
+                foreach (var value in kvp.Value)
+                {
+                    yield return value;
+                }
+            }
+
+                //return from tseq in tokens.Pairwise(
+                //(f, s) =>
+                //        f.IsName() && s.IsValue()
+                //            ? typeLookup(f.Text).MapValueOrDefault(info =>
+                //                   info.TargetType == TargetType.Sequence
+                //                        ? new[] { f }.Concat(tokens.OfSequence(f, info))
+                //                        : new Token[] { }, new Token[] { })
+                //            : new Token[] { })
+                //   from t in tseq
+                //   select t;
         }
 
-        private static IEnumerable<Token> OfSequence(this IEnumerable<Token> tokens, Token nameToken, TypeDescriptor info)
+        //private static IEnumerable<Token> OfSequence(this IEnumerable<Token> tokens, Token nameToken, TypeDescriptor info)
+        //{
+        //    var state = SequenceState.TokenSearch;
+        //    var count = 0;
+        //    var max = info.MaxItems.GetValueOrDefault(int.MaxValue);
+        //    var values = max != int.MaxValue
+        //        ? new List<Token>(max)
+        //        : new List<Token>();
+
+        //    foreach (var token in tokens)
+        //    {
+        //        if (count == max)
+        //        {
+        //            break;
+        //        }
+
+        //        switch (state)
+        //        {
+        //            case SequenceState.TokenSearch:
+        //                if (token.IsName() && token.Text.Equals(nameToken.Text))
+        //                {
+        //                    state = SequenceState.TokenFound;
+        //                }
+        //                break;
+
+        //            case SequenceState.TokenFound:
+        //                if (token.IsValue())
+        //                {
+        //                    state = SequenceState.ValueFound;
+        //                    count++;
+        //                    values.Add(token);
+        //                }
+        //                else
+        //                {
+        //                    // Invalid to provide option without value
+        //                    return Enumerable.Empty<Token>();
+        //                }
+        //                break;
+
+        //            case SequenceState.ValueFound:
+        //                if (token.IsValue())
+        //                {
+        //                    count++;
+        //                    values.Add(token);
+        //                }
+        //                else if (token.IsName() && token.Text.Equals(nameToken.Text))
+        //                {
+        //                    state = SequenceState.TokenFound;
+        //                }
+        //                else
+        //                {
+        //                    state = SequenceState.TokenSearch;
+        //                }
+        //                break;
+        //        }
+        //    }
+
+        //    return values;
+        //}
+
+        private enum SequenceState
         {
-            var nameIndex = tokens.IndexOf(t => t.Equals(nameToken));
-            if (nameIndex >= 0)
-            {
-                return info.NextValue.MapValueOrDefault(
-                    _ => info.MaxItems.MapValueOrDefault(
-                            n => tokens.Skip(nameIndex + 1).Take(n),
-                                 tokens.Skip(nameIndex + 1).TakeWhile(v => v.IsValue())),
-                    tokens.Skip(nameIndex + 1).TakeWhile(v => v.IsValue()));
-            }
-            return new Token[] { };
+            TokenSearch,
+            TokenFound,
         }
     }
 }

--- a/src/CommandLine/Core/SpecificationPropertyRules.cs
+++ b/src/CommandLine/Core/SpecificationPropertyRules.cs
@@ -14,6 +14,14 @@ namespace CommandLine.Core
             Lookup(
                 IEnumerable<Token> tokens)
         {
+            return Lookup(tokens, false);
+        }
+
+        public static IEnumerable<Func<IEnumerable<SpecificationProperty>, IEnumerable<Error>>>
+            Lookup(
+                IEnumerable<Token> tokens,
+                bool allowMultiInstance)
+        {
             return new List<Func<IEnumerable<SpecificationProperty>, IEnumerable<Error>>>
                 {
                     EnforceMutuallyExclusiveSet(),
@@ -21,7 +29,7 @@ namespace CommandLine.Core
                     EnforceMutuallyExclusiveSetAndGroupAreNotUsedTogether(),
                     EnforceRequired(),
                     EnforceRange(),
-                    EnforceSingle(tokens)
+                    EnforceSingle(tokens, allowMultiInstance)
                 };
         }
 
@@ -173,10 +181,15 @@ namespace CommandLine.Core
                 };
         }
 
-        private static Func<IEnumerable<SpecificationProperty>, IEnumerable<Error>> EnforceSingle(IEnumerable<Token> tokens)
+        private static Func<IEnumerable<SpecificationProperty>, IEnumerable<Error>> EnforceSingle(IEnumerable<Token> tokens, bool allowMultiInstance)
         {
             return specProps =>
                 {
+                    if (allowMultiInstance)
+                    {
+                        return Enumerable.Empty<Error>();
+                    }
+
                     var specs = from sp in specProps
                                 where sp.Specification.IsOption()
                                 where sp.Value.IsJust()

--- a/src/CommandLine/Core/TokenPartitioner.cs
+++ b/src/CommandLine/Core/TokenPartitioner.cs
@@ -21,10 +21,11 @@ namespace CommandLine.Core
             var switches = new HashSet<Token>(Switch.Partition(tokenList, typeLookup), tokenComparer);
             var scalars = new HashSet<Token>(Scalar.Partition(tokenList, typeLookup), tokenComparer);
             var sequences = new HashSet<Token>(Sequence.Partition(tokenList, typeLookup), tokenComparer);
+            var dedupedSequences = new HashSet<Token>(sequences);
             var nonOptions = tokenList
                 .Where(t => !switches.Contains(t))
                 .Where(t => !scalars.Contains(t))
-                .Where(t => !sequences.Contains(t)).Memoize();
+                .Where(t => !dedupedSequences.Contains(t)).Memoize();
             var values = nonOptions.Where(v => v.IsValue()).Memoize();
             var errors = nonOptions.Except(values, (IEqualityComparer<Token>)ReferenceEqualityComparer.Default).Memoize();
 

--- a/src/CommandLine/Core/TypeConverter.cs
+++ b/src/CommandLine/Core/TypeConverter.cs
@@ -16,7 +16,7 @@ namespace CommandLine.Core
         public static Maybe<object> ChangeType(IEnumerable<string> values, Type conversionType, bool scalar, CultureInfo conversionCulture, bool ignoreValueCase)
         {
             return scalar
-                ? ChangeTypeScalar(values.Single(), conversionType, conversionCulture, ignoreValueCase)
+                ? ChangeTypeScalar(values.Last(), conversionType, conversionCulture, ignoreValueCase)
                 : ChangeTypeSequence(values, conversionType, conversionCulture, ignoreValueCase);
         }
 

--- a/src/CommandLine/OptionAttribute.cs
+++ b/src/CommandLine/OptionAttribute.cs
@@ -17,14 +17,16 @@ namespace CommandLine
         private string setName;
         private char separator;
         private string group=string.Empty;
+        private bool? allowMultiInstance;
 
-        private OptionAttribute(string shortName, string longName) : base()
+        private OptionAttribute(string shortName, string longName, bool? allowMultiInstance) : base()
         {
             if (shortName == null) throw new ArgumentNullException("shortName");
             if (longName == null) throw new ArgumentNullException("longName");
 
             this.shortName = shortName;
             this.longName = longName;
+            this.allowMultiInstance = allowMultiInstance;
             setName = string.Empty;
             separator = '\0';
         }
@@ -34,7 +36,7 @@ namespace CommandLine
         /// The default long name will be inferred from target property.
         /// </summary>
         public OptionAttribute()
-            : this(string.Empty, string.Empty)
+            : this(string.Empty, string.Empty, null)
         {
         }
 
@@ -43,7 +45,7 @@ namespace CommandLine
         /// </summary>
         /// <param name="longName">The long name of the option.</param>
         public OptionAttribute(string longName)
-            : this(string.Empty, longName)
+            : this(string.Empty, longName, null)
         {
         }
 
@@ -53,7 +55,7 @@ namespace CommandLine
         /// <param name="shortName">The short name of the option.</param>
         /// <param name="longName">The long name of the option or null if not used.</param>
         public OptionAttribute(char shortName, string longName)
-            : this(shortName.ToOneCharString(), longName)
+            : this(shortName.ToOneCharString(), longName, null)
         {
         }
 
@@ -62,7 +64,39 @@ namespace CommandLine
         /// </summary>
         /// <param name="shortName">The short name of the option..</param>
         public OptionAttribute(char shortName)
-            : this(shortName.ToOneCharString(), string.Empty)
+            : this(shortName.ToOneCharString(), string.Empty, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommandLine.OptionAttribute"/> class.
+        /// </summary>
+        /// <param name="longName">The long name of the option.</param>
+        /// <param name="allowMultiInstance">Should multiple instances of this option being repeated be allowed or not.</param>
+        public OptionAttribute(string longName, bool allowMultiInstance)
+            : this(string.Empty, longName, allowMultiInstance)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommandLine.OptionAttribute"/> class.
+        /// </summary>
+        /// <param name="shortName">The short name of the option.</param>
+        /// <param name="longName">The long name of the option or null if not used.</param>
+        /// <param name="allowMultiInstance">Should multiple instances of this option being repeated be allowed or not.</param>
+        public OptionAttribute(char shortName, string longName, bool allowMultiInstance)
+            : this(shortName.ToOneCharString(), longName, allowMultiInstance)
+        {
+            this.allowMultiInstance = allowMultiInstance;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommandLine.OptionAttribute"/> class.
+        /// </summary>
+        /// <param name="shortName">The short name of the option..</param>
+        /// <param name="allowMultiInstance">Should multiple instances of this option being repeated be allowed or not.</param>
+        public OptionAttribute(char shortName, bool allowMultiInstance)
+            : this(shortName.ToOneCharString(), string.Empty, allowMultiInstance)
         {
         }
 
@@ -80,6 +114,14 @@ namespace CommandLine
         public string ShortName
         {
             get { return shortName; }
+        }
+
+        /// <summary>
+        /// Gets if multi instancing should be allowed on this option.
+        /// </summary>
+        public bool? AllowMultiInstance
+        {
+            get { return allowMultiInstance; }
         }
 
         /// <summary>

--- a/src/CommandLine/OptionAttribute.cs
+++ b/src/CommandLine/OptionAttribute.cs
@@ -87,7 +87,6 @@ namespace CommandLine
         public OptionAttribute(char shortName, string longName, bool allowMultiInstance)
             : this(shortName.ToOneCharString(), longName, allowMultiInstance)
         {
-            this.allowMultiInstance = allowMultiInstance;
         }
 
         /// <summary>

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -101,6 +101,7 @@ namespace CommandLine
                     settings.ParsingCulture,
                     settings.AutoHelp,
                     settings.AutoVersion,
+                    settings.AllowMultiInstance,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }
@@ -131,6 +132,7 @@ namespace CommandLine
                     settings.ParsingCulture,
                     settings.AutoHelp,
                     settings.AutoVersion,
+                    settings.AllowMultiInstance,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }
@@ -163,6 +165,7 @@ namespace CommandLine
                     settings.ParsingCulture,
                     settings.AutoHelp,
                     settings.AutoVersion,
+                    settings.AllowMultiInstance,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -101,7 +101,7 @@ namespace CommandLine
                     settings.ParsingCulture,
                     settings.AutoHelp,
                     settings.AutoVersion,
-                    settings.AllowMultiInstance,
+                    settings.AllowMultiInstanceByDefault,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }
@@ -132,7 +132,7 @@ namespace CommandLine
                     settings.ParsingCulture,
                     settings.AutoHelp,
                     settings.AutoVersion,
-                    settings.AllowMultiInstance,
+                    settings.AllowMultiInstanceByDefault,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }
@@ -165,7 +165,7 @@ namespace CommandLine
                     settings.ParsingCulture,
                     settings.AutoHelp,
                     settings.AutoVersion,
-                    settings.AllowMultiInstance,
+                    settings.AllowMultiInstanceByDefault,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -25,6 +25,7 @@ namespace CommandLine
         private CultureInfo parsingCulture;
         private bool enableDashDash;
         private int maximumDisplayWidth;
+        private bool allowMultiInstance;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ParserSettings"/> class.
@@ -172,6 +173,15 @@ namespace CommandLine
         {
             get { return maximumDisplayWidth; }
             set { maximumDisplayWidth = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether options are allowed to be specified multiple times.
+        /// </summary>
+        public bool AllowMultiInstance
+        {
+            get => allowMultiInstance;
+            set => PopsicleSetter.Set(Consumed, ref allowMultiInstance, value);
         }
 
         internal StringComparer NameComparer

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -25,7 +25,7 @@ namespace CommandLine
         private CultureInfo parsingCulture;
         private bool enableDashDash;
         private int maximumDisplayWidth;
-        private bool allowMultiInstance;
+        private bool allowMultiInstanceByDefaultByDefault;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ParserSettings"/> class.
@@ -176,12 +176,12 @@ namespace CommandLine
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether options are allowed to be specified multiple times.
+        /// Gets or sets a value indicating whether options are allowed to be specified multiple times by default.
         /// </summary>
-        public bool AllowMultiInstance
+        public bool AllowMultiInstanceByDefault
         {
-            get => allowMultiInstance;
-            set => PopsicleSetter.Set(Consumed, ref allowMultiInstance, value);
+            get => allowMultiInstanceByDefaultByDefault;
+            set => PopsicleSetter.Set(Consumed, ref allowMultiInstanceByDefaultByDefault, value);
         }
 
         internal StringComparer NameComparer

--- a/tests/CommandLine.Tests/Fakes/Verb_Fakes.cs
+++ b/tests/CommandLine.Tests/Fakes/Verb_Fakes.cs
@@ -71,6 +71,16 @@ namespace CommandLine.Tests.Fakes
         public IEnumerable<string> StringSequence { get; set; }
     }
 
+    [Verb("sequence", HelpText = "Sequence options test.")]
+    public class SequenceOptions_With_AllowMultiInstance
+    {
+        [Option("long-seq", true, Separator = ';')]
+        public IEnumerable<long> LongSequence { get; set; }
+
+        [Option('s', true, Min = 1, Max = 100, Separator = ',')]
+        public IEnumerable<string> StringSequence { get; set; }
+    }
+
     abstract class Base_Class_For_Verb
     {
         [Option('p', "patch", SetName = "mode",

--- a/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
@@ -19,7 +19,7 @@ namespace CommandLine.Tests.Unit.Core
 {
     public class InstanceBuilderTests
     {
-        private static ParserResult<T> InvokeBuild<T>(string[] arguments, bool autoHelp = true, bool autoVersion = true)
+        private static ParserResult<T> InvokeBuild<T>(string[] arguments, bool autoHelp = true, bool autoVersion = true, bool multiInstance = false)
             where T : new()
         {
             return InstanceBuilder.Build(
@@ -31,6 +31,7 @@ namespace CommandLine.Tests.Unit.Core
                 CultureInfo.InvariantCulture,
                 autoHelp,
                 autoVersion,
+                multiInstance,
                 Enumerable.Empty<ErrorType>());
         }
 
@@ -1233,6 +1234,17 @@ namespace CommandLine.Tests.Unit.Core
             var errors = ((NotParsed<Simple_Options_With_OptionGroup_MutuallyExclusiveSet>)result).Errors;
 
             errors.Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Fact]
+        public void Parse_int_sequence_with_multi_instance()
+        {
+            var expected = new[] { 1, 2, 3 };
+            var result = InvokeBuild<Options_With_Sequence>(
+                new[] { "--int-seq", "1", "2", "--int-seq", "3" },
+                multiInstance: true);
+
+            ((Parsed<Options_With_Sequence>)result).Value.IntSequence.Should().BeEquivalentTo(expected);
         }
 
         #region custom types 

--- a/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
@@ -15,7 +15,8 @@ namespace CommandLine.Tests.Unit.Core
     {
         private static ParserResult<object> InvokeChoose(
             IEnumerable<Type> types,
-            IEnumerable<string> arguments)
+            IEnumerable<string> arguments,
+            bool multiInstance = false)
         {
             return InstanceChooser.Choose(
                 (args, optionSpecs) => Tokenizer.ConfigureTokenizer(StringComparer.Ordinal, false, false)(args, optionSpecs),
@@ -26,6 +27,7 @@ namespace CommandLine.Tests.Unit.Core
                 CultureInfo.InvariantCulture,
                 true,
                 true,
+                multiInstance,
                 Enumerable.Empty<ErrorType>());
         }
 
@@ -167,6 +169,19 @@ namespace CommandLine.Tests.Unit.Core
             Assert.IsType<SequenceOptions>(((Parsed<object>)result).Value);
             expected.Should().BeEquivalentTo(((Parsed<object>)result).Value);
             // Teardown
+        }
+
+        [Fact]
+        public void Parse_sequence_verb_with_multi_instance_returns_verb_instance()
+        {
+            var expected = new SequenceOptions { LongSequence = new long[] { }, StringSequence = new[] { "s1", "s2" } };
+            var result = InvokeChoose(
+                new[] { typeof(Add_Verb), typeof(Commit_Verb), typeof(Clone_Verb), typeof(SequenceOptions) },
+                new[] { "sequence", "-s", "s1", "-s", "s2" },
+                true);
+
+            Assert.IsType<SequenceOptions>(((Parsed<object>)result).Value);
+            expected.Should().BeEquivalentTo(((Parsed<object>)result).Value);
         }
     }
 }

--- a/tests/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
@@ -49,5 +49,67 @@ namespace CommandLine.Tests.Unit.Core
 
             // Teardown
         }
+
+        [Fact]
+        public void Map_with_multi_instance_scalar()
+        {
+            var tokenPartitions = new[]
+            {
+                new KeyValuePair<string, IEnumerable<string>>("s", new[] { "string1" }),
+                new KeyValuePair<string, IEnumerable<string>>("shortandlong", new[] { "string2" }),
+                new KeyValuePair<string, IEnumerable<string>>("shortandlong", new[] { "string3" }),
+                new KeyValuePair<string, IEnumerable<string>>("s", new[] { "string4" }),
+            };
+
+            var specProps = new[]
+            {
+                SpecificationProperty.Create(
+                    new OptionSpecification("s", "shortandlong", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(string), TargetType.Scalar, string.Empty),
+                    typeof(Simple_Options).GetProperties().Single(p => p.Name.Equals(nameof(Simple_Options.ShortAndLong), StringComparison.Ordinal)),
+                    Maybe.Nothing<object>()),
+            };
+
+            var result = OptionMapper.MapValues(
+                specProps.Where(pt => pt.Specification.IsOption()),
+                tokenPartitions,
+                (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, CultureInfo.InvariantCulture, false),
+                StringComparer.Ordinal);
+
+            var property = result.SucceededWith().Single();
+            Assert.True(property.Specification.IsOption());
+            Assert.True(property.Value.MatchJust(out var stringVal));
+            Assert.Equal(tokenPartitions.Last().Value.Last(), stringVal);
+        }
+
+        [Fact]
+        public void Map_with_multi_instance_sequence()
+        {
+            var tokenPartitions = new[]
+            {
+                new KeyValuePair<string, IEnumerable<string>>("i", new [] { "1", "2" }),
+                new KeyValuePair<string, IEnumerable<string>>("i", new [] { "3" }),
+                new KeyValuePair<string, IEnumerable<string>>("i", new [] { "4", "5" }),
+            };
+            var specProps = new[]
+            {
+                SpecificationProperty.Create(
+                    new OptionSpecification("i", string.Empty, false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<int>), TargetType.Sequence, string.Empty),
+                    typeof(Simple_Options).GetProperties().Single(p => p.Name.Equals(nameof(Simple_Options.IntSequence), StringComparison.Ordinal)),
+                    Maybe.Nothing<object>())
+            };
+
+            var result = OptionMapper.MapValues(
+                specProps.Where(pt => pt.Specification.IsOption()),
+                tokenPartitions,
+                (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, CultureInfo.InvariantCulture, false),
+                StringComparer.Ordinal);
+
+            var property = result.SucceededWith().Single();
+            Assert.True(property.Specification.IsOption());
+            Assert.True(property.Value.MatchJust(out var sequence));
+
+            var expected = tokenPartitions.Aggregate(Enumerable.Empty<int>(), (prev, part) => prev.Concat(part.Value.Select(i => int.Parse(i))));
+            Assert.Equal(expected, sequence);
+        }
     }
 }

--- a/tests/CommandLine.Tests/Unit/Core/SequenceTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/SequenceTests.cs
@@ -49,7 +49,7 @@ namespace CommandLine.Tests.Unit.Core
         }
 
         [Fact]
-        public void Partition_sequence_values_from_two_sequneces()
+        public void Partition_sequence_values_from_two_sequences()
         {
             var expected = new[]
                 {
@@ -92,6 +92,68 @@ namespace CommandLine.Tests.Unit.Core
                         : Maybe.Nothing<TypeDescriptor>());
 
             expected.Should().BeEquivalentTo(result);
+        }
+
+        [Fact]
+        public void Partition_sequence_multi_instance()
+        {
+            var expected = new[]
+            {
+                Token.Name("seq"),
+                Token.Value("seqval0"),
+                Token.Value("seqval1"),
+                Token.Value("seqval2"),
+                Token.Value("seqval3"),
+                Token.Value("seqval4"),
+            };
+
+            var result = Sequence.Partition(
+                new[]
+                {
+                    Token.Name("str"), Token.Value("strvalue"), Token.Value("freevalue"),
+                    Token.Name("seq"), Token.Value("seqval0"), Token.Value("seqval1"),
+                    Token.Name("x"), Token.Value("freevalue2"),
+                    Token.Name("seq"), Token.Value("seqval2"), Token.Value("seqval3"),
+                    Token.Name("seq"), Token.Value("seqval4")
+                },
+                name =>
+                    new[] { "seq" }.Contains(name)
+                        ? Maybe.Just(TypeDescriptor.Create(TargetType.Sequence, Maybe.Nothing<int>()))
+                        : Maybe.Nothing<TypeDescriptor>());
+
+            var actual = result.ToArray();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Partition_sequence_multi_instance_with_max()
+        {
+            var expected = new[]
+            {
+                Token.Name("seq"),
+                Token.Value("seqval0"),
+                Token.Value("seqval1"),
+                Token.Value("seqval2"),
+                Token.Value("seqval3"),
+                Token.Value("seqval4"),
+                Token.Value("seqval5"),
+            };
+
+            var result = Sequence.Partition(
+                new[]
+                {
+                    Token.Name("str"), Token.Value("strvalue"), Token.Value("freevalue"),
+                    Token.Name("seq"), Token.Value("seqval0"), Token.Value("seqval1"),
+                    Token.Name("x"), Token.Value("freevalue2"),
+                    Token.Name("seq"), Token.Value("seqval2"), Token.Value("seqval3"),
+                    Token.Name("seq"), Token.Value("seqval4"), Token.Value("seqval5"),
+                },
+                name =>
+                    new[] { "seq" }.Contains(name)
+                        ? Maybe.Just(TypeDescriptor.Create(TargetType.Sequence, Maybe.Just<int>(3)))
+                        : Maybe.Nothing<TypeDescriptor>());
+
+            Assert.Equal(expected, result);
         }
     }
 }

--- a/tests/CommandLine.Tests/Unit/Core/SpecificationPropertyRulesTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/SpecificationPropertyRulesTests.cs
@@ -1,0 +1,58 @@
+﻿using CommandLine.Core;
+using CommandLine.Tests.Fakes;
+using CSharpx;
+using System.Collections.Generic;
+using Xunit;
+
+namespace CommandLine.Tests.Unit.Core
+{
+
+    public class SpecificationPropertyRulesTests
+    {
+        [Fact]
+        public void Lookup_allows_multi_instance()
+        {
+            var tokens = new[]
+            {
+                Token.Name("name"),
+                Token.Value("value"),
+                Token.Name("name"),
+                Token.Value("value2"),
+            };
+
+            var specProps = new[]
+            {
+                SpecificationProperty.Create(
+                    new OptionSpecification(string.Empty, "name", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty),
+                    typeof(SequenceOptions).GetProperty(nameof(SequenceOptions.StringSequence)),
+                    Maybe.Just(new object())),
+            };
+
+            var results = specProps.Validate(SpecificationPropertyRules.Lookup(tokens, true));
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public void Lookup_fails_with_repeated_options_false_multi_instance()
+        {
+            var tokens = new[]
+            {
+                Token.Name("name"),
+                Token.Value("value"),
+                Token.Name("name"),
+                Token.Value("value2"),
+            };
+
+            var specProps = new[]
+            {
+                SpecificationProperty.Create(
+                    new OptionSpecification(string.Empty, "name", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty),
+                    typeof(SequenceOptions).GetProperty(nameof(SequenceOptions.StringSequence)),
+                    Maybe.Just(new object())),
+            };
+
+            var results = specProps.Validate(SpecificationPropertyRules.Lookup(tokens, false));
+            Assert.Contains(results, r => r.GetType() == typeof(RepeatedOptionError));
+        }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
@@ -33,6 +33,16 @@ namespace CommandLine.Tests.Unit.Core
             }
         }
 
+        [Fact]
+        public void ChangeType_Scalar_LastOneWins()
+        {
+            var values = new[] { "100", "200", "300", "400", "500" };
+            var result = TypeConverter.ChangeType(values, typeof(int), true, CultureInfo.InvariantCulture, true);
+            result.MatchJust(out var matchedValue).Should().BeTrue("should parse successfully");
+            Assert.Equal(500, matchedValue);
+
+        }
+
         public static IEnumerable<object[]> ChangeType_scalars_source
         {
             get

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -850,7 +850,7 @@ namespace CommandLine.Tests.Unit
         [Fact]
         public void Parse_repeated_options_in_verbs_scenario_with_multi_instance()
         {
-            using (var sut = new Parser(settings => settings.AllowMultiInstance = true))
+            using (var sut = new Parser(settings => settings.AllowMultiInstanceByDefault = true))
             {
                 var longVal1 = 100;
                 var longVal2 = 200;
@@ -872,9 +872,59 @@ namespace CommandLine.Tests.Unit
         }
 
         [Fact]
+        public void Parse_repeated_options_in_verbs_scenario_without_multi_instance_fails()
+        {
+            using (var sut = new Parser(settings => settings.AllowMultiInstanceByDefault = false))
+            {
+                var longVal1 = 100;
+                var longVal2 = 200;
+                var longVal3 = 300;
+                var stringVal = "shortSeq1";
+
+                var result = sut.ParseArguments(
+                    new[] { "sequence", "--long-seq", $"{longVal1}", "-s", stringVal, "--long-seq", $"{longVal2};{longVal3}" },
+                    typeof(Add_Verb), typeof(Commit_Verb), typeof(SequenceOptions));
+
+                Assert.IsType<NotParsed<object>>(result);
+                result.WithNotParsed(errors =>
+                {
+                    Assert.Single(errors);
+                    Assert.All(errors, error =>
+                    {
+                        Assert.IsType<RepeatedOptionError>(error);
+                    });
+                });
+            }
+        }
+
+        [Fact]
+        public void Parse_repeated_options_in_verbs_scenario_with_per_option_multi_instance()
+        {
+            using (var sut = new Parser(settings => settings.AllowMultiInstanceByDefault = false))
+            {
+                var longVal1 = 100;
+                var longVal2 = 200;
+                var longVal3 = 300;
+                var stringVal = "shortSeq1";
+
+                var result = sut.ParseArguments(
+                    new[] { "sequence", "--long-seq", $"{longVal1}", "-s", stringVal, "--long-seq", $"{longVal2};{longVal3}" },
+                    typeof(Add_Verb), typeof(Commit_Verb), typeof(SequenceOptions_With_AllowMultiInstance));
+
+                Assert.IsType<Parsed<object>>(result);
+                Assert.IsType<SequenceOptions_With_AllowMultiInstance>(((Parsed<object>)result).Value);
+                result.WithParsed<SequenceOptions_With_AllowMultiInstance>(verb =>
+                {
+                    Assert.Equal(new long[] { longVal1, longVal2, longVal3 }, verb.LongSequence);
+                    Assert.Equal(new[] { stringVal }, verb.StringSequence);
+                });
+            }
+        }
+
+        [Fact]
         public void Parse_repeated_options_in_verbs_scenario_without_multi_instance()
         {
-            using (var sut = new Parser(settings => settings.AllowMultiInstance = false))
+            using (var sut = new Parser(settings => settings.AllowMultiInstanceByDefault = false))
             {
                 var longVal1 = 100;
                 var longVal2 = 200;


### PR DESCRIPTION
This PR continues on the work done in PR #594 and makes the following changes:

- Renames the parser setting to AllowMultiInstanceByDefault
- Add a per-option AllowMultiInstance option that can be set in the constructor (by default, each option looks at the AllowMultiInstanceByDefault parser setting)
- Added 2 additional tests (1 for the AllowMultiInstance option)
- Previously enabling AllowMultiInstance(ByDefault) would disable any 'EnforceSingle' check, now it will perform all checks again but at the final step we look at the AllowMultiInstanceByDefault parser setting and the AllowMultiInstance option

Any feedback is welcome.