### PR TITLE
Set to true nullable bool arguments without the value

### DIFF
--- a/src/CommandLine/Core/KeyValuePairHelper.cs
+++ b/src/CommandLine/Core/KeyValuePairHelper.cs
@@ -15,6 +15,14 @@ namespace CommandLine.Core
             return tokens.Select(t => t.Text.ToKeyValuePair("true"));
         }
 
+        public static IEnumerable<KeyValuePair<string, IEnumerable<string>>> ForScalarSwitch(
+            IEnumerable<Token> tokens)
+        {
+            return tokens
+                .Group(2)
+                .Select((g) => g[0].Text.ToKeyValuePair(g[1].Text));
+        }
+
         public static IEnumerable<KeyValuePair<string, IEnumerable<string>>> ForScalar(
             IEnumerable<Token> tokens)
         {

--- a/src/CommandLine/Core/ReflectionExtensions.cs
+++ b/src/CommandLine/Core/ReflectionExtensions.cs
@@ -40,9 +40,9 @@ namespace CommandLine.Core
         {
             return
                 (from pi in type.FlattenHierarchy().SelectMany(x => x.GetTypeInfo().GetProperties())
-                    let attrs = pi.GetCustomAttributes(true)
-                    where attrs.OfType<UsageAttribute>().Any()
-                    select Tuple.Create(pi, (UsageAttribute)attrs.First()))
+                 let attrs = pi.GetCustomAttributes(true)
+                 where attrs.OfType<UsageAttribute>().Any()
+                 select Tuple.Create(pi, (UsageAttribute)attrs.First()))
                         .SingleOrDefault()
                         .ToMaybe();
         }
@@ -73,11 +73,13 @@ namespace CommandLine.Core
         {
             return type == typeof(bool)
                        ? TargetType.Switch
-                       : type == typeof(string)
-                             ? TargetType.Scalar
-                             : type.IsArray || typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(type)
-                                   ? TargetType.Sequence
-                                   : TargetType.Scalar;
+                       : type == typeof(bool?)
+                             ? TargetType.ScalarSwitch
+                             : type == typeof(string)
+                                   ? TargetType.Scalar
+                                   : type.IsArray || typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(type)
+                                         ? TargetType.Sequence
+                                         : TargetType.Scalar;
         }
 
         public static IEnumerable<Error> SetProperties<T>(
@@ -136,7 +138,7 @@ namespace CommandLine.Core
             // Find all inherited defined properties and fields on the type
             var inheritedTypes = type.GetTypeInfo().FlattenHierarchy().Select(i => i.GetTypeInfo());
 
-            foreach (var inheritedType in inheritedTypes) 
+            foreach (var inheritedType in inheritedTypes)
             {
                 if (
                     inheritedType.GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.Instance).Any(p => p.CanWrite) ||
@@ -167,7 +169,7 @@ namespace CommandLine.Core
             }
 
             var ctorTypes = type.GetSpecifications(pi => pi.PropertyType).ToArray();
- 
+
             return ReflectionHelper.CreateDefaultImmutableInstance(type, ctorTypes);
         }
 
@@ -211,7 +213,7 @@ namespace CommandLine.Core
             return
                    (type.GetTypeInfo().IsValueType && type != typeof(Guid))
                 || type.GetTypeInfo().IsPrimitive
-                || new [] { 
+                || new [] {
                      typeof(string)
                     ,typeof(decimal)
                     ,typeof(DateTime)

--- a/src/CommandLine/Core/ScalarSwitch.cs
+++ b/src/CommandLine/Core/ScalarSwitch.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CSharpx;
+
+namespace CommandLine.Core
+{
+    static class ScalarSwitch
+    {
+        public static IEnumerable<Token> Partition(
+            IEnumerable<Token> tokens,
+            Func<string, Maybe<TypeDescriptor>> typeLookup)
+        {
+            return tokens.Zip(tokens.Skip(1).Concat(new Token[] { new Value("true") }),
+                (f, s) =>
+                    f.IsName() && s.IsValue()
+                        ? typeLookup(f.Text).MapValueOrDefault(info =>
+                                info.TargetType == TargetType.ScalarSwitch ? new[] { f, s } : new Token[] { }, new Token[] { })
+                                : f.IsName()
+                                    ? typeLookup(f.Text).MapValueOrDefault(info => new Token[] { f, new Value(f.IsName() && info.TargetType == TargetType.ScalarSwitch ? "true" : "false") }, new Token[] { })
+                                    : new Token[] { }
+            )
+            .SelectMany(t => t);
+        }
+    }
+}

--- a/src/CommandLine/Core/Specification.cs
+++ b/src/CommandLine/Core/Specification.cs
@@ -19,7 +19,8 @@ namespace CommandLine.Core
     {
         Switch,
         Scalar,
-        Sequence
+        Sequence,
+        ScalarSwitch
     }
 
     abstract class Specification
@@ -54,7 +55,7 @@ namespace CommandLine.Core
             this.hidden = hidden;
         }
 
-        public SpecificationType Tag 
+        public SpecificationType Tag
         {
             get { return tag; }
         }
@@ -110,13 +111,13 @@ namespace CommandLine.Core
         }
 
         public static Specification FromProperty(PropertyInfo property)
