### PR TITLE
Add the simple HelpText.AutoBuild() function

### DIFF
--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -311,6 +311,19 @@ namespace CommandLine.Text
         /// <returns>
         /// An instance of <see cref="CommandLine.Text.HelpText"/> class.
         /// </returns>
+        /// <param name="maxDisplayWidth">The maximum width of the display.</param>
+        public static HelpText AutoBuild<T>(int maxDisplayWidth = DefaultMaximumLength)
+        {
+            var parserResult = new NotParsed<T>(TypeInfo.Create(typeof(T)), new List<Error>() { new HelpRequestedError() });
+            return AutoBuild<T>(parserResult, x => x, maxDisplayWidth);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="CommandLine.Text.HelpText"/> class using common defaults.
+        /// </summary>
+        /// <returns>
+        /// An instance of <see cref="CommandLine.Text.HelpText"/> class.
+        /// </returns>
         /// <param name='parserResult'>The <see cref="CommandLine.ParserResult{T}"/> containing the instance that collected command line arguments parsed with <see cref="CommandLine.Parser"/> class.</param>
         /// <param name='onError'>A delegate used to customize the text block of reporting parsing errors text block.</param>
         /// <param name='onExample'>A delegate used to customize <see cref="CommandLine.Text.Example"/> model used to render text block of usage examples.</param>

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -911,8 +911,25 @@ namespace CommandLine.Tests.Unit.Text
             lines[7].Should().BeEquivalentTo("--version             Display version information.");
         }
 
+        [Fact]
+        public void AutoText_simple()
+        {
+            var message = HelpText.AutoBuild<Simple_Options>();
+            var text = message.ToString();
+            var lines = text.ToNotEmptyLines().TrimStringArray();
+
+            // Skip two top heading lines 
+            lines[2].Should().BeEquivalentTo("--stringvalue         Define a string value here.");
+            lines[3].Should().BeEquivalentTo("-s, --shortandlong    Example with both short and long name.");
+            lines[4].Should().BeEquivalentTo("-i                    Define a int sequence here.");
+            lines[5].Should().BeEquivalentTo("-x                    Define a boolean or switch value here.");
+            lines[6].Should().BeEquivalentTo("--help                Display this help screen.");
+            lines[7].Should().BeEquivalentTo("--version             Display version information.");
+            lines[8].Should().BeEquivalentTo("value pos. 0          Define a long value here.");
+        }
+
         #region Custom Help
-        
+
         [Fact]
         [Trait("Category", "CustomHelp")]
         public void AutoBuild_with_custom_copyright_using_onError_action()


### PR DESCRIPTION
This is the minimal AutoText() function that can generate help text only from the command line parameters class. 

Example:
```
HelpText helpText = HelpText.AutoBuild<MyCommandLine>();
Console.WriteLine(helpText.ToString());
```

I find it very useful for simple utilities that do not use verbs and have to show help text in case of invalid input data that cannot be detected by parsing. 