### PR TITLE
fix spacing on help messages when verbs have aliases

### DIFF
--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -851,8 +851,8 @@ namespace CommandLine.Text
             var optionSpecs = from verbTuple in Verb.SelectFromTypes(types)
                               select
                                   OptionSpecification.NewSwitch(
-                                      verbTuple.Item1.Name,
-                                      verbTuple.Item1.Aliases.ToDelimitedString(", "),
+                                      string.Empty,
+                                      verbTuple.Item1.Name.Concat(verbTuple.Item1.Aliases).ToDelimitedString(", "),
                                       false,
                                       verbTuple.Item1.IsDefault ? "(Default Verb) " + verbTuple.Item1.HelpText : verbTuple.Item1.HelpText,  //Default verb
                                       string.Empty,

--- a/tests/CommandLine.Tests/Unit/Issue6Tests.cs
+++ b/tests/CommandLine.Tests/Unit/Issue6Tests.cs
@@ -89,17 +89,17 @@ namespace CommandLine.Tests.Unit
             {
                 "copy, cp, cpy    (Default Verb) Copy some stuff",
                 "move, mv",
-                "delete        Delete stuff",
-                "help          Display more information on a specific command.",
-                "version       Display version information.",
+                "delete           Delete stuff",
+                "help             Display more information on a specific command.",
+                "version          Display version information.",
             })]
         [InlineData("help", true, new string[]
             {
                 "copy, cp, cpy    (Default Verb) Copy some stuff",
                 "move, mv",
-                "delete        Delete stuff",
-                "help          Display more information on a specific command.",
-                "version       Display version information.",
+                "delete           Delete stuff",
+                "help             Display more information on a specific command.",
+                "version          Display version information.",
             })]
         [InlineData("move --help", false, new string[]
             {
@@ -163,16 +163,16 @@ namespace CommandLine.Tests.Unit
         [InlineData("--help", true, new string[]
             {
                 "move, mv",
-                "delete     Delete stuff",
-                "help       Display more information on a specific command.",
-                "version    Display version information.",
+                "delete      Delete stuff",
+                "help        Display more information on a specific command.",
+                "version     Display version information.",
             })]
         [InlineData("help", true, new string[]
             {
                 "move, mv",
-                "delete     Delete stuff",
-                "help       Display more information on a specific command.",
-                "version    Display version information.",
+                "delete      Delete stuff",
+                "help        Display more information on a specific command.",
+                "version     Display version information.",
             })]
         [InlineData("move --help", false, new string[]
             {


### PR DESCRIPTION
Fixes #6 
Fixes #517 
Fixes #636

Uses suggestion from @twaalewijn in https://github.com/commandlineparser/commandline/pull/636#issuecomment-645501830 to fix layout of help messages. Uses existing extension method for the concat instead of the exact one provided in the example.
