### PR TITLE
Extend UnparserExtension with  FormatCommandLineArgs and SplitArgs methods

### DIFF
--- a/tests/CommandLine.Tests/Unit/UnParserExtensionsTests.cs
+++ b/tests/CommandLine.Tests/Unit/UnParserExtensionsTests.cs
@@ -25,6 +25,16 @@ namespace CommandLine.Tests.Unit
         }
 
         [Theory]
+        [MemberData(nameof(UnParseData))]
+        public static void UnParsing_instance_with_splitArgs_returns_same_option_class(Simple_Options options, string result)
+        {
+           new Parser()
+            .FormatCommandLineArgs(options)
+            .Should().BeEquivalentTo(result.SplitArgs());
+             
+        }
+
+        [Theory]
         [MemberData(nameof(UnParseFileDirectoryData))]
         public static void UnParsing_instance_returns_command_line_for_file_directory_paths(Options_With_FileDirectoryInfo options, string result)
         {
@@ -34,12 +44,29 @@ namespace CommandLine.Tests.Unit
         }
 
         [Theory]
+        [MemberData(nameof(UnParseFileDirectoryData))]
+        public static void UnParsing_instance_by_splitArgs_returns_command_line_for_file_directory_paths(Options_With_FileDirectoryInfo options, string result)
+        {
+            new Parser()
+                .FormatCommandLineArgs(options)
+                .Should().BeEquivalentTo(result.SplitArgs());
+        }
+        [Theory]
         [MemberData(nameof(UnParseDataVerbs))]
         public static void UnParsing_instance_returns_command_line_for_verbs(Add_Verb verb, string result)
         {
             new Parser()
                 .FormatCommandLine(verb)
                 .Should().BeEquivalentTo(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnParseDataVerbs))]
+        public static void UnParsing_instance_to_splitArgs_returns_command_line_for_verbs(Add_Verb verb, string result)
+        {
+            new Parser()
+                .FormatCommandLineArgs(verb)
+                .Should().BeEquivalentTo(result.SplitArgs());
         }
 
         [Theory]


### PR DESCRIPTION
- Fix  #375, #628 and #665
- Extend UnparserExtension with  FormatCommandLineArgs 
- Provide SplitArgs method that can split commandline string and  handle double quote and extra spaces and help in avoiding  use of  triple  quoted string and split interactive arguments #654.
- Replace Split() used in testing.
