### PR TITLE
ParserMode setting as enum rather than GetoptMode as bool

### DIFF
--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -187,13 +187,13 @@ namespace CommandLine
         {
             switch (settings.ParserMode)
             {
-                case ParserMode.Classic:
+                case ParserMode.GetoptParserV1:
                 return Tokenizer.ConfigureTokenizer(
                     settings.NameComparer,
                     settings.IgnoreUnknownArguments,
                     settings.EnableDashDash)(arguments, optionSpecs);
 
-                case ParserMode.Getopt:
+                case ParserMode.GetoptParserV2:
                 return GetoptTokenizer.ConfigureTokenizer(
                     settings.NameComparer,
                     settings.IgnoreUnknownArguments,

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -185,16 +185,28 @@ namespace CommandLine
                 IEnumerable<OptionSpecification> optionSpecs,
                 ParserSettings settings)
         {
-            return settings.GetoptMode
-                ? GetoptTokenizer.ConfigureTokenizer(
-                    settings.NameComparer,
-                    settings.IgnoreUnknownArguments,
-                    settings.EnableDashDash,
-                    settings.PosixlyCorrect)(arguments, optionSpecs)
-                : Tokenizer.ConfigureTokenizer(
+            switch (settings.ParserMode)
+            {
+                case ParserMode.Classic:
+                return Tokenizer.ConfigureTokenizer(
                     settings.NameComparer,
                     settings.IgnoreUnknownArguments,
                     settings.EnableDashDash)(arguments, optionSpecs);
+
+                case ParserMode.Getopt:
+                return GetoptTokenizer.ConfigureTokenizer(
+                    settings.NameComparer,
+                    settings.IgnoreUnknownArguments,
+                    settings.EnableDashDash,
+                    settings.PosixlyCorrect)(arguments, optionSpecs);
+
+                // No need to test ParserMode.Default, as it should always be one of the above modes
+                default:
+                return Tokenizer.ConfigureTokenizer(
+                    settings.NameComparer,
+                    settings.IgnoreUnknownArguments,
+                    settings.EnableDashDash)(arguments, optionSpecs);
+            }
         }
 
         private static ParserResult<T> MakeParserResult<T>(ParserResult<T> parserResult, ParserSettings settings)

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -11,10 +11,10 @@ namespace CommandLine
 {
     public enum ParserMode
     {
-        Classic,
-        Getopt,
+        GetoptParserV1,
+        GetoptParserV2,
 
-        Default = Classic
+        Default = GetoptParserV1
     }
 
     /// <summary>
@@ -174,11 +174,11 @@ namespace CommandLine
         /// <summary>
         /// Gets or sets a value indicating whether enable double dash '--' syntax,
         /// that forces parsing of all subsequent tokens as values.
-        /// Normally defaults to false. If ParserMode = ParserMode.Getopt, this defaults to true, but can be turned off by explicitly specifying EnableDashDash = false.
+        /// Normally defaults to false. If ParserMode = ParserMode.GetoptParserV2, this defaults to true, but can be turned off by explicitly specifying EnableDashDash = false.
         /// </summary>
         public bool EnableDashDash
         {
-            get => enableDashDash.MatchJust(out bool value) ? value : (parserMode == ParserMode.Getopt);
+            get => enableDashDash.MatchJust(out bool value) ? value : (parserMode == ParserMode.GetoptParserV2);
             set => PopsicleSetter.Set(Consumed, ref enableDashDash, Maybe.Just(value));
         }
 
@@ -193,11 +193,11 @@ namespace CommandLine
 
         /// <summary>
         /// Gets or sets a value indicating whether options are allowed to be specified multiple times.
-        /// If ParserMode = ParserMode.Getopt, this defaults to true, but can be turned off by explicitly specifying AllowMultiInstance = false.
+        /// If ParserMode = ParserMode.GetoptParserV2, this defaults to true, but can be turned off by explicitly specifying AllowMultiInstance = false.
         /// </summary>
         public bool AllowMultiInstance
         {
-            get => allowMultiInstance.MatchJust(out bool value) ? value : (parserMode == ParserMode.Getopt);
+            get => allowMultiInstance.MatchJust(out bool value) ? value : (parserMode == ParserMode.GetoptParserV2);
             set => PopsicleSetter.Set(Consumed, ref allowMultiInstance, Maybe.Just(value));
         }
 

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -9,6 +9,14 @@ using CSharpx;
 
 namespace CommandLine
 {
+    public enum ParserMode
+    {
+        Classic,
+        Getopt,
+
+        Default = Classic
+    }
+
     /// <summary>
     /// Provides settings for <see cref="CommandLine.Parser"/>. Once consumed cannot be reused.
     /// </summary>
@@ -27,7 +35,7 @@ namespace CommandLine
         private Maybe<bool> enableDashDash;
         private int maximumDisplayWidth;
         private Maybe<bool> allowMultiInstance;
-        private bool getoptMode;
+        private ParserMode parserMode;
         private Maybe<bool> posixlyCorrect;
 
         /// <summary>
@@ -41,7 +49,7 @@ namespace CommandLine
             autoVersion = true;
             parsingCulture = CultureInfo.InvariantCulture;
             maximumDisplayWidth = GetWindowWidth();
-            getoptMode = false;
+            parserMode = ParserMode.Default;
             enableDashDash = Maybe.Nothing<bool>();
             allowMultiInstance = Maybe.Nothing<bool>();
             posixlyCorrect = Maybe.Nothing<bool>();
@@ -166,11 +174,11 @@ namespace CommandLine
         /// <summary>
         /// Gets or sets a value indicating whether enable double dash '--' syntax,
         /// that forces parsing of all subsequent tokens as values.
-        /// If GetoptMode is true, this defaults to true, but can be turned off by explicitly specifying EnableDashDash = false.
+        /// Normally defaults to false. If ParserMode = ParserMode.Getopt, this defaults to true, but can be turned off by explicitly specifying EnableDashDash = false.
         /// </summary>
         public bool EnableDashDash
         {
-            get => enableDashDash.MatchJust(out bool value) ? value : getoptMode;
+            get => enableDashDash.MatchJust(out bool value) ? value : (parserMode == ParserMode.Getopt);
             set => PopsicleSetter.Set(Consumed, ref enableDashDash, Maybe.Just(value));
         }
 
@@ -185,21 +193,38 @@ namespace CommandLine
 
         /// <summary>
         /// Gets or sets a value indicating whether options are allowed to be specified multiple times.
-        /// If GetoptMode is true, this defaults to true, but can be turned off by explicitly specifying AllowMultiInstance = false.
+        /// If ParserMode = ParserMode.Getopt, this defaults to true, but can be turned off by explicitly specifying AllowMultiInstance = false.
         /// </summary>
         public bool AllowMultiInstance
         {
-            get => allowMultiInstance.MatchJust(out bool value) ? value : getoptMode;
+            get => allowMultiInstance.MatchJust(out bool value) ? value : (parserMode == ParserMode.Getopt);
             set => PopsicleSetter.Set(Consumed, ref allowMultiInstance, Maybe.Just(value));
         }
 
         /// <summary>
-        /// Whether strict getopt-like processing is applied to option values; if true, AllowMultiInstance and EnableDashDash will default to true as well.
+        /// Set this to change how the parser processes command-line arguments. Currently valid values are:
+        /// <list>
+        /// <item>
+        /// <term>Classic</term>
+        /// <description>Uses - for short options and -- for long options.
+        /// Values of long options can only start with a - character if the = syntax is used.
+        /// E.g., "--string-option -x" will consider "-x" to be an option, not the value of "--string-option",
+        /// but "--string-option=-x" will consider "-x" to be the value of "--string-option".</description>
+        /// </item>
+        /// <item>
+        /// <term>Getopt</term>
+        /// <description>Strict getopt-like processing is applied to option values.
+        /// Mostly like classic mode, except that option values with = and with space are more consistent.
+        /// After an option that takes a value, and whose value was not specified with "=", the next argument will be considered the value even if it starts with "-".
+        /// E.g., both "--string-option=-x" and "--string-option -x" will consider "-x" to be the value of "--string-option".
+        /// If this mode is chosen, AllowMultiInstance and EnableDashDash will default to true as well, though they can be explicitly turned off if desired.</description>
+        /// </item>
+        /// </list>
         /// </summary>
-        public bool GetoptMode
+        public ParserMode ParserMode
         {
-            get => getoptMode;
-            set => PopsicleSetter.Set(Consumed, ref getoptMode, value);
+            get => parserMode;
+            set => PopsicleSetter.Set(Consumed, ref parserMode, value);
         }
 
         /// <summary>

--- a/tests/CommandLine.Tests/Unit/Core/GetoptTokenizerTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/GetoptTokenizerTests.cs
@@ -24,7 +24,7 @@ namespace CommandLine.Tests.Unit.Core
 
             // Exercize system
             var result =
-                GetoptTokenizer.ExplodeOptionList(
+                Tokenizer.ExplodeOptionList(
                     Result.Succeed(
                         Enumerable.Empty<Token>().Concat(new[] { Token.Name("i"), Token.Value("10"),
                             Token.Name("string-seq"), Token.Value("aaa,bb,cccc"), Token.Name("switch") }),
@@ -47,7 +47,7 @@ namespace CommandLine.Tests.Unit.Core
 
             // Exercize system
             var result =
-                GetoptTokenizer.ExplodeOptionList(
+                Tokenizer.ExplodeOptionList(
                     Result.Succeed(
                         Enumerable.Empty<Token>().Concat(new[] { Token.Name("x"),
                             Token.Name("string-seq"), Token.Value("aaa,bb,cccc"), Token.Name("switch") }),
@@ -90,7 +90,7 @@ namespace CommandLine.Tests.Unit.Core
             var errors = result.SuccessMessages();
 
             Assert.NotNull(errors);
-            Assert.Equal(1, errors.Count());
+            Assert.NotEmpty(errors);
             Assert.Equal(ErrorType.BadFormatTokenError, errors.First().Tag);
 
             var tokens = result.SucceededWith();

--- a/tests/CommandLine.Tests/Unit/GetoptParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/GetoptParserTests.cs
@@ -155,7 +155,7 @@ namespace CommandLine.Tests.Unit
         {
             // Arrange
             var sut = new Parser(config => {
-                config.ParserMode = ParserMode.Getopt;
+                config.ParserMode = ParserMode.GetoptParserV2;
                 config.PosixlyCorrect = false;
             });
 
@@ -215,7 +215,7 @@ namespace CommandLine.Tests.Unit
         {
             // Arrange
             var sut = new Parser(config => {
-                config.ParserMode = ParserMode.Getopt;
+                config.ParserMode = ParserMode.GetoptParserV2;
                 config.PosixlyCorrect = true;
                 config.EnableDashDash = true;
             });
@@ -233,7 +233,7 @@ namespace CommandLine.Tests.Unit
         {
             // Arrange
             var sut = new Parser(config => {
-                config.ParserMode = ParserMode.Getopt;
+                config.ParserMode = ParserMode.GetoptParserV2;
                 config.PosixlyCorrect = false;
             });
             var args = new string [] {"--stringvalue", "foo", "256", "--", "-x", "-sbar" };
@@ -259,7 +259,7 @@ namespace CommandLine.Tests.Unit
         {
             // Arrange
             var sut = new Parser(config => {
-                config.ParserMode = ParserMode.Getopt;
+                config.ParserMode = ParserMode.GetoptParserV2;
                 config.PosixlyCorrect = false;
                 config.EnableDashDash = false;
             });

--- a/tests/CommandLine.Tests/Unit/GetoptParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/GetoptParserTests.cs
@@ -155,7 +155,7 @@ namespace CommandLine.Tests.Unit
         {
             // Arrange
             var sut = new Parser(config => {
-                config.GetoptMode = true;
+                config.ParserMode = ParserMode.Getopt;
                 config.PosixlyCorrect = false;
             });
 
@@ -215,7 +215,7 @@ namespace CommandLine.Tests.Unit
         {
             // Arrange
             var sut = new Parser(config => {
-                config.GetoptMode = true;
+                config.ParserMode = ParserMode.Getopt;
                 config.PosixlyCorrect = true;
                 config.EnableDashDash = true;
             });
@@ -233,7 +233,7 @@ namespace CommandLine.Tests.Unit
         {
             // Arrange
             var sut = new Parser(config => {
-                config.GetoptMode = true;
+                config.ParserMode = ParserMode.Getopt;
                 config.PosixlyCorrect = false;
             });
             var args = new string [] {"--stringvalue", "foo", "256", "--", "-x", "-sbar" };
@@ -259,7 +259,7 @@ namespace CommandLine.Tests.Unit
         {
             // Arrange
             var sut = new Parser(config => {
-                config.GetoptMode = true;
+                config.ParserMode = ParserMode.Getopt;
                 config.PosixlyCorrect = false;
                 config.EnableDashDash = false;
             });

--- a/tests/CommandLine.Tests/Unit/SequenceParsingTests.cs
+++ b/tests/CommandLine.Tests/Unit/SequenceParsingTests.cs
@@ -17,9 +17,9 @@ namespace CommandLine.Tests.Unit
     {
         // Issue #91
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public static void Enumerable_with_separator_before_values_does_not_try_to_parse_too_much(bool useGetoptMode)
+        [InlineData(ParserMode.Classic)]
+        [InlineData(ParserMode.Getopt)]
+        public static void Enumerable_with_separator_before_values_does_not_try_to_parse_too_much(ParserMode parserMode)
         {
             var args = "--exclude=a,b InputFile.txt".Split();
             var expected = new Options_For_Issue_91 {
@@ -27,7 +27,7 @@ namespace CommandLine.Tests.Unit
                 Included = Enumerable.Empty<string>(),
                 InputFileName = "InputFile.txt",
             };
-            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var sut = new Parser(parserSettings => { parserSettings.ParserMode = parserMode; });
             var result = sut.ParseArguments<Options_For_Issue_91>(args);
             result.Should().BeOfType<Parsed<Options_For_Issue_91>>();
             result.As<Parsed<Options_For_Issue_91>>().Value.Should().BeEquivalentTo(expected);
@@ -35,13 +35,13 @@ namespace CommandLine.Tests.Unit
 
         // Issue #396
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public static void Options_with_similar_names_are_not_ambiguous(bool useGetoptMode)
+        [InlineData(ParserMode.Classic)]
+        [InlineData(ParserMode.Getopt)]
+        public static void Options_with_similar_names_are_not_ambiguous(ParserMode parserMode)
         {
             var args = new[] { "--configure-profile", "deploy", "--profile", "local" };
             var expected = new Options_With_Similar_Names { ConfigureProfile = "deploy", Profile = "local", Deploys = Enumerable.Empty<string>() };
-            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var sut = new Parser(parserSettings => { parserSettings.ParserMode = parserMode; });
             var result = sut.ParseArguments<Options_With_Similar_Names>(args);
             result.Should().BeOfType<Parsed<Options_With_Similar_Names>>();
             result.As<Parsed<Options_With_Similar_Names>>().Value.Should().BeEquivalentTo(expected);
@@ -68,17 +68,17 @@ namespace CommandLine.Tests.Unit
 
         // Issue #454
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [InlineData(ParserMode.Classic)]
+        [InlineData(ParserMode.Getopt)]
 
-        public static void Enumerable_with_colon_separator_before_values_does_not_try_to_parse_too_much(bool useGetoptMode)
+        public static void Enumerable_with_colon_separator_before_values_does_not_try_to_parse_too_much(ParserMode parserMode)
         {
             var args = "-c chanA:chanB file.hdf5".Split();
             var expected = new Options_For_Issue_454 {
                 Channels = new[] { "chanA", "chanB" },
                 ArchivePath = "file.hdf5",
             };
-            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var sut = new Parser(parserSettings => { parserSettings.ParserMode = parserMode; });
             var result = sut.ParseArguments<Options_For_Issue_454>(args);
             result.Should().BeOfType<Parsed<Options_For_Issue_454>>();
             result.As<Parsed<Options_For_Issue_454>>().Value.Should().BeEquivalentTo(expected);
@@ -86,14 +86,14 @@ namespace CommandLine.Tests.Unit
 
         // Issue #510
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [InlineData(ParserMode.Classic)]
+        [InlineData(ParserMode.Getopt)]
 
-        public static void Enumerable_before_values_does_not_try_to_parse_too_much(bool useGetoptMode)
+        public static void Enumerable_before_values_does_not_try_to_parse_too_much(ParserMode parserMode)
         {
             var args = new[] { "-a", "1,2", "c" };
             var expected = new Options_For_Issue_510 { A = new[] { "1", "2" }, C = "c" };
-            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var sut = new Parser(parserSettings => { parserSettings.ParserMode = parserMode; });
             var result = sut.ParseArguments<Options_For_Issue_510>(args);
             result.Should().BeOfType<Parsed<Options_For_Issue_510>>();
             result.As<Parsed<Options_For_Issue_510>>().Value.Should().BeEquivalentTo(expected);
@@ -101,17 +101,17 @@ namespace CommandLine.Tests.Unit
 
         // Issue #617
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [InlineData(ParserMode.Classic)]
+        [InlineData(ParserMode.Getopt)]
 
-        public static void Enumerable_with_enum_before_values_does_not_try_to_parse_too_much(bool useGetoptMode)
+        public static void Enumerable_with_enum_before_values_does_not_try_to_parse_too_much(ParserMode parserMode)
         {
             var args = "--fm D,C a.txt".Split();
             var expected = new Options_For_Issue_617 {
                 Mode = new[] { FMode.D, FMode.C },
                 Files = new[] { "a.txt" },
             };
-            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var sut = new Parser(parserSettings => { parserSettings.ParserMode = parserMode; });
             var result = sut.ParseArguments<Options_For_Issue_617>(args);
             result.Should().BeOfType<Parsed<Options_For_Issue_617>>();
             result.As<Parsed<Options_For_Issue_617>>().Value.Should().BeEquivalentTo(expected);
@@ -119,10 +119,10 @@ namespace CommandLine.Tests.Unit
 
         // Issue #619
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [InlineData(ParserMode.Classic)]
+        [InlineData(ParserMode.Getopt)]
 
-        public static void Separator_just_before_values_does_not_try_to_parse_values(bool useGetoptMode)
+        public static void Separator_just_before_values_does_not_try_to_parse_values(ParserMode parserMode)
         {
             var args = "--outdir ./x64/Debug --modules ../utilities/x64/Debug,../auxtool/x64/Debug m_xfunit.f03 m_xfunit_assertion.f03".Split();
             var expected = new Options_For_Issue_619 {
@@ -131,7 +131,7 @@ namespace CommandLine.Tests.Unit
                 Ignores = Enumerable.Empty<string>(),
                 Srcs = new[] { "m_xfunit.f03", "m_xfunit_assertion.f03" },
             };
-            var sut = new Parser(parserSettings => { parserSettings.GetoptMode = useGetoptMode; });
+            var sut = new Parser(parserSettings => { parserSettings.ParserMode = parserMode; });
             var result = sut.ParseArguments<Options_For_Issue_619>(args);
             result.Should().BeOfType<Parsed<Options_For_Issue_619>>();
             result.As<Parsed<Options_For_Issue_619>>().Value.Should().BeEquivalentTo(expected);

--- a/tests/CommandLine.Tests/Unit/SequenceParsingTests.cs
+++ b/tests/CommandLine.Tests/Unit/SequenceParsingTests.cs
@@ -17,8 +17,8 @@ namespace CommandLine.Tests.Unit
     {
         // Issue #91
         [Theory]
-        [InlineData(ParserMode.Classic)]
-        [InlineData(ParserMode.Getopt)]
+        [InlineData(ParserMode.GetoptParserV1)]
+        [InlineData(ParserMode.GetoptParserV2)]
         public static void Enumerable_with_separator_before_values_does_not_try_to_parse_too_much(ParserMode parserMode)
         {
             var args = "--exclude=a,b InputFile.txt".Split();
@@ -35,8 +35,8 @@ namespace CommandLine.Tests.Unit
 
         // Issue #396
         [Theory]
-        [InlineData(ParserMode.Classic)]
-        [InlineData(ParserMode.Getopt)]
+        [InlineData(ParserMode.GetoptParserV1)]
+        [InlineData(ParserMode.GetoptParserV2)]
         public static void Options_with_similar_names_are_not_ambiguous(ParserMode parserMode)
         {
             var args = new[] { "--configure-profile", "deploy", "--profile", "local" };
@@ -68,8 +68,8 @@ namespace CommandLine.Tests.Unit
 
         // Issue #454
         [Theory]
-        [InlineData(ParserMode.Classic)]
-        [InlineData(ParserMode.Getopt)]
+        [InlineData(ParserMode.GetoptParserV1)]
+        [InlineData(ParserMode.GetoptParserV2)]
 
         public static void Enumerable_with_colon_separator_before_values_does_not_try_to_parse_too_much(ParserMode parserMode)
         {
@@ -86,8 +86,8 @@ namespace CommandLine.Tests.Unit
 
         // Issue #510
         [Theory]
-        [InlineData(ParserMode.Classic)]
-        [InlineData(ParserMode.Getopt)]
+        [InlineData(ParserMode.GetoptParserV1)]
+        [InlineData(ParserMode.GetoptParserV2)]
 
         public static void Enumerable_before_values_does_not_try_to_parse_too_much(ParserMode parserMode)
         {
@@ -101,8 +101,8 @@ namespace CommandLine.Tests.Unit
 
         // Issue #617
         [Theory]
-        [InlineData(ParserMode.Classic)]
-        [InlineData(ParserMode.Getopt)]
+        [InlineData(ParserMode.GetoptParserV1)]
+        [InlineData(ParserMode.GetoptParserV2)]
 
         public static void Enumerable_with_enum_before_values_does_not_try_to_parse_too_much(ParserMode parserMode)
         {
@@ -119,8 +119,8 @@ namespace CommandLine.Tests.Unit
 
         // Issue #619
         [Theory]
-        [InlineData(ParserMode.Classic)]
-        [InlineData(ParserMode.Getopt)]
+        [InlineData(ParserMode.GetoptParserV1)]
+        [InlineData(ParserMode.GetoptParserV2)]
 
         public static void Separator_just_before_values_does_not_try_to_parse_values(ParserMode parserMode)
         {


### PR DESCRIPTION
This is https://github.com/commandlineparser/commandline/commit/b7102d89a90acd2d9356637ead5a0a64b58b131a with the Legacy name renamed to Classic so as not to suggest that it's obsolete or going away anytime soon. See https://github.com/commandlineparser/commandline/pull/684#issuecomment-681783784 for the rationale.