### PR TITLE
Add GetoptMode parser setting and implementation

### DIFF
--- a/src/CommandLine/Core/GetoptTokenizer.cs
+++ b/src/CommandLine/Core/GetoptTokenizer.cs
@@ -94,19 +94,28 @@ namespace CommandLine.Core
         {
             var tokens = tokenizerResult.SucceededWith().Memoize();
 
-            var replaces = tokens.Select((t, i) =>
-                optionSequenceWithSeparatorLookup(t.Text)
-                    .MapValueOrDefault(sep => Tuple.Create(i + 1, sep),
-                        Tuple.Create(-1, '\0'))).SkipWhile(x => x.Item1 < 0).Memoize();
-
-            var exploded = tokens.Select((t, i) =>
-                        replaces.FirstOrDefault(x => x.Item1 == i).ToMaybe()
-                            .MapValueOrDefault(r => t.Text.Split(r.Item2).Select(Token.Value),
-                                Enumerable.Empty<Token>().Concat(new[] { t })));
-
-            var flattened = exploded.SelectMany(x => x);
-
-            return Result.Succeed(flattened, tokenizerResult.SuccessMessages());
+            var exploded = new List<Token>(tokens is ICollection<Token> coll ? coll.Count : tokens.Count());
+            var nothing = Maybe.Nothing<char>();  // Re-use same Nothing instance for efficiency
+            var separator = nothing;
+            foreach (var token in tokens) {
+                if (token.IsName()) {
+                    separator = optionSequenceWithSeparatorLookup(token.Text);
+                    exploded.Add(token);
+                } else {
+                    // Forced values are never considered option values, so they should not be split
+                    if (separator.MatchJust(out char sep) && sep != '\0' && !token.IsValueForced()) {
+                        if (token.Text.Contains(sep)) {
+                            exploded.AddRange(token.Text.Split(sep).Select(Token.ValueFromSeparator));
+                        } else {
+                            exploded.Add(token);
+                        }
+                    } else {
+                        exploded.Add(token);
+                    }
+                    separator = nothing;  // Only first value after a separator can possibly be split
+                }
+            }
+            return Result.Succeed(exploded as IEnumerable<Token>, tokenizerResult.SuccessMessages());
         }
 
         public static Func<

--- a/src/CommandLine/Core/GetoptTokenizer.cs
+++ b/src/CommandLine/Core/GetoptTokenizer.cs
@@ -1,0 +1,219 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CommandLine.Infrastructure;
+using CSharpx;
+using RailwaySharp.ErrorHandling;
+using System.Text.RegularExpressions;
+
+namespace CommandLine.Core
+{
+    static class GetoptTokenizer
+    {
+        public static Result<IEnumerable<Token>, Error> Tokenize(
+            IEnumerable<string> arguments,
+            Func<string, NameLookupResult> nameLookup)
+        {
+            return GetoptTokenizer.Tokenize(arguments, nameLookup, ignoreUnknownArguments:false, allowDashDash:true, posixlyCorrect:false);
+        }
+
+        public static Result<IEnumerable<Token>, Error> Tokenize(
+            IEnumerable<string> arguments,
+            Func<string, NameLookupResult> nameLookup,
+            bool ignoreUnknownArguments,
+            bool allowDashDash,
+            bool posixlyCorrect)
+        {
+            var errors = new List<Error>();
+            Action<string> onBadFormatToken = arg => errors.Add(new BadFormatTokenError(arg));
+            Action<string> unknownOptionError = name => errors.Add(new UnknownOptionError(name));
+            Action<string> doNothing = name => {};
+            Action<string> onUnknownOption = ignoreUnknownArguments ? doNothing : unknownOptionError;
+
+            int consumeNext = 0;
+            Action<int> onConsumeNext = (n => consumeNext = consumeNext + n);
+            bool forceValues = false;
+
+            var tokens = new List<Token>();
+
+            var enumerator = arguments.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                switch (enumerator.Current) {
+                    case null:
+                        break;
+
+                    case string arg when forceValues:
+                        tokens.Add(Token.ValueForced(arg));
+                        break;
+
+                    case string arg when consumeNext > 0:
+                        tokens.Add(Token.Value(arg));
+                        consumeNext = consumeNext - 1;
+                        break;
+
+                    case "--" when allowDashDash:
+                        forceValues = true;
+                        break;
+
+                    case "--":
+                        tokens.Add(Token.Value("--"));
+                        if (posixlyCorrect) forceValues = true;
+                        break;
+
+                    case "-":
+                        // A single hyphen is always a value (it usually means "read from stdin" or "write to stdout")
+                        tokens.Add(Token.Value("-"));
+                        if (posixlyCorrect) forceValues = true;
+                        break;
+
+                    case string arg when arg.StartsWith("--"):
+                        tokens.AddRange(TokenizeLongName(arg, nameLookup, onBadFormatToken, onUnknownOption, onConsumeNext));
+                        break;
+
+                    case string arg when arg.StartsWith("-"):
+                        tokens.AddRange(TokenizeShortName(arg, nameLookup, onUnknownOption, onConsumeNext));
+                        break;
+
+                    case string arg:
+                        // If we get this far, it's a plain value
+                        tokens.Add(Token.Value(arg));
+                        if (posixlyCorrect) forceValues = true;
+                        break;
+                }
+            }
+
+            return Result.Succeed<IEnumerable<Token>, Error>(tokens.AsEnumerable(), errors.AsEnumerable());
+        }
+
+        public static Result<IEnumerable<Token>, Error> ExplodeOptionList(
+            Result<IEnumerable<Token>, Error> tokenizerResult,
+            Func<string, Maybe<char>> optionSequenceWithSeparatorLookup)
+        {
+            var tokens = tokenizerResult.SucceededWith().Memoize();
+
+            var replaces = tokens.Select((t, i) =>
+                optionSequenceWithSeparatorLookup(t.Text)
+                    .MapValueOrDefault(sep => Tuple.Create(i + 1, sep),
+                        Tuple.Create(-1, '\0'))).SkipWhile(x => x.Item1 < 0).Memoize();
+
+            var exploded = tokens.Select((t, i) =>
+                        replaces.FirstOrDefault(x => x.Item1 == i).ToMaybe()
+                            .MapValueOrDefault(r => t.Text.Split(r.Item2).Select(Token.Value),
+                                Enumerable.Empty<Token>().Concat(new[] { t })));
+
+            var flattened = exploded.SelectMany(x => x);
+
+            return Result.Succeed(flattened, tokenizerResult.SuccessMessages());
+        }
+
+        public static Func<
+                    IEnumerable<string>,
+                    IEnumerable<OptionSpecification>,
+                    Result<IEnumerable<Token>, Error>>
+            ConfigureTokenizer(
+                    StringComparer nameComparer,
+                    bool ignoreUnknownArguments,
+                    bool enableDashDash,
+                    bool posixlyCorrect)
+        {
+            return (arguments, optionSpecs) =>
+                {
+                    var tokens = GetoptTokenizer.Tokenize(arguments, name => NameLookup.Contains(name, optionSpecs, nameComparer), ignoreUnknownArguments, enableDashDash, posixlyCorrect);
+                    var explodedTokens = GetoptTokenizer.ExplodeOptionList(tokens, name => NameLookup.HavingSeparator(name, optionSpecs, nameComparer));
+                    return explodedTokens;
+                };
+        }
+
+        private static IEnumerable<Token> TokenizeShortName(
+            string arg,
+            Func<string, NameLookupResult> nameLookup,
+            Action<string> onUnknownOption,
+            Action<int> onConsumeNext)
+        {
+
+            // First option char that requires a value means we swallow the rest of the string as the value
+            // But if there is no rest of the string, then instead we swallow the next argument
+            string chars = arg.Substring(1);
+            int len = chars.Length;
+            if (len > 0 && Char.IsDigit(chars[0]))
+            {
+                // Assume it's a negative number
+                yield return Token.Value(arg);
+                yield break;
+            }
+            for (int i = 0; i < len; i++)
+            {
+                var s = new String(chars[i], 1);
+                switch(nameLookup(s))
+                {
+                    case NameLookupResult.OtherOptionFound:
+                        yield return Token.Name(s);
+
+                        if (i+1 < len)
+                        {
+                            // Rest of this is the value (e.g. "-sfoo" where "-s" is a string-consuming arg)
+                            yield return Token.Value(chars.Substring(i+1));
+                            yield break;
+                        }
+                        else
+                        {
+                            // Value is in next param (e.g., "-s foo")
+                            onConsumeNext(1);
+                        }
+                        break;
+
+                    case NameLookupResult.NoOptionFound:
+                        onUnknownOption(s);
+                        break;
+
+                    default:
+                        yield return Token.Name(s);
+                        break;
+                }
+            }
+        }
+
+        private static IEnumerable<Token> TokenizeLongName(
+            string arg,
+            Func<string, NameLookupResult> nameLookup,
+            Action<string> onBadFormatToken,
+            Action<string> onUnknownOption,
+            Action<int> onConsumeNext)
+        {
+            string[] parts = arg.Substring(2).Split(new char[] { '=' }, 2);
+            string name = parts[0];
+            string value = (parts.Length > 1) ? parts[1] : null;
+            // A parameter like "--stringvalue=" is acceptable, and makes stringvalue be the empty string
+            if (String.IsNullOrWhiteSpace(name) || name.Contains(" "))
+            {
+                onBadFormatToken(arg);
+                yield break;
+            }
+            switch(nameLookup(name))
+            {
+                case NameLookupResult.NoOptionFound:
+                    onUnknownOption(name);
+                    yield break;
+
+                case NameLookupResult.OtherOptionFound:
+                    yield return Token.Name(name);
+                    if (value == null) // NOT String.IsNullOrEmpty
+                    {
+                        onConsumeNext(1);
+                    }
+                    else
+                    {
+                        yield return Token.Value(value);
+                    }
+                    break;
+
+                default:
+                    yield return Token.Name(name);
+                    break;
+            }
+        }
+    }
+}

