### PR TITLE
Sequences that hit max should stop grabbing values

### DIFF
--- a/src/CommandLine/Core/TokenPartitioner.cs
+++ b/src/CommandLine/Core/TokenPartitioner.cs
@@ -96,7 +96,6 @@ namespace CommandLine.Core
                         case SequenceState.TokenSearch:
                         case SequenceState.ScalarTokenFound when nameToken == null:
                         case SequenceState.SequenceTokenFound when nameToken == null:
-                            // if (nameToken == null) Console.WriteLine($"  (because there was no nameToken)");
                             nameToken = null;
                             nonOptionTokens.Add(token);
                             state = SequenceState.TokenSearch;
@@ -110,14 +109,14 @@ namespace CommandLine.Core
 
                         case SequenceState.SequenceTokenFound:
                             if (sequences.TryGetValue(nameToken, out var sequence)) {
-                                // if (max[nameToken].MatchJust(out int m) && count[nameToken] >= m)
-                                // {
-                                //     // This sequence is completed, so this and any further values are non-option values
-                                //     nameToken = null;
-                                //     nonOptionTokens.Add(token);
-                                //     state = SequenceState.TokenSearch;
-                                // }
-                                // else
+                                if (max[nameToken].MatchJust(out int m) && count[nameToken] >= m)
+                                {
+                                    // This sequence is completed, so this and any further values are non-option values
+                                    nameToken = null;
+                                    nonOptionTokens.Add(token);
+                                    state = SequenceState.TokenSearch;
+                                }
+                                else
                                 {
                                     sequence.Add(token);
                                     count[nameToken]++;
@@ -125,9 +124,10 @@ namespace CommandLine.Core
                             }
                             else
                             {
-                                Console.WriteLine("***BUG!!!***");
-                                throw new NullReferenceException($"Sequence for name {nameToken} doesn't exist, and it should");
-                                // sequences[nameToken] = new List<Token>(new[] { token });
+                                // Should never get here, but just in case:
+                                sequences[nameToken] = new List<Token>(new[] { token });
+                                count[nameToken] = 0;
+                                max[nameToken] = Maybe.Nothing<int>();
                             }
                             break;
                         }

--- a/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
@@ -185,7 +185,7 @@ namespace CommandLine.Tests.Unit.Core
         }
 
         [Fact]
-        public void Breaking_min_constraint_in_string_sequence_gererates_MissingValueOptionError()
+        public void Breaking_min_constraint_in_string_sequence_generates_MissingValueOptionError()
         {
             // Fixture setup
             var expectedResult = new[] { new MissingValueOptionError(new NameInfo("s", "string-seq")) };
@@ -199,7 +199,7 @@ namespace CommandLine.Tests.Unit.Core
         }
 
         [Fact]
-        public void Breaking_min_constraint_in_string_sequence_as_value_gererates_SequenceOutOfRangeError()
+        public void Breaking_min_constraint_in_string_sequence_as_value_generates_SequenceOutOfRangeError()
         {
             // Fixture setup
             var expectedResult = new[] { new SequenceOutOfRangeError(NameInfo.EmptyName) };
@@ -213,21 +213,22 @@ namespace CommandLine.Tests.Unit.Core
         }
 
         [Fact]
-        public void Breaking_max_constraint_in_string_sequence_gererates_SequenceOutOfRangeError()
+        public void Breaking_max_constraint_in_string_sequence_does_not_generate_SequenceOutOfRangeError()
         {
             // Fixture setup
-            var expectedResult = new[] { new SequenceOutOfRangeError(new NameInfo("s", "string-seq")) };
+            var expectedResult = new[] { "one", "two", "three" };
 
             // Exercize system 
             var result = InvokeBuild<Options_With_Sequence_And_Only_Max_Constraint>(
                 new[] { "--string-seq=one", "two", "three", "this-is-too-much" });
 
             // Verify outcome
-            ((NotParsed<Options_With_Sequence_And_Only_Max_Constraint>)result).Errors.Should().BeEquivalentTo(expectedResult);
+            ((Parsed<Options_With_Sequence_And_Only_Max_Constraint>)result).Value.StringSequence.Should().BeEquivalentTo(expectedResult);
+            // The "this-is-too-much" arg would end up assigned to a Value; since there is no Value, it is silently dropped
         }
 
         [Fact]
-        public void Breaking_max_constraint_in_string_sequence_as_value_gererates_SequenceOutOfRangeError()
+        public void Breaking_max_constraint_in_string_sequence_as_value_generates_SequenceOutOfRangeError()
         {
             // Fixture setup
             var expectedResult = new[] { new SequenceOutOfRangeError(NameInfo.EmptyName) };
@@ -427,7 +428,7 @@ namespace CommandLine.Tests.Unit.Core
         }
 
         [Fact]