-        {       
+        {
             var attrs = property.GetCustomAttributes(true);
             var oa = attrs.OfType<OptionAttribute>();
             if (oa.Count() == 1)
             {
                 var spec = OptionSpecification.FromAttribute(oa.Single(), property.PropertyType,
-                    ReflectionHelper.GetNamesOfEnum(property.PropertyType)); 
+                    ReflectionHelper.GetNamesOfEnum(property.PropertyType));
 
                 if (spec.ShortName.Length == 0 && spec.LongName.Length == 0)
                 {

--- a/src/CommandLine/Core/TokenPartitioner.cs
+++ b/src/CommandLine/Core/TokenPartitioner.cs
@@ -19,17 +19,20 @@ namespace CommandLine.Core
 
             var tokenList = tokens.Memoize();
             var switches = new HashSet<Token>(Switch.Partition(tokenList, typeLookup), tokenComparer);
+            var scalarSwitches = new HashSet<Token>(ScalarSwitch.Partition(tokenList, typeLookup), tokenComparer);
             var scalars = new HashSet<Token>(Scalar.Partition(tokenList, typeLookup), tokenComparer);
             var sequences = new HashSet<Token>(Sequence.Partition(tokenList, typeLookup), tokenComparer);
             var nonOptions = tokenList
                 .Where(t => !switches.Contains(t))
                 .Where(t => !scalars.Contains(t))
+                .Where(t => !scalarSwitches.Contains(t))
                 .Where(t => !sequences.Contains(t)).Memoize();
             var values = nonOptions.Where(v => v.IsValue()).Memoize();
             var errors = nonOptions.Except(values, (IEqualityComparer<Token>)ReferenceEqualityComparer.Default).Memoize();
 
             return Tuple.Create(
                     KeyValuePairHelper.ForSwitch(switches)
+                        .Concat(KeyValuePairHelper.ForScalarSwitch(scalarSwitches))
                         .Concat(KeyValuePairHelper.ForScalar(scalars))
                         .Concat(KeyValuePairHelper.ForSequence(sequences)),
                 values.Select(t => t.Text),

--- a/src/CommandLine/UnParserExtensions.cs
+++ b/src/CommandLine/UnParserExtensions.cs
@@ -212,6 +212,7 @@ namespace CommandLine
             switch (spec.TargetType)
             {
                 case TargetType.Scalar:
+                case TargetType.ScalarSwitch:
                     builder.Append(FormatWithQuotesIfString(value));
                     break;
                 case TargetType.Sequence:

--- a/tests/CommandLine.Tests/Fakes/Options_With_Nullable_Bool.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_Nullable_Bool.cs
@@ -1,0 +1,11 @@
+﻿namespace CommandLine.Tests.Fakes
+{
+    class Options_With_Nullable_Bool
+    {
+        [Option('b', "bool")]
+        public bool Bool { get; set; }
+
+        [Option('n', "nullable-bool")]
+        public bool? NullableBool { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/Issue316Tests.cs
+++ b/tests/CommandLine.Tests/Unit/Issue316Tests.cs
@@ -1,0 +1,42 @@
+﻿using Xunit;
+using CommandLine.Tests.Fakes;
+using System.Collections.Generic;
+using System;
+
+namespace CommandLine.Tests.Unit
+{
+    //issue#316, Set to true nullable bool arguments without the value
+    public class Issue316Tests
+    {
+        [Theory]
+        [InlineData("--bool --nullable-bool", true, true)]
+        [InlineData("--nullable-bool --bool", true, true)]
+        [InlineData("--nullable-bool true --bool", true, true)]
+        [InlineData("--bool --nullable-bool true", true, true)]
+        [InlineData("--nullable-bool false --bool", true, false)]
+        [InlineData("--bool --nullable-bool false", true, false)]
+        [InlineData("--bool", true, null)]
+        [InlineData("--nullable-bool", false, true)]
+        [InlineData("--nullable-bool true", false, true)]
+        [InlineData("--nullable-bool false", false, false)]
+        [InlineData("", false, null)]
+        public void Check_if_nullable_boolean_works_correctly(string args, bool expectedBoolean, bool? expectedNullable)
+        {
+            string[] arguments = args.Split(' ');
+
+            Options_With_Nullable_Bool options = null;
+            IEnumerable<Error> errors = null;
+            Parser.Default.ParseArguments<Options_With_Nullable_Bool>(arguments)
+                .WithParsed(o => options = o)
+                .WithNotParsed(o => errors = o);
+
+            if (errors != null)
+                foreach (Error e in errors)
+                    Console.WriteLine(e);
+
+            Assert.NotNull(options);
+            Assert.Equal(options.Bool, expectedBoolean);
+            Assert.Equal(options.NullableBool, expectedNullable);
+        }
+    }
+}


### PR DESCRIPTION
Well, it fixes #316, what can I say ¯\\_(ツ)_/¯

Quick example:

```c#
class Parameters
{
    [Option("bool")]
    public bool Bool { get; set; }
    
    [Option("nullable-bool")]
    public bool? NullableBool { get; set; }
}
```

| --bool | --nullable-bool | Parameters(Bool, NullableBool) |
| ------- | ---------------- | ------- |
| + | `true` | (`true`, `true`) |
| + | `false` | (`true`, `false`) |
| + | + | (`true`, `true`) |
| + | - | (`true`, `null`) |
| - | `true` | (`false`, `true`) |
| - | `false` | (`false`, `false`) |
| - | + | (`false`, `true`) |
| - | - | (`false`, `null`) |