--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -88,14 +88,14 @@ namespace CommandLine.Core
                     OptionMapper.MapValues(
                         (from pt in specProps where pt.Specification.IsOption() select pt),
                         optionsPartition,
-                        (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, parsingCulture, ignoreValueCase),
+                        (vals, type, isScalar, isFlag) => TypeConverter.ChangeType(vals, type, isScalar, isFlag, parsingCulture, ignoreValueCase),
                         nameComparer);
 
                 var valueSpecPropsResult =
                     ValueMapper.MapValues(
                         (from pt in specProps where pt.Specification.IsValue() orderby ((ValueSpecification)pt.Specification).Index select pt),
                         valuesPartition,    
-                        (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, parsingCulture, ignoreValueCase));
+                        (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, false, parsingCulture, ignoreValueCase));
 
                 var missingValueErrors = from token in errorsPartition
                                          select

--- a/src/CommandLine/Core/NameLookup.cs
+++ b/src/CommandLine/Core/NameLookup.cs
@@ -20,7 +20,7 @@ namespace CommandLine.Core
         {
             var option = specifications.FirstOrDefault(a => name.MatchName(a.ShortName, a.LongName, comparer));
             if (option == null) return NameLookupResult.NoOptionFound;
-            return option.ConversionType == typeof(bool)
+            return option.ConversionType == typeof(bool) || (option.ConversionType == typeof(int) && option.FlagCounter)
                 ? NameLookupResult.BooleanOptionFound
                 : NameLookupResult.OtherOptionFound;
         }

--- a/src/CommandLine/Core/OptionMapper.cs
+++ b/src/CommandLine/Core/OptionMapper.cs
@@ -15,7 +15,7 @@ namespace CommandLine.Core
             MapValues(
                 IEnumerable<SpecificationProperty> propertyTuples,
                 IEnumerable<KeyValuePair<string, IEnumerable<string>>> options,
-                Func<IEnumerable<string>, Type, bool, Maybe<object>> converter,
+                Func<IEnumerable<string>, Type, bool, bool, Maybe<object>> converter,
                 StringComparer comparer)
         {
             var sequencesAndErrors = propertyTuples
@@ -27,7 +27,7 @@ namespace CommandLine.Core
                         if (matched.IsJust())
                         {
                             var matches = matched.GetValueOrDefault(Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>());
-                            var values = new HashSet<string>();
+                            var values = new List<string>();
                             foreach (var kvp in matches)
                             {
                                 foreach (var value in kvp.Value)
@@ -36,7 +36,9 @@ namespace CommandLine.Core
                                 }
                             }
 
-                            return converter(values, pt.Property.PropertyType, pt.Specification.TargetType != TargetType.Sequence)
+                            bool isFlag = pt.Specification.Tag == SpecificationType.Option && ((OptionSpecification)pt.Specification).FlagCounter;
+
+                            return converter(values, isFlag ? typeof(bool) : pt.Property.PropertyType, pt.Specification.TargetType != TargetType.Sequence, isFlag)
                                 .Select(value => Tuple.Create(pt.WithValue(Maybe.Just(value)), Maybe.Nothing<Error>()))
                                 .GetValueOrDefault(
                                     Tuple.Create<SpecificationProperty, Maybe<Error>>(

--- a/src/CommandLine/Core/OptionSpecification.cs
+++ b/src/CommandLine/Core/OptionSpecification.cs
@@ -14,18 +14,20 @@ namespace CommandLine.Core
         private readonly char separator;
         private readonly string setName;
         private readonly string group;
+        private readonly bool flagCounter;
 
         public OptionSpecification(string shortName, string longName, bool required, string setName, Maybe<int> min, Maybe<int> max,
             char separator, Maybe<object> defaultValue, string helpText, string metaValue, IEnumerable<string> enumValues,
-            Type conversionType, TargetType targetType, string group, bool hidden = false)
+            Type conversionType, TargetType targetType, string group, bool flagCounter = false, bool hidden = false)
             : base(SpecificationType.Option,
-                 required, min, max, defaultValue, helpText, metaValue, enumValues, conversionType, targetType, hidden)
+                 required, min, max, defaultValue, helpText, metaValue, enumValues, conversionType, conversionType == typeof(int) && flagCounter ? TargetType.Switch : targetType, hidden)
         {
             this.shortName = shortName;
             this.longName = longName;
             this.separator = separator;
             this.setName = setName;
             this.group = group;
+            this.flagCounter = flagCounter;
         }
 
         public static OptionSpecification FromAttribute(OptionAttribute attribute, Type conversionType, IEnumerable<string> enumValues)
@@ -45,13 +47,14 @@ namespace CommandLine.Core
                 conversionType,
                 conversionType.ToTargetType(),
                 attribute.Group,
+                attribute.FlagCounter,
                 attribute.Hidden);
         }
 
         public static OptionSpecification NewSwitch(string shortName, string longName, bool required, string helpText, string metaValue, bool hidden = false)
         {
             return new OptionSpecification(shortName, longName, required, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(),
-                '\0', Maybe.Nothing<object>(), helpText, metaValue, Enumerable.Empty<string>(), typeof(bool), TargetType.Switch, string.Empty, hidden);
+                '\0', Maybe.Nothing<object>(), helpText, metaValue, Enumerable.Empty<string>(), typeof(bool), TargetType.Switch, string.Empty, false, hidden);
         }
 
         public string ShortName
@@ -77,6 +80,14 @@ namespace CommandLine.Core
         public string Group
         {
             get { return group; }
+        }
+
+        /// <summary>
+        /// Whether this is an int option that counts how many times a flag was set rather than taking a value on the command line
+        /// </summary>
+        public bool FlagCounter
+        {
+            get { return flagCounter; }
         }
     }
 }

--- a/src/CommandLine/Core/SpecificationExtensions.cs
+++ b/src/CommandLine/Core/SpecificationExtensions.cs
@@ -35,6 +35,7 @@ namespace CommandLine.Core
                 specification.ConversionType,
                 specification.TargetType,
                 specification.Group,
+                specification.FlagCounter,
                 specification.Hidden);
         }
 

--- a/src/CommandLine/Core/Token.cs
+++ b/src/CommandLine/Core/Token.cs
@@ -34,7 +34,12 @@ namespace CommandLine.Core
 
         public static Token ValueForced(string text)
         {
-            return new Value(text, false, true);
+            return new Value(text, false, true, false);
+        }
+
+        public static Token ValueFromSeparator(string text)
+        {
+            return new Value(text, false, false, true);
         }
 
         public TokenType Tag