-        public void Parse_option_from_different_sets_gererates_MutuallyExclusiveSetError()
+        public void Parse_option_from_different_sets_generates_MutuallyExclusiveSetError()
         {
             // Fixture setup
             var expectedResult = new[]
@@ -480,7 +481,7 @@ namespace CommandLine.Tests.Unit.Core
         }
 
         [Fact]
-        public void Omitting_required_option_gererates_MissingRequiredOptionError()
+        public void Omitting_required_option_generates_MissingRequiredOptionError()
         {
             // Fixture setup
             var expectedResult = new[] { new MissingRequiredOptionError(new NameInfo("", "str")) };
@@ -494,7 +495,7 @@ namespace CommandLine.Tests.Unit.Core
         }
 
         [Fact]
-        public void Wrong_range_in_sequence_gererates_SequenceOutOfRangeError()
+        public void Wrong_range_in_sequence_generates_SequenceOutOfRangeError()
         {
             // Fixture setup
             var expectedResult = new[] { new SequenceOutOfRangeError(new NameInfo("i", "")) };
@@ -508,7 +509,7 @@ namespace CommandLine.Tests.Unit.Core
         }
 
         [Fact]
-        public void Parse_unknown_long_option_gererates_UnknownOptionError()
+        public void Parse_unknown_long_option_generates_UnknownOptionError()
         {
             // Fixture setup
             var expectedResult = new[] { new UnknownOptionError("xyz") };
@@ -522,7 +523,7 @@ namespace CommandLine.Tests.Unit.Core
         }
 
         [Fact]
-        public void Parse_unknown_short_option_gererates_UnknownOptionError()
+        public void Parse_unknown_short_option_generates_UnknownOptionError()
         {
             // Fixture setup
             var expectedResult = new[] { new UnknownOptionError("z") };
@@ -536,7 +537,7 @@ namespace CommandLine.Tests.Unit.Core
         }
 
         [Fact]
-        public void Parse_unknown_short_option_in_option_group_gererates_UnknownOptionError()
+        public void Parse_unknown_short_option_in_option_group_generates_UnknownOptionError()
         {
             // Fixture setup
             var expectedResult = new[] { new UnknownOptionError("z") };
@@ -596,7 +597,7 @@ namespace CommandLine.Tests.Unit.Core
         }
 
         [Fact]
-        public void Breaking_equal_min_max_constraint_in_string_sequence_as_value_gererates_SequenceOutOfRangeError()
+        public void Breaking_equal_min_max_constraint_in_string_sequence_as_value_generates_SequenceOutOfRangeError()
         {
             // Fixture setup
             var expectedResult = new[] { new SequenceOutOfRangeError(NameInfo.EmptyName) };

--- a/tests/CommandLine.Tests/Unit/Core/SequenceTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/SequenceTests.cs
@@ -133,7 +133,7 @@ namespace CommandLine.Tests.Unit.Core
         [Fact]
         public void Partition_sequence_multi_instance_with_max()
         {
-            var expected = new[]
+            var incorrect = new[]
             {
                 Token.Name("seq"),
                 Token.Value("seqval0"),
@@ -142,6 +142,14 @@ namespace CommandLine.Tests.Unit.Core
                 Token.Value("seqval3"),
                 Token.Value("seqval4"),
                 Token.Value("seqval5"),
+            };
+
+            var expected = new[]
+            {
+                Token.Name("seq"),
+                Token.Value("seqval0"),
+                Token.Value("seqval1"),
+                Token.Value("seqval2"),
             };
 
             var tokens = TokenPartitioner.PartitionTokensByType(
@@ -159,6 +167,8 @@ namespace CommandLine.Tests.Unit.Core
                         : Maybe.Nothing<TypeDescriptor>());
             var result = tokens.Item3;  // Switch, Scalar, *Sequence*, NonOption
 
+            // Max of 3 will apply to the total values, so there should only be 3 values, not 6
+            Assert.NotEqual(incorrect, result);
             Assert.Equal(expected, result);
         }
     }


### PR DESCRIPTION
Once a sequence option that has Max=N has hit N values, it will stop grabbing values from the command line, and any remaining values will be able to be assigned to other properties with the Value attribute.

Fixes #681.

Two unit tests had incorrect semantics, as discussed in #681, so this also changes those two tests to expect the correct behavior for sequences with Max=N. I also fixed a spelling mistake (gererates instead of generates) while I was working in the InstanceBuilderTests.cs file on one of those two unit tests.