### PR TITLE
Bugfix: Binding Localized Resource to Argument Help Text

### DIFF
--- a/src/CommandLine/Infrastructure/LocalizableAttributeProperty.cs
+++ b/src/CommandLine/Infrastructure/LocalizableAttributeProperty.cs
@@ -46,9 +46,9 @@ namespace CommandLine.Infrastructure
                 // Static class IsAbstract 
                 if (!_type.IsVisible)
                     throw new ArgumentException($"Invalid resource type '{_type.FullName}'! {_type.Name} is not visible for the parser! Change resources 'Access Modifier' to 'Public'", _propertyName);
-                PropertyInfo propertyInfo = _type.GetProperty(_value, BindingFlags.Public | BindingFlags.GetProperty | BindingFlags.Static);
+                PropertyInfo propertyInfo = _type.GetProperty(_value, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
                 if (propertyInfo == null || !propertyInfo.CanRead || propertyInfo.PropertyType != typeof(string))
-                    throw new ArgumentException("Invalid resource property name! Localized value: {_value}", _propertyName);
+                    throw new ArgumentException($"Invalid resource property name! Localized value: {_value}", _propertyName);
                 _localizationPropertyInfo = propertyInfo;
             }
             return (string)_localizationPropertyInfo.GetValue(null, null);

--- a/src/CommandLine/Infrastructure/LocalizableAttributeProperty.cs
+++ b/src/CommandLine/Infrastructure/LocalizableAttributeProperty.cs
@@ -46,7 +46,7 @@ namespace CommandLine.Infrastructure
                 // Static class IsAbstract 
                 if (!_type.IsVisible)
                     throw new ArgumentException($"Invalid resource type '{_type.FullName}'! {_type.Name} is not visible for the parser! Change resources 'Access Modifier' to 'Public'", _propertyName);
-                PropertyInfo propertyInfo = _type.GetProperty(_value, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
+                PropertyInfo propertyInfo = _type.GetProperty(_value, BindingFlags.Static | BindingFlags.Public);
                 if (propertyInfo == null || !propertyInfo.CanRead || propertyInfo.PropertyType != typeof(string))
                     throw new ArgumentException($"Invalid resource property name! Localized value: {_value}", _propertyName);
                 _localizationPropertyInfo = propertyInfo;


### PR DESCRIPTION
This patch fixes the following issue:

* When specifying a name of a resource to use for the help text of an argument, the utility method responsible for retrieving the resource fails. One of the binding flags in this method (BindingFlag.GetProperty) is invalid. It should only be used in conjunction with the Type.InvokeMember method.

* The exception message that is thrown when a resource cannot be found will now contain the name of the resource in question. The exception message string was obviously supposed to be interpolated but the dollar sign marking it as such was missing.