@@ -86,29 +91,45 @@ namespace CommandLine.Core
     {
         private readonly bool explicitlyAssigned;
         private readonly bool forced;
+        private readonly bool fromSeparator;
 
         public Value(string text)
-            : this(text, false, false)
+            : this(text, false, false, false)
         {
         }
 
         public Value(string text, bool explicitlyAssigned)
-            : this(text, explicitlyAssigned, false)
+            : this(text, explicitlyAssigned, false, false)
         {
         }
 
-        public Value(string text, bool explicitlyAssigned, bool forced)
+        public Value(string text, bool explicitlyAssigned, bool forced, bool fromSeparator)
             : base(TokenType.Value, text)
         {
             this.explicitlyAssigned = explicitlyAssigned;
             this.forced = forced;
+            this.fromSeparator = fromSeparator;
         }
 
+        /// <summary>
+        /// Whether this value came from a long option with "=" separating the name from the value
+        /// </summary>
         public bool ExplicitlyAssigned
         {
             get { return explicitlyAssigned; }
         }
 
+        /// <summary>
+        /// Whether this value came from a sequence specified with a separator (e.g., "--files a.txt,b.txt,c.txt")
+        /// </summary>
+        public bool FromSeparator
+        {
+            get { return fromSeparator; }
+        }
+
+        /// <summary>
+        /// Whether this value came from args after the -- separator (when EnableDashDash = true)
+        /// </summary>
         public bool Forced
         {
             get { return forced; }
@@ -151,6 +172,11 @@ namespace CommandLine.Core
         public static bool IsValue(this Token token)
         {
             return token.Tag == TokenType.Value;
+        }
+
+        public static bool IsValueFromSeparator(this Token token)
+        {
+            return token.IsValue() && ((Value)token).FromSeparator;
         }
 
         public static bool IsValueForced(this Token token)

--- a/src/CommandLine/Core/TypeConverter.cs
+++ b/src/CommandLine/Core/TypeConverter.cs
@@ -13,11 +13,13 @@ namespace CommandLine.Core
 {
     static class TypeConverter
     {
-        public static Maybe<object> ChangeType(IEnumerable<string> values, Type conversionType, bool scalar, CultureInfo conversionCulture, bool ignoreValueCase)
+        public static Maybe<object> ChangeType(IEnumerable<string> values, Type conversionType, bool scalar, bool isFlag, CultureInfo conversionCulture, bool ignoreValueCase)
         {
-            return scalar
-                ? ChangeTypeScalar(values.Last(), conversionType, conversionCulture, ignoreValueCase)
-                : ChangeTypeSequence(values, conversionType, conversionCulture, ignoreValueCase);
+            return isFlag
+                ? ChangeTypeFlagCounter(values, conversionType, conversionCulture, ignoreValueCase)
+                : scalar
+                    ? ChangeTypeScalar(values.Last(), conversionType, conversionCulture, ignoreValueCase)
+                    : ChangeTypeSequence(values, conversionType, conversionCulture, ignoreValueCase);
         }
 
         private static Maybe<object> ChangeTypeSequence(IEnumerable<string> values, Type conversionType, CultureInfo conversionCulture, bool ignoreValueCase)
@@ -44,6 +46,14 @@ namespace CommandLine.Core
             result.Match((_,__) => { }, e => e.First().RethrowWhenAbsentIn(
                 new[] { typeof(InvalidCastException), typeof(FormatException), typeof(OverflowException) }));
             return result.ToMaybe();
+        }
+
+        private static Maybe<object> ChangeTypeFlagCounter(IEnumerable<string> values, Type conversionType, CultureInfo conversionCulture, bool ignoreValueCase)
+        {
+            var converted = values.Select(value => ChangeTypeScalar(value, typeof(bool), conversionCulture, ignoreValueCase));
+            return converted.Any(maybe => maybe.MatchNothing())
+                ? Maybe.Nothing<object>()
+                : Maybe.Just((object)converted.Count(value => value.IsJust()));
         }
 
         private static object ConvertString(string value, Type type, CultureInfo conversionCulture)

--- a/src/CommandLine/Infrastructure/StringExtensions.cs
+++ b/src/CommandLine/Infrastructure/StringExtensions.cs
@@ -73,5 +73,23 @@ namespace CommandLine.Infrastructure
         {
             return value.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
+
+        public static bool ToBooleanLoose(this string value)
+        {
+            if ((string.IsNullOrEmpty(value)) ||
+                (value == "0") ||
+                (value.Equals("f", StringComparison.OrdinalIgnoreCase)) ||
+                (value.Equals("n", StringComparison.OrdinalIgnoreCase)) ||
+                (value.Equals("no", StringComparison.OrdinalIgnoreCase)) ||
+                (value.Equals("off", StringComparison.OrdinalIgnoreCase)) ||
+                (value.Equals("false", StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
     }
 }

--- a/src/CommandLine/OptionAttribute.cs
+++ b/src/CommandLine/OptionAttribute.cs
@@ -15,6 +15,7 @@ namespace CommandLine
         private readonly string longName;
         private readonly string shortName;
         private string setName;
+        private bool flagCounter;
         private char separator;
         private string group=string.Empty;
 
@@ -94,6 +95,16 @@ namespace CommandLine
 
                 setName = value;
             }
+        }
+
+        /// <summary>
+        /// If true, this is an int option that counts how many times a flag was set (e.g. "-v -v -v" or "-vvv" would return 3).
+        /// The property must be of type int (signed 32-bit integer).
+        /// </summary>
+        public bool FlagCounter
+        {
+            get { return flagCounter; }
+            set { flagCounter = value; }
         }
 
         /// <summary>

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -185,8 +185,13 @@ namespace CommandLine
                 IEnumerable<OptionSpecification> optionSpecs,
                 ParserSettings settings)
         {
-            return
-                Tokenizer.ConfigureTokenizer(
+            return settings.GetoptMode
+                ? GetoptTokenizer.ConfigureTokenizer(
+                    settings.NameComparer,
+                    settings.IgnoreUnknownArguments,
+                    settings.EnableDashDash,
+                    settings.PosixlyCorrect)(arguments, optionSpecs)
+                : Tokenizer.ConfigureTokenizer(
                     settings.NameComparer,
                     settings.IgnoreUnknownArguments,
                     settings.EnableDashDash)(arguments, optionSpecs);

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -185,16 +185,28 @@ namespace CommandLine
                 IEnumerable<OptionSpecification> optionSpecs,
                 ParserSettings settings)
         {
-            return settings.GetoptMode
-                ? GetoptTokenizer.ConfigureTokenizer(
-                    settings.NameComparer,
-                    settings.IgnoreUnknownArguments,
-                    settings.EnableDashDash,
-                    settings.PosixlyCorrect)(arguments, optionSpecs)
-                : Tokenizer.ConfigureTokenizer(
+            switch (settings.ParserMode)
+            {
+                case ParserMode.Legacy:
+                return Tokenizer.ConfigureTokenizer(
                     settings.NameComparer,
                     settings.IgnoreUnknownArguments,
                     settings.EnableDashDash)(arguments, optionSpecs);
+
+                case ParserMode.Getopt:
+                return GetoptTokenizer.ConfigureTokenizer(
+                    settings.NameComparer,
+                    settings.IgnoreUnknownArguments,
+                    settings.EnableDashDash,
+                    settings.PosixlyCorrect)(arguments, optionSpecs);
+
+                // No need to test ParserMode.Default, as it should always be one of the above modes
+                default:
+                return Tokenizer.ConfigureTokenizer(
+                    settings.NameComparer,
+                    settings.IgnoreUnknownArguments,
+                    settings.EnableDashDash)(arguments, optionSpecs);
+            }
         }
 
         private static ParserResult<T> MakeParserResult<T>(ParserResult<T> parserResult, ParserSettings settings)

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 
 using CommandLine.Infrastructure;
+using CSharpx;
 
 namespace CommandLine
 {
@@ -23,9 +24,11 @@ namespace CommandLine
         private bool autoHelp;
         private bool autoVersion;
         private CultureInfo parsingCulture;
-        private bool enableDashDash;
+        private Maybe<bool> enableDashDash;
         private int maximumDisplayWidth;
-        private bool allowMultiInstance;
+        private Maybe<bool> allowMultiInstance;
+        private bool getoptMode;
+        private Maybe<bool> posixlyCorrect;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ParserSettings"/> class.
@@ -38,6 +41,10 @@ namespace CommandLine
             autoVersion = true;
             parsingCulture = CultureInfo.InvariantCulture;
             maximumDisplayWidth = GetWindowWidth();
+            getoptMode = false;
+            enableDashDash = Maybe.Nothing<bool>();
+            allowMultiInstance = Maybe.Nothing<bool>();
+            posixlyCorrect = Maybe.Nothing<bool>();
         }
 
         private int GetWindowWidth()
@@ -159,11 +166,12 @@ namespace CommandLine
         /// <summary>
         /// Gets or sets a value indicating whether enable double dash '--' syntax,
         /// that forces parsing of all subsequent tokens as values.
+        /// If GetoptMode is true, this defaults to true, but can be turned off by explicitly specifying EnableDashDash = false.
         /// </summary>
         public bool EnableDashDash
         {
-            get { return enableDashDash; }
-            set { PopsicleSetter.Set(Consumed, ref enableDashDash, value); }
+            get => enableDashDash.MatchJust(out bool value) ? value : getoptMode;
+            set => PopsicleSetter.Set(Consumed, ref enableDashDash, Maybe.Just(value));
         }
 
         /// <summary>
@@ -177,11 +185,31 @@ namespace CommandLine
 
         /// <summary>
         /// Gets or sets a value indicating whether options are allowed to be specified multiple times.
+        /// If GetoptMode is true, this defaults to true, but can be turned off by explicitly specifying AllowMultiInstance = false.
         /// </summary>
         public bool AllowMultiInstance
         {
-            get => allowMultiInstance;
-            set => PopsicleSetter.Set(Consumed, ref allowMultiInstance, value);
+            get => allowMultiInstance.MatchJust(out bool value) ? value : getoptMode;
+            set => PopsicleSetter.Set(Consumed, ref allowMultiInstance, Maybe.Just(value));
+        }
+
+        /// <summary>
+        /// Whether strict getopt-like processing is applied to option values; if true, AllowMultiInstance and EnableDashDash will default to true as well.
+        /// </summary>
+        public bool GetoptMode
+        {
+            get => getoptMode;
+            set => PopsicleSetter.Set(Consumed, ref getoptMode, value);
+        }
+
+        /// <summary>
+        /// Whether getopt-like processing should follow the POSIX rules (the equivalent of using the "+" prefix in the C getopt() call).
+        /// If not explicitly set, will default to false unless the POSIXLY_CORRECT environment variable is set, in which case it will default to true.
+        /// </summary>
+        public bool PosixlyCorrect
+        {
+            get => posixlyCorrect.MapValueOrDefault(val => val, () => Environment.GetEnvironmentVariable("POSIXLY_CORRECT").ToBooleanLoose());
+            set => PopsicleSetter.Set(Consumed, ref posixlyCorrect, Maybe.Just(value));
         }
 
         internal StringComparer NameComparer

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -9,6 +9,14 @@ using CSharpx;
 
 namespace CommandLine
 {
+    public enum ParserMode
+    {
+        Legacy,
+        Getopt,
+
+        Default = Legacy
+    }
+
     /// <summary>
     /// Provides settings for <see cref="CommandLine.Parser"/>. Once consumed cannot be reused.
     /// </summary>
@@ -27,7 +35,7 @@ namespace CommandLine
         private Maybe<bool> enableDashDash;
         private int maximumDisplayWidth;
         private Maybe<bool> allowMultiInstance;
-        private bool getoptMode;
+        private ParserMode parserMode;
         private Maybe<bool> posixlyCorrect;
 
         /// <summary>
@@ -41,7 +49,7 @@ namespace CommandLine
             autoVersion = true;
             parsingCulture = CultureInfo.InvariantCulture;
             maximumDisplayWidth = GetWindowWidth();
-            getoptMode = false;
+            parserMode = ParserMode.Default;
             enableDashDash = Maybe.Nothing<bool>();
             allowMultiInstance = Maybe.Nothing<bool>();
             posixlyCorrect = Maybe.Nothing<bool>();
@@ -166,11 +174,11 @@ namespace CommandLine
         /// <summary>
         /// Gets or sets a value indicating whether enable double dash '--' syntax,
         /// that forces parsing of all subsequent tokens as values.
-        /// If GetoptMode is true, this defaults to true, but can be turned off by explicitly specifying EnableDashDash = false.
+        /// Normally defaults to false. If ParserMode = ParserMode.Getopt, this defaults to true, but can be turned off by explicitly specifying EnableDashDash = false.
         /// </summary>
         public bool EnableDashDash
         {
-            get => enableDashDash.MatchJust(out bool value) ? value : getoptMode;
+            get => enableDashDash.MatchJust(out bool value) ? value : (parserMode == ParserMode.Getopt);
             set => PopsicleSetter.Set(Consumed, ref enableDashDash, Maybe.Just(value));
         }
 
@@ -185,21 +193,38 @@ namespace CommandLine
 
         /// <summary>
         /// Gets or sets a value indicating whether options are allowed to be specified multiple times.
-        /// If GetoptMode is true, this defaults to true, but can be turned off by explicitly specifying AllowMultiInstance = false.
+        /// If ParserMode = ParserMode.Getopt, this defaults to true, but can be turned off by explicitly specifying AllowMultiInstance = false.
         /// </summary>
         public bool AllowMultiInstance
         {
-            get => allowMultiInstance.MatchJust(out bool value) ? value : getoptMode;
+            get => allowMultiInstance.MatchJust(out bool value) ? value : (parserMode == ParserMode.Getopt);
             set => PopsicleSetter.Set(Consumed, ref allowMultiInstance, Maybe.Just(value));
         }
 
         /// <summary>
-        /// Whether strict getopt-like processing is applied to option values; if true, AllowMultiInstance and EnableDashDash will default to true as well.
+        /// Set this to change how the parser processes command-line arguments. Currently valid values are:
+        /// <list>
+        /// <item>
+        /// <term>Legacy</term>
+        /// <description>Uses - for short options and -- for long options.
+        /// Values of long options can only start with a - character if the = syntax is used.
+        /// E.g., "--string-option -x" will consider "-x" to be an option, not the value of "--string-option",
+        /// but "--string-option=-x" will consider "-x" to be the value of "--string-option".</description>
+        /// </item>
+        /// <item>
+        /// <term>Getopt</term>
+        /// <description>Strict getopt-like processing is applied to option values.
+        /// Mostly like legacy mode, except that option values with = and with space are more consistent.
+        /// After an option that takes a value, and whose value was not specified with "=", the next argument will be considered the value even if it starts with "-".
+        /// E.g., both "--string-option=-x" and "--string-option -x" will consider "-x" to be the value of "--string-option".
+        /// If this mode is chosen, AllowMultiInstance and EnableDashDash will default to true as well, though they can be explicitly turned off if desired.</description>
+        /// </item>
+        /// </list>
         /// </summary>
-        public bool GetoptMode
+        public ParserMode ParserMode
         {
-            get => getoptMode;
-            set => PopsicleSetter.Set(Consumed, ref getoptMode, value);
+            get => parserMode;
+            set => PopsicleSetter.Set(Consumed, ref parserMode, value);
         }
 
         /// <summary>

--- a/tests/CommandLine.Tests/Fakes/Options_With_FlagCounter_Switches.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_FlagCounter_Switches.cs
@@ -1,0 +1,13 @@
+// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+namespace CommandLine.Tests.Fakes
+{
+    public class Options_With_FlagCounter_Switches
+    {
+        [Option('v', FlagCounter=true)]
+        public int Verbose { get; set; }
+
+        [Option('s', FlagCounter=true)]
+        public int Silent { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Fakes/Options_With_Sequence_Having_Separator_And_Values.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_Sequence_Having_Separator_And_Values.cs
@@ -1,0 +1,74 @@
+// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace CommandLine.Tests.Fakes
+{
+    public class Options_For_Issue_91
+    {
+        [Value(0, Required = true)]
+        public string InputFileName { get; set; }
+
+        [Option('o', "output")]
+        public string OutputFileName { get; set; }
+
+        [Option('i', "include", Separator = ',')]
+        public IEnumerable<string> Included { get; set; }
+
+        [Option('e', "exclude", Separator = ',')]
+        public IEnumerable<string> Excluded { get; set; }
+    }
+
+    public class Options_For_Issue_454
+    {
+        [Option('c', "channels", Required = true, Separator = ':', HelpText = "Channel names")]
+        public IEnumerable<string> Channels { get; set; }
+
+        [Value(0, Required = true, MetaName = "file_path", HelpText = "Path of archive to be processed")]
+        public string ArchivePath { get; set; }
+    }
+
+    public class Options_For_Issue_510
+    {
+        [Option('a', "aa", Required = false, Separator = ',')]
+        public IEnumerable<string> A { get; set; }
+
+        [Option('b', "bb", Required = false)]
+        public string B { get; set; }
+        
+        [Value(0, Required = true)]
+        public string C { get; set; }
+    }
+
+    public enum FMode { C, D, S };
+
+    public class Options_For_Issue_617
+    {
+        [Option("fm",  Separator=',', Default = new[] { FMode.S })]  
+        public IEnumerable<FMode> Mode { get; set; }
+            
+        [Option('q')]
+        public bool q { get;set; }
+            
+        [Value(0)]
+        public IList<string> Files { get; set; }
+    }
+
+    public class Options_For_Issue_619
+    {
+        [Option("verbose", Required = false, Default = false, HelpText = "Generate process tracing information")]
+        public bool Verbose { get; set; }
+
+        [Option("outdir", Required = false, Default = ".", HelpText = "Directory to look for object file")]
+        public string OutDir { get; set; }
+
+        [Option("modules", Required = true, Separator = ',', HelpText = "Directories to look for module file")]
+        public IEnumerable<string> ModuleDirs { get; set; }
+
+        [Option("ignore", Required = false, Separator = ' ', HelpText = "List of additional module name references to ignore")]
+        public IEnumerable<string> Ignores { get; set; }
+
+        [Value(0, Required = true, HelpText = "List of source files to process")]
+        public IEnumerable<string> Srcs { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Fakes/Options_With_Similar_Names.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_Similar_Names.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace CommandLine.Tests.Fakes
+{
+    public class Options_With_Similar_Names
+    {
+        [Option("deploy", Separator = ',', HelpText= "Projects to deploy")]
+        public IEnumerable<string> Deploys { get; set; }
+
+        [Option("profile", Required = true, HelpText = "Profile to use when restoring and publishing")]
+        public string Profile { get; set; }
+
+        [Option("configure-profile", Required = true, HelpText = "Profile to use for Configure")]
+        public string ConfigureProfile { get; set; }
+    }
+
+    public class Options_With_Similar_Names_And_Separator
+    {
+        [Option('f', "flag", HelpText = "Flag")]
+        public bool Flag { get; set; }
+
+        [Option('c', "categories", Required = false, Separator = ',', HelpText = "Categories")]
+        public IEnumerable<string> Categories { get; set; }
+
+        [Option('j', "jobId", Required = true, HelpText = "Texts.ExplainJob")]
+        public int JobId { get; set; }
+    }
+
+}

--- a/tests/CommandLine.Tests/Fakes/Simple_Options_With_ExtraArgs.cs
+++ b/tests/CommandLine.Tests/Fakes/Simple_Options_With_ExtraArgs.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace CommandLine.Tests.Fakes
+{
+    public class Simple_Options_WithExtraArgs
+    {
+        [Option(HelpText = "Define a string value here.")]
+        public string StringValue { get; set; }
+
+        [Option('s', "shortandlong", HelpText = "Example with both short and long name.")]
+        public string ShortAndLong { get; set; }
+
+        [Option('i', Min = 3, Max = 4, Separator = ',', HelpText = "Define a int sequence here.")]
+        public IEnumerable<int> IntSequence { get; set; }
+
+        [Option('x', HelpText = "Define a boolean or switch value here.")]
+        public bool BoolValue { get; set; }
+
+        [Value(0, HelpText = "Define a long value here.")]
+        public long LongValue { get; set; }
+
+        [Value(1, HelpText = "Extra args get collected here.")]
+        public IEnumerable<string> ExtraArgs { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/Core/GetoptTokenizerTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/GetoptTokenizerTests.cs
@@ -8,11 +8,10 @@ using FluentAssertions;
 using CSharpx;
 using RailwaySharp.ErrorHandling;
 using CommandLine.Core;
-using CommandLine.Infrastructure;
 
 namespace CommandLine.Tests.Unit.Core
 {
-    public class TokenizerTests
+    public class GetoptTokenizerTests
     {
         [Fact]
         public void Explode_scalar_with_separator_in_odd_args_input_returns_sequence()
@@ -25,7 +24,7 @@ namespace CommandLine.Tests.Unit.Core
 
             // Exercize system
             var result =
-                Tokenizer.ExplodeOptionList(
+                GetoptTokenizer.ExplodeOptionList(
                     Result.Succeed(
                         Enumerable.Empty<Token>().Concat(new[] { Token.Name("i"), Token.Value("10"),
                             Token.Name("string-seq"), Token.Value("aaa,bb,cccc"), Token.Name("switch") }),
@@ -48,7 +47,7 @@ namespace CommandLine.Tests.Unit.Core
 
             // Exercize system
             var result =
-                Tokenizer.ExplodeOptionList(
+                GetoptTokenizer.ExplodeOptionList(
                     Result.Succeed(
                         Enumerable.Empty<Token>().Concat(new[] { Token.Name("x"),
                             Token.Name("string-seq"), Token.Value("aaa,bb,cccc"), Token.Name("switch") }),
@@ -57,34 +56,6 @@ namespace CommandLine.Tests.Unit.Core
 
             // Verify outcome
             ((Ok<IEnumerable<Token>, Error>)result).Success.Should().BeEquivalentTo(expectedTokens);
-
-            // Teardown
-        }
-
-        [Fact]
-        public void Normalize_should_remove_all_value_with_explicit_assignment_of_existing_name()
-        {
-            // Fixture setup
-            var expectedTokens = new[] {
-                Token.Name("x"), Token.Name("string-seq"), Token.Value("aaa"), Token.Value("bb"),
-                Token.Name("unknown"), Token.Name("switch") };
-            Func<string, bool> nameLookup =
-                name => name.Equals("x") || name.Equals("string-seq") || name.Equals("switch");
-
-            // Exercize system
-            var result =
-                Tokenizer.Normalize(
-                        //Result.Succeed(
-                        Enumerable.Empty<Token>()
-                            .Concat(
-                                new[] {
-                                    Token.Name("x"), Token.Name("string-seq"), Token.Value("aaa"), Token.Value("bb"),
-                                    Token.Name("unknown"), Token.Value("value0", true), Token.Name("switch") })
-                    //,Enumerable.Empty<Error>()),
-                    , nameLookup);
-
-            // Verify outcome
-            result.Should().BeEquivalentTo(expectedTokens);
 
             // Teardown
         }
@@ -99,7 +70,7 @@ namespace CommandLine.Tests.Unit.Core
              */
             var args = new[] { "--connectionString=Server=localhost;Data Source=(LocalDB)\v12.0;Initial Catalog=temp;" };
 
-            var result = Tokenizer.Tokenize(args, name => NameLookupResult.OtherOptionFound, token => token);
+            var result = GetoptTokenizer.Tokenize(args, name => NameLookupResult.OtherOptionFound);
 
             var tokens = result.SucceededWith();
 
@@ -112,29 +83,37 @@ namespace CommandLine.Tests.Unit.Core
         [Fact]
         public void Should_return_error_if_option_format_with_equals_is_not_correct()
         {
-            var args = new[] { "--option1 = fail", "--option2= fail" };
+            var args = new[] { "--option1 = fail", "--option2= succeed" };
 
-            var result = Tokenizer.Tokenize(args, name => NameLookupResult.OtherOptionFound, token => token);
+            var result = GetoptTokenizer.Tokenize(args, name => NameLookupResult.OtherOptionFound);
 
-            var tokens = result.SuccessMessages();
+            var errors = result.SuccessMessages();
 
+            Assert.NotNull(errors);
+            Assert.Equal(1, errors.Count());
+            Assert.Equal(ErrorType.BadFormatTokenError, errors.First().Tag);
+
+            var tokens = result.SucceededWith();
             Assert.NotNull(tokens);
             Assert.Equal(2, tokens.Count());
-            Assert.Equal(ErrorType.BadFormatTokenError, tokens.First().Tag);
-            Assert.Equal(ErrorType.BadFormatTokenError, tokens.Last().Tag);
+            Assert.Equal(TokenType.Name, tokens.First().Tag);
+            Assert.Equal(TokenType.Value, tokens.Last().Tag);
+            Assert.Equal("option2", tokens.First().Text);
+            Assert.Equal(" succeed", tokens.Last().Text);
         }
+
 
         [Theory]
         [InlineData(new[] { "-a", "-" }, 2,"a","-")]
         [InlineData(new[] { "--file", "-" }, 2,"file","-")]
         [InlineData(new[] { "-f-" }, 2,"f", "-")]
         [InlineData(new[] { "--file=-" }, 2, "file", "-")]
-        [InlineData(new[] { "-a", "--" }, 1, "a", "a")]
+        [InlineData(new[] { "-a", "--" }, 2, "a", "--")]
         public void Single_dash_as_a_value(string[] args, int countExcepted,string first,string last)
         {
             //Arrange
             //Act
-            var result = Tokenizer.Tokenize(args, name => NameLookupResult.OtherOptionFound, token => token);
+            var result = GetoptTokenizer.Tokenize(args, name => NameLookupResult.OtherOptionFound);
             var tokens = result.SucceededWith().ToList();
             //Assert
             tokens.Should().NotBeNull();

--- a/tests/CommandLine.Tests/Unit/Core/GetoptTokenizerTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/GetoptTokenizerTests.cs
@@ -24,7 +24,7 @@ namespace CommandLine.Tests.Unit.Core
 
             // Exercize system
             var result =
-                GetoptTokenizer.ExplodeOptionList(
+                Tokenizer.ExplodeOptionList(
                     Result.Succeed(
                         Enumerable.Empty<Token>().Concat(new[] { Token.Name("i"), Token.Value("10"),
                             Token.Name("string-seq"), Token.Value("aaa,bb,cccc"), Token.Name("switch") }),
@@ -47,7 +47,7 @@ namespace CommandLine.Tests.Unit.Core
 
             // Exercize system
             var result =
-                GetoptTokenizer.ExplodeOptionList(
+                Tokenizer.ExplodeOptionList(
                     Result.Succeed(
                         Enumerable.Empty<Token>().Concat(new[] { Token.Name("x"),
                             Token.Name("string-seq"), Token.Value("aaa,bb,cccc"), Token.Name("switch") }),
@@ -90,7 +90,7 @@ namespace CommandLine.Tests.Unit.Core
             var errors = result.SuccessMessages();
 
             Assert.NotNull(errors);
-            Assert.Equal(1, errors.Count());
+            Assert.NotEmpty(errors);
             Assert.Equal(ErrorType.BadFormatTokenError, errors.First().Tag);
 
             var tokens = result.SucceededWith();

--- a/tests/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
@@ -37,7 +37,7 @@ namespace CommandLine.Tests.Unit.Core
             var result = OptionMapper.MapValues(
                 specProps.Where(pt => pt.Specification.IsOption()),
                 tokenPartitions,
-                (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, CultureInfo.InvariantCulture, false),
+                (vals, type, isScalar, isFlag) => TypeConverter.ChangeType(vals, type, isScalar, isFlag, CultureInfo.InvariantCulture, false),
                 StringComparer.Ordinal
                 );
 
@@ -72,7 +72,7 @@ namespace CommandLine.Tests.Unit.Core
             var result = OptionMapper.MapValues(
                 specProps.Where(pt => pt.Specification.IsOption()),
                 tokenPartitions,
-                (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, CultureInfo.InvariantCulture, false),
+                (vals, type, isScalar, isFlag) => TypeConverter.ChangeType(vals, type, isScalar, isFlag, CultureInfo.InvariantCulture, false),
                 StringComparer.Ordinal);
 
             var property = result.SucceededWith().Single();
@@ -101,7 +101,7 @@ namespace CommandLine.Tests.Unit.Core
             var result = OptionMapper.MapValues(
                 specProps.Where(pt => pt.Specification.IsOption()),
                 tokenPartitions,
-                (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, CultureInfo.InvariantCulture, false),
+                (vals, type, isScalar, isFlag) => TypeConverter.ChangeType(vals, type, isScalar, isFlag, CultureInfo.InvariantCulture, false),
                 StringComparer.Ordinal);
 
             var property = result.SucceededWith().Single();

--- a/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
@@ -27,7 +27,7 @@ namespace CommandLine.Tests.Unit.Core
         [MemberData(nameof(ChangeType_scalars_source))]
         public void ChangeType_scalars(string testValue, Type destinationType, bool expectFail, object expectedResult)
         {
-            Maybe<object> result = TypeConverter.ChangeType(new[] {testValue}, destinationType, true, CultureInfo.InvariantCulture, true);
+            Maybe<object> result = TypeConverter.ChangeType(new[] {testValue}, destinationType, true, false, CultureInfo.InvariantCulture, true);
 
             if (expectFail)
             {
@@ -121,11 +121,43 @@ namespace CommandLine.Tests.Unit.Core
             }
         }
 
+        [Theory]
+        [MemberData(nameof(ChangeType_flagCounters_source))]
+        public void ChangeType_flagCounters(string[] testValue, Type destinationType, bool expectFail, object expectedResult)
+        {
+            Maybe<object> result = TypeConverter.ChangeType(testValue, destinationType, true, true, CultureInfo.InvariantCulture, true);
+
+            if (expectFail)
+            {
+                result.MatchNothing().Should().BeTrue("should fail parsing");
+            }
+            else
+            {
+                result.MatchJust(out object matchedValue).Should().BeTrue("should parse successfully");
+                Assert.Equal(matchedValue, expectedResult);
+            }
+        }
+
+        public static IEnumerable<object[]> ChangeType_flagCounters_source
+        {
+            get
+            {
+                return new[]
+                {
+                    new object[] {new string[0], typeof (int), false, 0},
+                    new object[] {new[] {"true"}, typeof (int), false, 1},
+                    new object[] {new[] {"true", "true"}, typeof (int), false, 2},
+                    new object[] {new[] {"true", "true", "true"}, typeof (int), false, 3},
+                    new object[] {new[] {"true", "x"}, typeof (int), true, 0},
+                };
+            }
+        }
+
         [Fact]
         public void ChangeType_Scalar_LastOneWins()
         {
             var values = new[] { "100", "200", "300", "400", "500" };
-            var result = TypeConverter.ChangeType(values, typeof(int), true, CultureInfo.InvariantCulture, true);
+            var result = TypeConverter.ChangeType(values, typeof(int), true, false, CultureInfo.InvariantCulture, true);
             result.MatchJust(out var matchedValue).Should().BeTrue("should parse successfully");
             Assert.Equal(500, matchedValue);
 

--- a/tests/CommandLine.Tests/Unit/GetoptParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/GetoptParserTests.cs
@@ -1,0 +1,284 @@
+using System;
+using Xunit;
+using FluentAssertions;
+using CommandLine.Core;
+using CommandLine.Tests.Fakes;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace CommandLine.Tests.Unit
+{
+    public class GetoptParserTests
+    {
+        public GetoptParserTests()
+        {
+        }
+
+        public class SimpleArgsData : TheoryData<string[], Simple_Options_WithExtraArgs>
+        {
+            public SimpleArgsData()
+            {
+                // Options and values can be mixed by default
+                Add(new string [] { "--stringvalue=foo", "-x", "256" },
+                    new Simple_Options_WithExtraArgs {
+                        IntSequence = Enumerable.Empty<int>(),
+                        ShortAndLong = null,
+                        StringValue = "foo",
+                        BoolValue = true,
+                        LongValue = 256,
+                        ExtraArgs = Enumerable.Empty<string>(),
+                    });
+                Add(new string [] { "256", "--stringvalue=foo", "-x" },
+                    new Simple_Options_WithExtraArgs {
+                        StringValue = "foo",
+                        ShortAndLong = null,
+                        IntSequence = Enumerable.Empty<int>(),
+                        BoolValue = true,
+                        LongValue = 256,
+                        ExtraArgs = Enumerable.Empty<string>(),
+                    });
+                Add(new string [] {"--stringvalue=foo", "256", "-x" },
+                    new Simple_Options_WithExtraArgs {
+                        StringValue = "foo",
+                        ShortAndLong = null,
+                        IntSequence = Enumerable.Empty<int>(),
+                        BoolValue = true,
+                        LongValue = 256,
+                        ExtraArgs = Enumerable.Empty<string>(),
+                    });
+
+                // Sequences end at first non-value arg even if they haven't yet consumed their max
+                Add(new string [] {"--stringvalue=foo", "-i1", "2", "3", "-x", "256" },
+                    new Simple_Options_WithExtraArgs {
+                        StringValue = "foo",
+                        ShortAndLong = null,
+                        IntSequence = new[] { 1, 2, 3 },
+                        BoolValue = true,
+                        LongValue = 256,
+                        ExtraArgs = Enumerable.Empty<string>(),
+                    });
+                // Sequences also end after consuming their max even if there would be more parameters
+                Add(new string [] {"--stringvalue=foo", "-i1", "2", "3", "4", "256", "-x" },
+                    new Simple_Options_WithExtraArgs {
+                        StringValue = "foo",
+                        ShortAndLong = null,
+                        IntSequence = new[] { 1, 2, 3, 4 },
+                        BoolValue = true,
+                        LongValue = 256,
+                        ExtraArgs = Enumerable.Empty<string>(),
+                    });
+
+                // The special -- option, if not consumed, turns off further option processing
+                Add(new string [] {"--stringvalue", "foo", "256", "-x", "-sbar" },
+                    new Simple_Options_WithExtraArgs {
+                        StringValue = "foo",
+                        ShortAndLong = "bar",
+                        BoolValue = true,
+                        LongValue = 256,
+                        IntSequence = Enumerable.Empty<int>(),
+                        ExtraArgs = Enumerable.Empty<string>(),
+                    });
+                Add(new string [] {"--stringvalue", "foo", "--", "256", "-x", "-sbar" },
+                    new Simple_Options_WithExtraArgs {
+                        StringValue = "foo",
+                        ShortAndLong = null,
+                        BoolValue = false,
+                        LongValue = 256,
+                        IntSequence = Enumerable.Empty<int>(),
+                        ExtraArgs = new [] { "-x", "-sbar" },
+                    });
+
+                // But if -- is specified as a value following an equal sign, it has no special meaning
+                Add(new string [] {"--stringvalue=--", "256", "-x", "-sbar" },
+                    new Simple_Options_WithExtraArgs {
+                        StringValue = "--",
+                        ShortAndLong = "bar",
+                        BoolValue = true,
+                        LongValue = 256,
+                        IntSequence = Enumerable.Empty<int>(),
+                        ExtraArgs = Enumerable.Empty<string>(),
+                    });
+
+                // Options that take values will take the next arg whatever it looks like
+                Add(new string [] {"--stringvalue", "-x", "256" },
+                    new Simple_Options_WithExtraArgs {
+                        StringValue = "-x",
+                        BoolValue = false,
+                        LongValue = 256,
+                        IntSequence = Enumerable.Empty<int>(),
+                        ExtraArgs = Enumerable.Empty<string>(),
+                    });
+                Add(new string [] {"--stringvalue", "-x", "-x", "256" },
+                    new Simple_Options_WithExtraArgs {
+                        StringValue = "-x",
+                        BoolValue = true,
+                        LongValue = 256,
+                        IntSequence = Enumerable.Empty<int>(),
+                        ExtraArgs = Enumerable.Empty<string>(),
+                    });
+
+                // That applies even if the next arg is -- which would normally stop option processing: if it's after an option that takes a value, it's consumed as the value
+                Add(new string [] {"--stringvalue", "--", "256", "-x", "-sbar" },
+                    new Simple_Options_WithExtraArgs {
+                        StringValue = "--",
+                        ShortAndLong = "bar",
+                        BoolValue = true,
+                        LongValue = 256,
+                        IntSequence = Enumerable.Empty<int>(),
+                        ExtraArgs = Enumerable.Empty<string>(),
+                    });
+
+                // Options that take values will not swallow the next arg if a value was specified with =
+                Add(new string [] {"--stringvalue=-x", "256" },
+                    new Simple_Options_WithExtraArgs {
+                        StringValue = "-x",
+                        BoolValue = false,
+                        LongValue = 256,
+                        IntSequence = Enumerable.Empty<int>(),
+                        ExtraArgs = Enumerable.Empty<string>(),
+                    });
+                Add(new string [] {"--stringvalue=-x", "-x", "256" },
+                    new Simple_Options_WithExtraArgs {
+                        StringValue = "-x",
+                        BoolValue = true,
+                        LongValue = 256,
+                        IntSequence = Enumerable.Empty<int>(),
+                        ExtraArgs = Enumerable.Empty<string>(),
+                    });
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(SimpleArgsData))]
+        public void Getopt_parser_without_posixly_correct_allows_mixed_options_and_nonoptions(string[] args, Simple_Options_WithExtraArgs expected)
+        {
+            // Arrange
+            var sut = new Parser(config => {
+                config.GetoptMode = true;
+                config.PosixlyCorrect = false;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options_WithExtraArgs>(args);
+
+            // Assert
+            if (result is Parsed<Simple_Options_WithExtraArgs> parsed) {
+                parsed.Value.Should().BeEquivalentTo(expected);
+            } else if (result is NotParsed<Simple_Options_WithExtraArgs> notParsed) {
+                Console.WriteLine(String.Join(", ", notParsed.Errors.Select(err => err.Tag.ToString())));
+            }
+            result.Should().BeOfType<Parsed<Simple_Options_WithExtraArgs>>();
+            result.As<Parsed<Simple_Options_WithExtraArgs>>().Value.Should().BeEquivalentTo(expected);
+        }
+
+        public class SimpleArgsDataWithPosixlyCorrect : TheoryData<string[], Simple_Options_WithExtraArgs>
+        {
+            public SimpleArgsDataWithPosixlyCorrect()
+            {
+                Add(new string [] { "--stringvalue=foo", "-x", "256" },
+                    // Parses all options
+                    new Simple_Options_WithExtraArgs {
+                        StringValue = "foo",
+                        ShortAndLong = null,
+                        IntSequence = Enumerable.Empty<int>(),
+                        BoolValue = true,
+                        LongValue = 256,
+                        ExtraArgs = Enumerable.Empty<string>(),
+                    });
+                Add(new string [] { "256", "--stringvalue=foo", "-x" },
+                    // Stops parsing after "256", so StringValue and BoolValue not set
+                    new Simple_Options_WithExtraArgs {
+                        StringValue = null,
+                        ShortAndLong = null,
+                        IntSequence = Enumerable.Empty<int>(),
+                        BoolValue = false,
+                        LongValue = 256,
+                        ExtraArgs = new string[] { "--stringvalue=foo", "-x" },
+                    });
+                Add(new string [] {"--stringvalue=foo", "256", "-x" },
+                    // Stops parsing after "256", so StringValue is set but BoolValue is not
+                    new Simple_Options_WithExtraArgs {
+                        StringValue = "foo",
+                        ShortAndLong = null,
+                        IntSequence = Enumerable.Empty<int>(),
+                        BoolValue = false,
+                        LongValue = 256,
+                        ExtraArgs = new string[] { "-x" },
+                    });
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(SimpleArgsDataWithPosixlyCorrect))]
+        public void Getopt_parser_with_posixly_correct_stops_parsing_at_first_nonoption(string[] args, Simple_Options_WithExtraArgs expected)
+        {
+            // Arrange
+            var sut = new Parser(config => {
+                config.GetoptMode = true;
+                config.PosixlyCorrect = true;
+                config.EnableDashDash = true;
+            });
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options_WithExtraArgs>(args);
+
+            // Assert
+            result.Should().BeOfType<Parsed<Simple_Options_WithExtraArgs>>();
+            result.As<Parsed<Simple_Options_WithExtraArgs>>().Value.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void Getopt_mode_defaults_to_EnableDashDash_being_true()
+        {
+            // Arrange
+            var sut = new Parser(config => {
+                config.GetoptMode = true;
+                config.PosixlyCorrect = false;
+            });
+            var args = new string [] {"--stringvalue", "foo", "256", "--", "-x", "-sbar" };
+            var expected = new Simple_Options_WithExtraArgs {
+                    StringValue = "foo",
+                    ShortAndLong = null,
+                    BoolValue = false,
+                    LongValue = 256,
+                    IntSequence = Enumerable.Empty<int>(),
+                    ExtraArgs = new [] { "-x", "-sbar" },
+                };
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options_WithExtraArgs>(args);
+
+            // Assert
+            result.Should().BeOfType<Parsed<Simple_Options_WithExtraArgs>>();
+            result.As<Parsed<Simple_Options_WithExtraArgs>>().Value.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void Getopt_mode_can_have_EnableDashDash_expicitly_disabled()
+        {
+            // Arrange
+            var sut = new Parser(config => {
+                config.GetoptMode = true;
+                config.PosixlyCorrect = false;
+                config.EnableDashDash = false;
+            });
+            var args = new string [] {"--stringvalue", "foo", "256", "--", "-x", "-sbar" };
+            var expected = new Simple_Options_WithExtraArgs {
+                    StringValue = "foo",
+                    ShortAndLong = "bar",
+                    BoolValue = true,
+                    LongValue = 256,
+                    IntSequence = Enumerable.Empty<int>(),
+                    ExtraArgs = new [] { "--" },
+                };
+
+            // Act
+            var result = sut.ParseArguments<Simple_Options_WithExtraArgs>(args);
+
+            // Assert
+            result.Should().BeOfType<Parsed<Simple_Options_WithExtraArgs>>();
+            result.As<Parsed<Simple_Options_WithExtraArgs>>().Value.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/GetoptParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/GetoptParserTests.cs
@@ -155,7 +155,7 @@ namespace CommandLine.Tests.Unit
         {
             // Arrange
             var sut = new Parser(config => {
-                config.GetoptMode = true;
+                config.ParserMode = ParserMode.Getopt;
                 config.PosixlyCorrect = false;
             });
 
@@ -215,7 +215,7 @@ namespace CommandLine.Tests.Unit
         {
             // Arrange
             var sut = new Parser(config => {
-                config.GetoptMode = true;
+                config.ParserMode = ParserMode.Getopt;
                 config.PosixlyCorrect = true;
                 config.EnableDashDash = true;
             });
@@ -233,7 +233,7 @@ namespace CommandLine.Tests.Unit
         {
             // Arrange
             var sut = new Parser(config => {
-                config.GetoptMode = true;
+                config.ParserMode = ParserMode.Getopt;
                 config.PosixlyCorrect = false;
             });
             var args = new string [] {"--stringvalue", "foo", "256", "--", "-x", "-sbar" };
@@ -259,7 +259,7 @@ namespace CommandLine.Tests.Unit
         {
             // Arrange
             var sut = new Parser(config => {
-                config.GetoptMode = true;
+                config.ParserMode = ParserMode.Getopt;
                 config.PosixlyCorrect = false;
                 config.EnableDashDash = false;
             });

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -95,6 +95,36 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
+        [Theory]
+        [InlineData(new string[0], 0, 0)]
+        [InlineData(new[] { "-v" }, 1, 0)]
+        [InlineData(new[] { "-vv" }, 2, 0)]
+        [InlineData(new[] { "-v", "-v" }, 2, 0)]
+        [InlineData(new[] { "-v", "-v", "-v" }, 3, 0)]
+        [InlineData(new[] { "-v", "-vv" }, 3, 0)]
+        [InlineData(new[] { "-vv", "-v" }, 3, 0)]
+        [InlineData(new[] { "-vvv" }, 3, 0)]
+        [InlineData(new[] { "-v", "-s", "-v", "-v" }, 3, 1)]
+        [InlineData(new[] { "-v", "-ss", "-v", "-v" }, 3, 2)]
+        [InlineData(new[] { "-v", "-s", "-sv", "-v" }, 3, 2)]
+        [InlineData(new[] { "-vsvv" }, 3, 1)]
+        [InlineData(new[] { "-vssvv" }, 3, 2)]
+        [InlineData(new[] { "-vsvsv" }, 3, 2)]
+        public void Parse_FlagCounter_options_with_short_name(string[] args, int verboseCount, int silentCount)
+        {
+            // Fixture setup
+            var expectedOptions = new Options_With_FlagCounter_Switches { Verbose = verboseCount, Silent = silentCount };
+            var sut = new Parser(with => with.AllowMultiInstance = true);
+
+            // Exercize system
+            var result = sut.ParseArguments<Options_With_FlagCounter_Switches>(args);
+
+            // Verify outcome
+            // ((NotParsed<Options_With_FlagCounter_Switches>)result).Errors.Should().BeEmpty();
+            ((Parsed<Options_With_FlagCounter_Switches>)result).Value.Should().BeEquivalentTo(expectedOptions);
+            // Teardown
+        }
+
         [Fact]
         public void Parse_repeated_options_with_default_parser()
         {

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -136,6 +136,7 @@ namespace CommandLine.Tests.Unit
 
             // Verify outcome
             Assert.IsType<NotParsed<Options_With_Switches>>(result);
+            // NOTE: Once GetoptMode becomes the default, it will imply MultiInstance and the above check will fail because it will be Parsed.
             // Teardown
         }
 
@@ -298,6 +299,7 @@ namespace CommandLine.Tests.Unit
 
             // Verify outcome
             Assert.IsType<NotParsed<object>>(result);
+            // NOTE: Once GetoptMode becomes the default, it will imply MultiInstance and the above check will fail because it will be Parsed.
             // Teardown
         }
 
@@ -973,6 +975,7 @@ namespace CommandLine.Tests.Unit
         [Fact]
         public void Parse_repeated_options_in_verbs_scenario_without_multi_instance()
         {
+            // NOTE: Once GetoptMode becomes the default, it will imply MultiInstance and this test will fail because the parser result will be Parsed.
             using (var sut = new Parser(settings => settings.AllowMultiInstance = false))
             {
                 var longVal1 = 100;

--- a/tests/CommandLine.Tests/Unit/SequenceParsingTests.cs
+++ b/tests/CommandLine.Tests/Unit/SequenceParsingTests.cs
@@ -1,0 +1,140 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System;
+using Xunit;
+using CommandLine.Text;
+using CommandLine.Tests.Fakes;
+using FluentAssertions;
+using CommandLine.Core;
+using System.Reflection;
+using CSharpx;
+using RailwaySharp.ErrorHandling;
+
+namespace CommandLine.Tests.Unit
+{
+	// Reference: PR #684
+    public class SequenceParsingTests
+    {
+        // Issue #91
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void Enumerable_with_separator_before_values_does_not_try_to_parse_too_much(bool useGetoptMode)
+        {
+            var args = "--exclude=a,b InputFile.txt".Split();
+            var expected = new Options_For_Issue_91 {
+                Excluded = new[] { "a", "b" },
+                Included = Enumerable.Empty<string>(),
+                InputFileName = "InputFile.txt",
+            };
+            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var result = sut.ParseArguments<Options_For_Issue_91>(args);
+            result.Should().BeOfType<Parsed<Options_For_Issue_91>>();
+            result.As<Parsed<Options_For_Issue_91>>().Value.Should().BeEquivalentTo(expected);
+        }
+
+        // Issue #396
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void Options_with_similar_names_are_not_ambiguous(bool useGetoptMode)
+        {
+            var args = new[] { "--configure-profile", "deploy", "--profile", "local" };
+            var expected = new Options_With_Similar_Names { ConfigureProfile = "deploy", Profile = "local", Deploys = Enumerable.Empty<string>() };
+            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var result = sut.ParseArguments<Options_With_Similar_Names>(args);
+            result.Should().BeOfType<Parsed<Options_With_Similar_Names>>();
+            result.As<Parsed<Options_With_Similar_Names>>().Value.Should().BeEquivalentTo(expected);
+        }
+
+        // Issue #420
+        [Fact]
+
+        public static void Values_with_same_name_as_sequence_option_do_not_cause_later_values_to_split_on_separators()
+        {
+            var args = new[] { "c", "x,y" };
+            var tokensExpected = new[] { Token.Value("c"), Token.Value("x,y") };
+            var typeInfo = typeof(Options_With_Similar_Names_And_Separator);
+
+            var specProps = typeInfo.GetSpecifications(pi => SpecificationProperty.Create(
+                    Specification.FromProperty(pi), pi, Maybe.Nothing<object>()))
+                .Select(sp => sp.Specification)
+                .OfType<OptionSpecification>();
+
+            var tokenizerResult = Tokenizer.ConfigureTokenizer(StringComparer.InvariantCulture, false, false)(args, specProps);
+            var tokens = tokenizerResult.SucceededWith();
+            tokens.Should().BeEquivalentTo(tokensExpected);
+        }
+
+        // Issue #454
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+
+        public static void Enumerable_with_colon_separator_before_values_does_not_try_to_parse_too_much(bool useGetoptMode)
+        {
+            var args = "-c chanA:chanB file.hdf5".Split();
+            var expected = new Options_For_Issue_454 {
+                Channels = new[] { "chanA", "chanB" },
+                ArchivePath = "file.hdf5",
+            };
+            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var result = sut.ParseArguments<Options_For_Issue_454>(args);
+            result.Should().BeOfType<Parsed<Options_For_Issue_454>>();
+            result.As<Parsed<Options_For_Issue_454>>().Value.Should().BeEquivalentTo(expected);
+        }
+
+        // Issue #510
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+
+        public static void Enumerable_before_values_does_not_try_to_parse_too_much(bool useGetoptMode)
+        {
+            var args = new[] { "-a", "1,2", "c" };
+            var expected = new Options_For_Issue_510 { A = new[] { "1", "2" }, C = "c" };
+            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var result = sut.ParseArguments<Options_For_Issue_510>(args);
+            result.Should().BeOfType<Parsed<Options_For_Issue_510>>();
+            result.As<Parsed<Options_For_Issue_510>>().Value.Should().BeEquivalentTo(expected);
+        }
+
+        // Issue #617
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+
+        public static void Enumerable_with_enum_before_values_does_not_try_to_parse_too_much(bool useGetoptMode)
+        {
+            var args = "--fm D,C a.txt".Split();
+            var expected = new Options_For_Issue_617 {
+                Mode = new[] { FMode.D, FMode.C },
+                Files = new[] { "a.txt" },
+            };
+            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var result = sut.ParseArguments<Options_For_Issue_617>(args);
+            result.Should().BeOfType<Parsed<Options_For_Issue_617>>();
+            result.As<Parsed<Options_For_Issue_617>>().Value.Should().BeEquivalentTo(expected);
+        }
+
+        // Issue #619
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+
+        public static void Separator_just_before_values_does_not_try_to_parse_values(bool useGetoptMode)
+        {
+            var args = "--outdir ./x64/Debug --modules ../utilities/x64/Debug,../auxtool/x64/Debug m_xfunit.f03 m_xfunit_assertion.f03".Split();
+            var expected = new Options_For_Issue_619 {
+                OutDir = "./x64/Debug",
+                ModuleDirs = new[] { "../utilities/x64/Debug", "../auxtool/x64/Debug" },
+                Ignores = Enumerable.Empty<string>(),
+                Srcs = new[] { "m_xfunit.f03", "m_xfunit_assertion.f03" },
+            };
+            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var result = sut.ParseArguments<Options_For_Issue_619>(args);
+            result.Should().BeOfType<Parsed<Options_For_Issue_619>>();
+            result.As<Parsed<Options_For_Issue_619>>().Value.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/SequenceParsingTests.cs
+++ b/tests/CommandLine.Tests/Unit/SequenceParsingTests.cs
@@ -17,9 +17,9 @@ namespace CommandLine.Tests.Unit
     {
         // Issue #91
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public static void Enumerable_with_separator_before_values_does_not_try_to_parse_too_much(bool useGetoptMode)
+        [InlineData(ParserMode.Legacy)]
+        [InlineData(ParserMode.Getopt)]
+        public static void Enumerable_with_separator_before_values_does_not_try_to_parse_too_much(ParserMode parserMode)
         {
             var args = "--exclude=a,b InputFile.txt".Split();
             var expected = new Options_For_Issue_91 {
@@ -27,7 +27,7 @@ namespace CommandLine.Tests.Unit
                 Included = Enumerable.Empty<string>(),
                 InputFileName = "InputFile.txt",
             };
-            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var sut = new Parser(parserSettings => { parserSettings.ParserMode = parserMode; });
             var result = sut.ParseArguments<Options_For_Issue_91>(args);
             result.Should().BeOfType<Parsed<Options_For_Issue_91>>();
             result.As<Parsed<Options_For_Issue_91>>().Value.Should().BeEquivalentTo(expected);
@@ -35,13 +35,13 @@ namespace CommandLine.Tests.Unit
 
         // Issue #396
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public static void Options_with_similar_names_are_not_ambiguous(bool useGetoptMode)
+        [InlineData(ParserMode.Legacy)]
+        [InlineData(ParserMode.Getopt)]
+        public static void Options_with_similar_names_are_not_ambiguous(ParserMode parserMode)
         {
             var args = new[] { "--configure-profile", "deploy", "--profile", "local" };
             var expected = new Options_With_Similar_Names { ConfigureProfile = "deploy", Profile = "local", Deploys = Enumerable.Empty<string>() };
-            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var sut = new Parser(parserSettings => { parserSettings.ParserMode = parserMode; });
             var result = sut.ParseArguments<Options_With_Similar_Names>(args);
             result.Should().BeOfType<Parsed<Options_With_Similar_Names>>();
             result.As<Parsed<Options_With_Similar_Names>>().Value.Should().BeEquivalentTo(expected);
@@ -68,17 +68,17 @@ namespace CommandLine.Tests.Unit
 
         // Issue #454
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [InlineData(ParserMode.Legacy)]
+        [InlineData(ParserMode.Getopt)]
 
-        public static void Enumerable_with_colon_separator_before_values_does_not_try_to_parse_too_much(bool useGetoptMode)
+        public static void Enumerable_with_colon_separator_before_values_does_not_try_to_parse_too_much(ParserMode parserMode)
         {
             var args = "-c chanA:chanB file.hdf5".Split();
             var expected = new Options_For_Issue_454 {
                 Channels = new[] { "chanA", "chanB" },
                 ArchivePath = "file.hdf5",
             };
-            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var sut = new Parser(parserSettings => { parserSettings.ParserMode = parserMode; });
             var result = sut.ParseArguments<Options_For_Issue_454>(args);
             result.Should().BeOfType<Parsed<Options_For_Issue_454>>();
             result.As<Parsed<Options_For_Issue_454>>().Value.Should().BeEquivalentTo(expected);
@@ -86,14 +86,14 @@ namespace CommandLine.Tests.Unit
 
         // Issue #510
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [InlineData(ParserMode.Legacy)]
+        [InlineData(ParserMode.Getopt)]
 
-        public static void Enumerable_before_values_does_not_try_to_parse_too_much(bool useGetoptMode)
+        public static void Enumerable_before_values_does_not_try_to_parse_too_much(ParserMode parserMode)
         {
             var args = new[] { "-a", "1,2", "c" };
             var expected = new Options_For_Issue_510 { A = new[] { "1", "2" }, C = "c" };
-            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var sut = new Parser(parserSettings => { parserSettings.ParserMode = parserMode; });
             var result = sut.ParseArguments<Options_For_Issue_510>(args);
             result.Should().BeOfType<Parsed<Options_For_Issue_510>>();
             result.As<Parsed<Options_For_Issue_510>>().Value.Should().BeEquivalentTo(expected);
@@ -101,17 +101,17 @@ namespace CommandLine.Tests.Unit
 
         // Issue #617
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [InlineData(ParserMode.Legacy)]
+        [InlineData(ParserMode.Getopt)]
 
-        public static void Enumerable_with_enum_before_values_does_not_try_to_parse_too_much(bool useGetoptMode)
+        public static void Enumerable_with_enum_before_values_does_not_try_to_parse_too_much(ParserMode parserMode)
         {
             var args = "--fm D,C a.txt".Split();
             var expected = new Options_For_Issue_617 {
                 Mode = new[] { FMode.D, FMode.C },
                 Files = new[] { "a.txt" },
             };
-            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var sut = new Parser(parserSettings => { parserSettings.ParserMode = parserMode; });
             var result = sut.ParseArguments<Options_For_Issue_617>(args);
             result.Should().BeOfType<Parsed<Options_For_Issue_617>>();
             result.As<Parsed<Options_For_Issue_617>>().Value.Should().BeEquivalentTo(expected);
@@ -119,10 +119,10 @@ namespace CommandLine.Tests.Unit
 
         // Issue #619
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [InlineData(ParserMode.Legacy)]
+        [InlineData(ParserMode.Getopt)]
 
-        public static void Separator_just_before_values_does_not_try_to_parse_values(bool useGetoptMode)
+        public static void Separator_just_before_values_does_not_try_to_parse_values(ParserMode parserMode)
         {
             var args = "--outdir ./x64/Debug --modules ../utilities/x64/Debug,../auxtool/x64/Debug m_xfunit.f03 m_xfunit_assertion.f03".Split();
             var expected = new Options_For_Issue_619 {
@@ -131,7 +131,7 @@ namespace CommandLine.Tests.Unit
                 Ignores = Enumerable.Empty<string>(),
                 Srcs = new[] { "m_xfunit.f03", "m_xfunit_assertion.f03" },
             };
-            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var sut = new Parser(parserSettings => { parserSettings.ParserMode = parserMode; });
             var result = sut.ParseArguments<Options_For_Issue_619>(args);
             result.Should().BeOfType<Parsed<Options_For_Issue_619>>();
             result.As<Parsed<Options_For_Issue_619>>().Value.Should().BeEquivalentTo(expected);

--- a/tests/CommandLine.Tests/Unit/UnParserExtensionsTests.cs
+++ b/tests/CommandLine.Tests/Unit/UnParserExtensionsTests.cs
@@ -254,6 +254,23 @@ namespace CommandLine.Tests.Unit
                 .Should().BeEquivalentTo(expected);
 
         }
+
+        [Theory]
+        [InlineData(false, false, 0, "")]
+        [InlineData(false, false, 1, "-v")]  // default but not skipped
+        [InlineData(false, false, 2, "-v -v")]
+        [InlineData(false, true, 2, "-vv")]
+        [InlineData(false, false, 3, "-v -v -v")]
+        [InlineData(false, true, 3, "-vvv")]
+        [InlineData(true, false, 1, "")]  // default, skipped
+        public static void UnParsing_instance_with_flag_counter(bool skipDefault, bool groupSwitches, int value, string expected)
+        {
+            var options = new Option_FlagCounter { VerboseLevel = value };
+            var result = new Parser()
+                .FormatCommandLine(options, x => { x.SkipDefault = skipDefault; x.GroupSwitches = groupSwitches; })
+                .Should().BeEquivalentTo(expected);
+        }
+
         [Theory]
         [InlineData(Shapes.Circle, "--shape Circle")]
         [InlineData(Shapes.Square, "--shape Square")]
@@ -309,6 +326,11 @@ namespace CommandLine.Tests.Unit
         class Option_Int
         {
             [Option('v', Default = 1)]
+            public int VerboseLevel { get; set; }
+        }
+        class Option_FlagCounter
+        {
+            [Option('v', Default = 1, FlagCounter=true)]
             public int VerboseLevel { get; set; }
         }
         class Option_Nullable_Bool


### PR DESCRIPTION
Turning on Getopt mode automatically turns on the EnableDashDash and AllowMultiInstance settings as well, but they can be disabled by explicitly setting them to false in the parser settings. This is essentially #607 rebased onto the develop branch, but with an option (defaulting to false) to turn it on. If the user doesn't set GetoptMode to true, then no behavior changes.

Note that two unit tests will fail until https://github.com/commandlineparser/commandline/pull/682 is merged, because they test for the same bug that #682 fixes.

This PR includes the FlagCounter feature from #607 as well; I've made the FlagCounter feature and the GetoptMode feature two separate commits so that if you want to use one but not the other, it's easy to cherry-pick the one you want to use. They don't depend on each other; in particular, FlagCounter works even without GetoptMode being true. But I've included both of them in this PR because GetoptMode without FlagCounter feels incomplete: people running in Getopt mode are going to expect to be able to do `-vvv` and get VerboseLevel=3.

My next PR will be a rebasing of #608 onto develop. Once that's done, if I'm sure that this PR is going to be merged, I'll start working on writing documentation of GetoptMode for the CLP wiki. In the meantime, the unit tests in GetoptParserTests.cs are pretty self-documenting.

Fixes #601.
Fixes #631.

I've also fixed #687 in this PR (in commit https://github.com/commandlineparser/commandline/pull/684/commits/47618e0ddf43a380baaa54484b188118b30d8a6c); I chose to incorporate that fix into this PR because GetoptTokenizer, introduced here, contains the same buggy ExplodeOptionList method as the original Tokenizer, and both of them need to be fixed to properly fix #687. In addition to #687, this PR now:

Fixes #619
Fixes #617
Fixes #510
Fixes #454
Fixes #420
Fixes #396
Fixes #91
