### PR TITLE
Fix unparsing FileInfo and DirectoryInfo

### DIFF
--- a/src/CommandLine/UnParserExtensions.cs
+++ b/src/CommandLine/UnParserExtensions.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections;
-using System.IO;
 using System.Linq;
 using System.Text;
 using CommandLine.Core;
@@ -205,14 +204,16 @@ namespace CommandLine
 
         private static object FormatWithQuotesIfString(object value)
         {
-            if (value is DateTime || value is DateTimeOffset || value is FileInfo || value is DirectoryInfo) return $"\"{value}\"";
+            string s = value.ToString();
+            if (!string.IsNullOrEmpty(s) && !s.Contains("\"") && s.Contains(" "))
+                return $"\"{s}\"";
+
             Func<string, string> doubQt = v
                 => v.Contains("\"") ? v.Replace("\"", "\\\"") : v;
 
-            return (value as string)
-                .ToMaybe()
-                .MapValueOrDefault(v => v.Contains(' ') || v.Contains("\"")
-                    ? "\"".JoinTo(doubQt(v), "\"") : v, value);
+            return s.ToMaybe()
+                    .MapValueOrDefault(v => v.Contains(' ') || v.Contains("\"")
+                        ? "\"".JoinTo(doubQt(v), "\"") : v, value);
         }
 
         private static char SeperatorOrSpace(this Specification spec)

--- a/src/CommandLine/UnParserExtensions.cs
+++ b/src/CommandLine/UnParserExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections;
+using System.IO;
 using System.Linq;
 using System.Text;
 using CommandLine.Core;
@@ -204,7 +205,7 @@ namespace CommandLine
 
         private static object FormatWithQuotesIfString(object value)
         {
-            if (value is DateTime || value is DateTimeOffset) return $"\"{value}\"";
+            if (value is DateTime || value is DateTimeOffset || value is FileInfo || value is DirectoryInfo) return $"\"{value}\"";
             Func<string, string> doubQt = v
                 => v.Contains("\"") ? v.Replace("\"", "\\\"") : v;
 

--- a/tests/CommandLine.Tests/Fakes/Options_With_FileDirectoryInfo.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_FileDirectoryInfo.cs
@@ -1,0 +1,18 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System.IO;
+
+namespace CommandLine.Tests.Fakes
+{
+    public class Options_With_FileDirectoryInfo
+    {
+        [Option('s', "stringPath")]
+        public string StringPath { get; set; }
+
+        [Option('f', "filePath")]
+        public FileInfo FilePath { get; set; }
+
+        [Option('d', "directoryPath")]
+        public DirectoryInfo DirectoryPath { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/UnParserExtensionsTests.cs
+++ b/tests/CommandLine.Tests/Unit/UnParserExtensionsTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Xunit;
 using FluentAssertions;
@@ -17,6 +18,15 @@ namespace CommandLine.Tests.Unit
         [Theory]
         [MemberData(nameof(UnParseData))]
         public static void UnParsing_instance_returns_command_line(Simple_Options options, string result)
+        {
+            new Parser()
+                .FormatCommandLine(options)
+                .Should().BeEquivalentTo(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnParseFileDirectoryData))]
+        public static void UnParsing_instance_returns_command_line_for_file_directory_paths(Options_With_FileDirectoryInfo options, string result)
         {
             new Parser()
                 .FormatCommandLine(options)
@@ -295,6 +305,15 @@ namespace CommandLine.Tests.Unit
                 yield return new object[] { new Simple_Options { LongValue = 123456789 }, "123456789" };
                 yield return new object[] { new Simple_Options { BoolValue = true, IntSequence = new[] { 1, 2, 3 }, StringValue = "nospaces", LongValue = 123456789 }, "-i 1 2 3 --stringvalue nospaces -x 123456789" };
                 yield return new object[] { new Simple_Options { BoolValue = true, IntSequence = new[] { 1, 2, 3 }, StringValue = "with \"quotes\" spaced", LongValue = 123456789 }, "-i 1 2 3 --stringvalue \"with \\\"quotes\\\" spaced\" -x 123456789" };
+            }
+        }
+
+        public static IEnumerable<object[]> UnParseFileDirectoryData
+        {
+            get
+            {
+                yield return new object[] { new Options_With_FileDirectoryInfo(), "" };
+                yield return new object[] { new Options_With_FileDirectoryInfo { FilePath = new FileInfo(@"C:\my path\with spaces\file with spaces.txt"), DirectoryPath = new DirectoryInfo(@"C:\my path\with spaces\"), StringPath = @"C:\my path\with spaces\file with spaces.txt" }, @"--directoryPath ""C:\my path\with spaces\"" --filePath ""C:\my path\with spaces\file with spaces.txt"" --stringPath ""C:\my path\with spaces\file with spaces.txt""" };
             }
         }
 


### PR DESCRIPTION
This treats FileInfo and DirectoryInfo as special as e.g. DateTime.
Unparsing a FileInfo or DirectoryInfo works now with a path that contains spaces.

Fixes #626