### PR TITLE
Add environment variable support

### DIFF
--- a/src/CommandLine/BaseAttribute.cs
+++ b/src/CommandLine/BaseAttribute.cs
@@ -12,6 +12,7 @@ namespace CommandLine
         private int min;
         private int max;
         private object @default;
+        private string env;
         private Infrastructure.LocalizableAttributeProperty helpText;
         private string metaValue;
         private Type resourceType;
@@ -84,6 +85,18 @@ namespace CommandLine
             set
             {
                 @default = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets mapped property env value.
+        /// </summary>
+        public string Env
+        {
+            get { return env; }
+            set
+            {
+                env = value;
             }
         }
 

--- a/src/CommandLine/Core/OptionSpecification.cs
+++ b/src/CommandLine/Core/OptionSpecification.cs
@@ -16,10 +16,10 @@ namespace CommandLine.Core
         private readonly string group;
 
         public OptionSpecification(string shortName, string longName, bool required, string setName, Maybe<int> min, Maybe<int> max,
-            char separator, Maybe<object> defaultValue, string helpText, string metaValue, IEnumerable<string> enumValues,
+            char separator, Maybe<object> defaultValue, Maybe<string> env, string helpText, string metaValue, IEnumerable<string> enumValues,
             Type conversionType, TargetType targetType, string group, bool hidden = false)
             : base(SpecificationType.Option,
-                 required, min, max, defaultValue, helpText, metaValue, enumValues, conversionType, targetType, hidden)
+                 required, min, max, defaultValue, env, helpText, metaValue, enumValues, conversionType, targetType, hidden)
         {
             this.shortName = shortName;
             this.longName = longName;
@@ -39,6 +39,7 @@ namespace CommandLine.Core
                 attribute.Max == -1 ? Maybe.Nothing<int>() : Maybe.Just(attribute.Max),
                 attribute.Separator,
                 attribute.Default.ToMaybe(),
+                attribute.Env.ToMaybe(),
                 attribute.HelpText,
                 attribute.MetaValue,
                 enumValues,
@@ -51,7 +52,7 @@ namespace CommandLine.Core
         public static OptionSpecification NewSwitch(string shortName, string longName, bool required, string helpText, string metaValue, bool hidden = false)
         {
             return new OptionSpecification(shortName, longName, required, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(),
-                '\0', Maybe.Nothing<object>(), helpText, metaValue, Enumerable.Empty<string>(), typeof(bool), TargetType.Switch, string.Empty, hidden);
+                '\0', Maybe.Nothing<object>(), Maybe.Nothing<string>(), helpText, metaValue, Enumerable.Empty<string>(), typeof(bool), TargetType.Switch, string.Empty, hidden);
         }
 
         public string ShortName

--- a/src/CommandLine/Core/Specification.cs
+++ b/src/CommandLine/Core/Specification.cs
@@ -30,6 +30,7 @@ namespace CommandLine.Core
         private readonly Maybe<int> min;
         private readonly Maybe<int> max;
         private readonly Maybe<object> defaultValue;
+        private readonly Maybe<string> env;
         private readonly string helpText;
         private readonly string metaValue;
         private readonly IEnumerable<string> enumValues;
@@ -38,7 +39,7 @@ namespace CommandLine.Core
         private readonly TargetType targetType;
 
         protected Specification(SpecificationType tag, bool required, Maybe<int> min, Maybe<int> max,
-            Maybe<object> defaultValue, string helpText, string metaValue, IEnumerable<string> enumValues,
+            Maybe<object> defaultValue, Maybe<string> env, string helpText, string metaValue, IEnumerable<string> enumValues,
             Type conversionType, TargetType targetType, bool hidden = false)
         {
             this.tag = tag;
@@ -46,6 +47,7 @@ namespace CommandLine.Core
             this.min = min;
             this.max = max;
             this.defaultValue = defaultValue;
+            this.env = env;
             this.conversionType = conversionType;
             this.targetType = targetType;
             this.helpText = helpText;
@@ -54,7 +56,7 @@ namespace CommandLine.Core
             this.hidden = hidden;
         }
 
-        public SpecificationType Tag 
+        public SpecificationType Tag
         {
             get { return tag; }
         }
@@ -78,6 +80,12 @@ namespace CommandLine.Core
         {
             get { return defaultValue; }
         }
+
+        public Maybe<string> Env
+        {
+            get { return env; }
+        }
+
 
         public string HelpText
         {
@@ -110,13 +118,13 @@ namespace CommandLine.Core
         }
 
         public static Specification FromProperty(PropertyInfo property)
-        {       
+        {
             var attrs = property.GetCustomAttributes(true);
             var oa = attrs.OfType<OptionAttribute>();
             if (oa.Count() == 1)
             {
                 var spec = OptionSpecification.FromAttribute(oa.Single(), property.PropertyType,
-                    ReflectionHelper.GetNamesOfEnum(property.PropertyType)); 
+                    ReflectionHelper.GetNamesOfEnum(property.PropertyType));
 
                 if (spec.ShortName.Length == 0 && spec.LongName.Length == 0)
                 {

--- a/src/CommandLine/Core/SpecificationExtensions.cs
+++ b/src/CommandLine/Core/SpecificationExtensions.cs
@@ -29,6 +29,7 @@ namespace CommandLine.Core
                 specification.Max,
                 specification.Separator,
                 specification.DefaultValue,
+                specification.Env,
                 specification.HelpText,
                 specification.MetaValue,
                 specification.EnumValues,

--- a/src/CommandLine/Core/ValueSpecification.cs
+++ b/src/CommandLine/Core/ValueSpecification.cs
@@ -11,10 +11,10 @@ namespace CommandLine.Core
         private readonly int index;
         private readonly string metaName;
 
-        public ValueSpecification(int index, string metaName, bool required, Maybe<int> min, Maybe<int> max, Maybe<object> defaultValue,
+        public ValueSpecification(int index, string metaName, bool required, Maybe<int> min, Maybe<int> max, Maybe<object> defaultValue, Maybe<string> env,
             string helpText, string metaValue, IEnumerable<string> enumValues,
             Type conversionType, TargetType targetType, bool hidden = false)
-            : base(SpecificationType.Value, required, min, max, defaultValue, helpText, metaValue, enumValues, conversionType, targetType, hidden)
+            : base(SpecificationType.Value, required, min, max, defaultValue, env, helpText, metaValue, enumValues, conversionType, targetType, hidden)
         {
             this.index = index;
             this.metaName = metaName;
@@ -29,6 +29,7 @@ namespace CommandLine.Core
                 attribute.Min == -1 ? Maybe.Nothing<int>() : Maybe.Just(attribute.Min),
                 attribute.Max == -1 ? Maybe.Nothing<int>() : Maybe.Just(attribute.Max),
                 attribute.Default.ToMaybe(),
+                attribute.Env.ToMaybe(),
                 attribute.HelpText,
                 attribute.MetaValue,
                 enumValues,

--- a/src/CommandLine/Infrastructure/StringExtensions.cs
+++ b/src/CommandLine/Infrastructure/StringExtensions.cs
@@ -66,12 +66,14 @@ namespace CommandLine.Infrastructure
         public static bool IsBooleanString(this string value)
         {
             return value.Equals("true", StringComparison.OrdinalIgnoreCase)
-                || value.Equals("false", StringComparison.OrdinalIgnoreCase);
+                || value.Equals("false", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("1", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("0", StringComparison.OrdinalIgnoreCase);
         }
 
         public static bool ToBoolean(this string value)
         {
-            return value.Equals("true", StringComparison.OrdinalIgnoreCase);
+            return value.Equals("true", StringComparison.OrdinalIgnoreCase) || value.Equals("1", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/tests/CommandLine.Tests/Fakes/Simple_Options_With_Env.cs
+++ b/tests/CommandLine.Tests/Fakes/Simple_Options_With_Env.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace CommandLine.Tests.Fakes
+{
+    class Simple_Options_With_Env
+    {
+        [Option('s', Default = "", Env = "StringValue")]
+        public string StringValue { get; set; }
+
+        [Option("bvff", Env = "BoolValueFullFalse", HelpText = "Define a boolean or switch value here.")]
+        public bool BoolValueFullFalse { get; set; }
+        [Option("bvft", Env = "BoolValueFullTrue", HelpText = "Define a boolean or switch value here.")]
+        public bool BoolValueFullTrue { get; set; }
+        [Option("bvst", Env = "BoolValueShortTrue", HelpText = "Define a boolean or switch value here.")]
+        public bool BoolValueShortTrue { get; set; }
+        [Option("bvsf", Env = "BoolValueShortFalse", HelpText = "Define a boolean or switch value here.")]
+        public bool BoolValueShortFalse { get; set; }
+
+
+        [Option('l', Default = 1, Env = "LongValue")]
+        public long LongValue { get; set; }
+
+        [Option('i', Default = 2, Env = "IntValue")]
+        public long IntValue { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/Core/NameLookupTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/NameLookupTests.cs
@@ -17,7 +17,7 @@ namespace CommandLine.Tests.Unit.Core
             // Fixture setup
             var expected = Maybe.Just(".");
             var specs = new[] { new OptionSpecification(string.Empty, "string-seq",
-                false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '.', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty)};
+                false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '.', null, null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty)};
 
             // Exercize system
             var result = NameLookup.HavingSeparator("string-seq", specs, StringComparer.Ordinal);
@@ -35,7 +35,7 @@ namespace CommandLine.Tests.Unit.Core
 
             // Fixture setup
             var expected = new NameInfo(ShortName, LongName);
-            var spec = new OptionSpecification(ShortName, LongName, false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '.', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty);
+            var spec = new OptionSpecification(ShortName, LongName, false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '.', null, null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty);
 
             // Exercize system
             var result = spec.FromOptionSpecification();

--- a/tests/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
@@ -28,7 +28,7 @@ namespace CommandLine.Tests.Unit.Core
             var specProps = new[]
                 {
                     SpecificationProperty.Create(
-                        new OptionSpecification("x", string.Empty, false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), string.Empty, string.Empty, new List<string>(), typeof(bool), TargetType.Switch, string.Empty),
+                        new OptionSpecification("x", string.Empty, false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', Maybe.Nothing<object>(), Maybe.Nothing<string>(), string.Empty, string.Empty, new List<string>(), typeof(bool), TargetType.Switch, string.Empty),
                         typeof(Simple_Options).GetProperties().Single(p => p.Name.Equals("BoolValue", StringComparison.Ordinal)),
                         Maybe.Nothing<object>())
                 };

--- a/tests/CommandLine.Tests/Unit/Core/TokenPartitionerTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TokenPartitionerTests.cs
@@ -21,8 +21,8 @@ namespace CommandLine.Tests.Unit.Core
                 };
             var specs = new[]
                 {
-                    new OptionSpecification(string.Empty, "stringvalue", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', null, string.Empty, string.Empty, new List<string>(), typeof(string), TargetType.Scalar, string.Empty),
-                    new OptionSpecification("i", string.Empty, false, string.Empty, Maybe.Just(3), Maybe.Just(4), '\0', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<int>), TargetType.Sequence, string.Empty)
+                    new OptionSpecification(string.Empty, "stringvalue", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', null, null, string.Empty, string.Empty, new List<string>(), typeof(string), TargetType.Scalar, string.Empty),
+                    new OptionSpecification("i", string.Empty, false, string.Empty, Maybe.Just(3), Maybe.Just(4), '\0', null, null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<int>), TargetType.Sequence, string.Empty)
                 };
 
             // Exercize system 
@@ -48,8 +48,8 @@ namespace CommandLine.Tests.Unit.Core
                 };
             var specs = new[]
                 {
-                    new OptionSpecification(string.Empty, "stringvalue", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', null, string.Empty, string.Empty, new List<string>(), typeof(string), TargetType.Scalar, string.Empty),
-                    new OptionSpecification("i", string.Empty, false, string.Empty, Maybe.Just(3), Maybe.Just(4), '\0', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<int>), TargetType.Sequence, string.Empty)
+                    new OptionSpecification(string.Empty, "stringvalue", false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '\0', null, null, string.Empty, string.Empty, new List<string>(), typeof(string), TargetType.Scalar, string.Empty),
+                    new OptionSpecification("i", string.Empty, false, string.Empty, Maybe.Just(3), Maybe.Just(4), '\0', null, null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<int>), TargetType.Sequence, string.Empty)
                 };
 
             // Exercize system 

--- a/tests/CommandLine.Tests/Unit/Core/TokenizerTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TokenizerTests.cs
@@ -21,7 +21,7 @@ namespace CommandLine.Tests.Unit.Core
             var expectedTokens = new[] { Token.Name("i"), Token.Value("10"), Token.Name("string-seq"),
                 Token.Value("aaa"), Token.Value("bb"),  Token.Value("cccc"), Token.Name("switch") };
             var specs = new[] { new OptionSpecification(string.Empty, "string-seq",
-                false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), ',', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty)};
+                false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), ',', null, null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty)};
 
             // Exercize system
             var result =
@@ -44,7 +44,7 @@ namespace CommandLine.Tests.Unit.Core
             var expectedTokens = new[] { Token.Name("x"), Token.Name("string-seq"),
                 Token.Value("aaa"), Token.Value("bb"),  Token.Value("cccc"), Token.Name("switch") };
             var specs = new[] { new OptionSpecification(string.Empty, "string-seq",
-                false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), ',', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty)};
+                false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), ',', null, null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence, string.Empty)};
 
             // Exercize system
             var result =

--- a/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
@@ -8,117 +8,117 @@ using CommandLine.Core;
 
 namespace CommandLine.Tests.Unit.Core
 {
-    public class TypeConverterTests
-    {
-        enum TestEnum
-        {
-            ValueA = 1,
-            ValueB = 2
-        }
+	public class TypeConverterTests
+	{
+		enum TestEnum
+		{
+			ValueA = 1,
+			ValueB = 2
+		}
 
-        [Flags]
-        enum TestFlagEnum
-        {
-            ValueA = 0x1,
-            ValueB = 0x2
-        }
+		[Flags]
+		enum TestFlagEnum
+		{
+			ValueA = 0x1,
+			ValueB = 0x2
+		}
 
-        [Theory]
-        [MemberData(nameof(ChangeType_scalars_source))]
-        public void ChangeType_scalars(string testValue, Type destinationType, bool expectFail, object expectedResult)
-        {
-            Maybe<object> result = TypeConverter.ChangeType(new[] {testValue}, destinationType, true, CultureInfo.InvariantCulture, true);
+		[Theory]
+		[MemberData(nameof(ChangeType_scalars_source))]
+		public void ChangeType_scalars(string testValue, Type destinationType, bool expectFail, object expectedResult)
+		{
+			Maybe<object> result = TypeConverter.ChangeType(new[] { testValue }, destinationType, true, CultureInfo.InvariantCulture, true);
 
-            if (expectFail)
-            {
-                result.MatchNothing().Should().BeTrue("should fail parsing");
-            }
-            else
-            {
-                result.MatchJust(out object matchedValue).Should().BeTrue("should parse successfully");
-                Assert.Equal(matchedValue, expectedResult);
-            }
-        }
+			if (expectFail)
+			{
+				result.MatchNothing().Should().BeTrue("should fail parsing");
+			}
+			else
+			{
+				result.MatchJust(out object matchedValue).Should().BeTrue("should parse successfully");
+				Assert.Equal(matchedValue, expectedResult);
+			}
+		}
 
-        public static IEnumerable<object[]> ChangeType_scalars_source
-        {
-            get
-            {
-                return new[]
-                {
-                    new object[] {"1", typeof (int), false, 1},
-                    new object[] {"0", typeof (int), false, 0},
-                    new object[] {"-1", typeof (int), false, -1},
-                    new object[] {"abcd", typeof (int), true, null},
-                    new object[] {"1.0", typeof (int), true, null},
-                    new object[] {int.MaxValue.ToString(), typeof (int), false, int.MaxValue},
-                    new object[] {int.MinValue.ToString(), typeof (int), false, int.MinValue},
-                    new object[] {((long) int.MaxValue + 1).ToString(), typeof (int), true, null},
-                    new object[] {((long) int.MinValue - 1).ToString(), typeof (int), true, null},
+		public static IEnumerable<object[]> ChangeType_scalars_source
+		{
+			get
+			{
+				return new[]
+				{
+					new object[] {"1", typeof (int), false, 1},
+					new object[] {"0", typeof (int), false, 0},
+					new object[] {"-1", typeof (int), false, -1},
+					new object[] {"abcd", typeof (int), true, null},
+					new object[] {"1.0", typeof (int), true, null},
+					new object[] {int.MaxValue.ToString(), typeof (int), false, int.MaxValue},
+					new object[] {int.MinValue.ToString(), typeof (int), false, int.MinValue},
+					new object[] {((long) int.MaxValue + 1).ToString(), typeof (int), true, null},
+					new object[] {((long) int.MinValue - 1).ToString(), typeof (int), true, null},
 
-                    new object[] {"1", typeof (uint), false, (uint) 1},
+					new object[] {"1", typeof (uint), false, (uint) 1},
                    // new object[] {"0", typeof (uint), false, (uint) 0},  //cause warning: Skipping test case with duplicate ID
                    // new object[] {"-1", typeof (uint), true, null},  //cause warning: Skipping test case with duplicate ID
                     new object[] {uint.MaxValue.ToString(), typeof (uint), false, uint.MaxValue},
-                    new object[] {uint.MinValue.ToString(), typeof (uint), false, uint.MinValue},
-                    new object[] {((long) uint.MaxValue + 1).ToString(), typeof (uint), true, null},
-                    new object[] {((long) uint.MinValue - 1).ToString(), typeof (uint), true, null},
+					new object[] {uint.MinValue.ToString(), typeof (uint), false, uint.MinValue},
+					new object[] {((long) uint.MaxValue + 1).ToString(), typeof (uint), true, null},
+					new object[] {((long) uint.MinValue - 1).ToString(), typeof (uint), true, null},
 
-                    new object[] {"true", typeof (bool), false, true},
-                    new object[] {"True", typeof (bool), false, true},
-                    new object[] {"TRUE", typeof (bool), false, true},
-                    new object[] {"false", typeof (bool), false, false},
-                    new object[] {"False", typeof (bool), false, false},
-                    new object[] {"FALSE", typeof (bool), false, false},
-                    new object[] {"abcd", typeof (bool), true, null},
-                    new object[] {"0", typeof (bool), true, null},
-                    new object[] {"1", typeof (bool), true, null},
+					new object[] {"true", typeof (bool), false, true},
+					new object[] {"True", typeof (bool), false, true},
+					new object[] {"TRUE", typeof (bool), false, true},
+					new object[] {"false", typeof (bool), false, false},
+					new object[] {"False", typeof (bool), false, false},
+					new object[] {"FALSE", typeof (bool), false, false},
+					new object[] {"abcd", typeof (bool), true, null},
+					new object[] {"0", typeof (bool), false, false},
+					new object[] {"1", typeof (bool), false, true},
 
-                    new object[] {"1.0", typeof (float), false, 1.0f},
-                    new object[] {"0.0", typeof (float), false, 0.0f},
-                    new object[] {"-1.0", typeof (float), false, -1.0f},
-                    new object[] {"abcd", typeof (float), true, null},
+					new object[] {"1.0", typeof (float), false, 1.0f},
+					new object[] {"0.0", typeof (float), false, 0.0f},
+					new object[] {"-1.0", typeof (float), false, -1.0f},
+					new object[] {"abcd", typeof (float), true, null},
 
-                    new object[] {"1.0", typeof (double), false, 1.0},
-                    new object[] {"0.0", typeof (double), false, 0.0},
-                    new object[] {"-1.0", typeof (double), false, -1.0},
-                    new object[] {"abcd", typeof (double), true, null},
+					new object[] {"1.0", typeof (double), false, 1.0},
+					new object[] {"0.0", typeof (double), false, 0.0},
+					new object[] {"-1.0", typeof (double), false, -1.0},
+					new object[] {"abcd", typeof (double), true, null},
 
-                    new object[] {"1.0", typeof (decimal), false, 1.0m},
-                    new object[] {"0.0", typeof (decimal), false, 0.0m},
-                    new object[] {"-1.0", typeof (decimal), false, -1.0m},
-                    new object[] {"-1.123456", typeof (decimal), false, -1.123456m},
-                    new object[] {"abcd", typeof (decimal), true, null},
+					new object[] {"1.0", typeof (decimal), false, 1.0m},
+					new object[] {"0.0", typeof (decimal), false, 0.0m},
+					new object[] {"-1.0", typeof (decimal), false, -1.0m},
+					new object[] {"-1.123456", typeof (decimal), false, -1.123456m},
+					new object[] {"abcd", typeof (decimal), true, null},
 
-                    new object[] {"", typeof (string), false, ""},
-                    new object[] {"abcd", typeof (string), false, "abcd"},
+					new object[] {"", typeof (string), false, ""},
+					new object[] {"abcd", typeof (string), false, "abcd"},
 
-                    new object[] {"ValueA", typeof (TestEnum), false, TestEnum.ValueA},
-                    new object[] {"VALUEA", typeof (TestEnum), false, TestEnum.ValueA},
-                    new object[] {"ValueB", typeof(TestEnum), false, TestEnum.ValueB},
-                    new object[] {((int) TestEnum.ValueA).ToString(), typeof (TestEnum), false, TestEnum.ValueA},
-                    new object[] {((int) TestEnum.ValueB).ToString(), typeof (TestEnum), false, TestEnum.ValueB},
-                    new object[] {((int) TestEnum.ValueB + 1).ToString(), typeof (TestEnum), true, null},
-                    new object[] {((int) TestEnum.ValueA - 1).ToString(), typeof (TestEnum), true, null},
+					new object[] {"ValueA", typeof (TestEnum), false, TestEnum.ValueA},
+					new object[] {"VALUEA", typeof (TestEnum), false, TestEnum.ValueA},
+					new object[] {"ValueB", typeof(TestEnum), false, TestEnum.ValueB},
+					new object[] {((int) TestEnum.ValueA).ToString(), typeof (TestEnum), false, TestEnum.ValueA},
+					new object[] {((int) TestEnum.ValueB).ToString(), typeof (TestEnum), false, TestEnum.ValueB},
+					new object[] {((int) TestEnum.ValueB + 1).ToString(), typeof (TestEnum), true, null},
+					new object[] {((int) TestEnum.ValueA - 1).ToString(), typeof (TestEnum), true, null},
 
-                    new object[] {"ValueA", typeof (TestFlagEnum), false, TestFlagEnum.ValueA},
-                    new object[] {"VALUEA", typeof (TestFlagEnum), false, TestFlagEnum.ValueA},
-                    new object[] {"ValueB", typeof(TestFlagEnum), false, TestFlagEnum.ValueB},
-                    new object[] {"ValueA,ValueB", typeof (TestFlagEnum), false, TestFlagEnum.ValueA | TestFlagEnum.ValueB},
-                    new object[] {"ValueA, ValueB", typeof (TestFlagEnum), false, TestFlagEnum.ValueA | TestFlagEnum.ValueB},
-                    new object[] {"VALUEA,ValueB", typeof (TestFlagEnum), false, TestFlagEnum.ValueA | TestFlagEnum.ValueB},
-                    new object[] {((int) TestFlagEnum.ValueA).ToString(), typeof (TestFlagEnum), false, TestFlagEnum.ValueA},
-                    new object[] {((int) TestFlagEnum.ValueB).ToString(), typeof (TestFlagEnum), false, TestFlagEnum.ValueB},
-                    new object[] {((int) (TestFlagEnum.ValueA | TestFlagEnum.ValueB)).ToString(), typeof (TestFlagEnum), false, TestFlagEnum.ValueA | TestFlagEnum.ValueB},
-                    new object[] {((int) TestFlagEnum.ValueB + 2).ToString(), typeof (TestFlagEnum), true, null},
-                    new object[] {((int) TestFlagEnum.ValueA - 1).ToString(), typeof (TestFlagEnum), true, null},
+					new object[] {"ValueA", typeof (TestFlagEnum), false, TestFlagEnum.ValueA},
+					new object[] {"VALUEA", typeof (TestFlagEnum), false, TestFlagEnum.ValueA},
+					new object[] {"ValueB", typeof(TestFlagEnum), false, TestFlagEnum.ValueB},
+					new object[] {"ValueA,ValueB", typeof (TestFlagEnum), false, TestFlagEnum.ValueA | TestFlagEnum.ValueB},
+					new object[] {"ValueA, ValueB", typeof (TestFlagEnum), false, TestFlagEnum.ValueA | TestFlagEnum.ValueB},
+					new object[] {"VALUEA,ValueB", typeof (TestFlagEnum), false, TestFlagEnum.ValueA | TestFlagEnum.ValueB},
+					new object[] {((int) TestFlagEnum.ValueA).ToString(), typeof (TestFlagEnum), false, TestFlagEnum.ValueA},
+					new object[] {((int) TestFlagEnum.ValueB).ToString(), typeof (TestFlagEnum), false, TestFlagEnum.ValueB},
+					new object[] {((int) (TestFlagEnum.ValueA | TestFlagEnum.ValueB)).ToString(), typeof (TestFlagEnum), false, TestFlagEnum.ValueA | TestFlagEnum.ValueB},
+					new object[] {((int) TestFlagEnum.ValueB + 2).ToString(), typeof (TestFlagEnum), true, null},
+					new object[] {((int) TestFlagEnum.ValueA - 1).ToString(), typeof (TestFlagEnum), true, null},
 
 
                     // Failed before #339
                     new object[] {"false", typeof (int), true, 0},
-                    new object[] {"true", typeof (int), true, 0}
-                };
-            }
-        }
-    }
+					new object[] {"true", typeof (int), true, 0}
+				};
+			}
+		}
+	}
 }

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -133,6 +133,39 @@ namespace CommandLine.Tests.Unit
         }
 
         [Fact]
+        public void Parse_spec_with_enviroment_variables()
+        {
+            // Fixture setup
+            var expectedOptions = new Simple_Options_With_Env
+            {
+                StringValue = "astring",
+                LongValue = 20L,
+                IntValue = 2,
+                BoolValueFullFalse = false,
+                BoolValueFullTrue = true,
+                BoolValueShortTrue = true,
+                BoolValueShortFalse = false,
+            };
+            var sut = new Parser(with => with.EnableDashDash = true);
+
+            // Exercize system
+            Environment.SetEnvironmentVariable("StringValue", "astring");
+            Environment.SetEnvironmentVariable("LongValue", "20");
+            Environment.SetEnvironmentVariable("IntValue", null);
+            Environment.SetEnvironmentVariable("BoolValueFullFalse", "false");
+            Environment.SetEnvironmentVariable("BoolValueFullTrue", "true");
+            Environment.SetEnvironmentVariable("BoolValueShortTrue", "1");
+            Environment.SetEnvironmentVariable("BoolValueShortFalse", "0");
+            var result =
+                sut.ParseArguments<Simple_Options_With_Env>(
+                    new string[0]);
+
+            // Verify outcome
+            ((Parsed<Simple_Options_With_Env>)result).Value.Should().BeEquivalentTo(expectedOptions);
+            // Teardown
+        }
+
+        [Fact]
         public void Parse_options_with_double_dash_and_option_sequence()
         {
             var expectedOptions = new Options_With_Option_Sequence_And_Value_Sequence


### PR DESCRIPTION
Fixes: https://github.com/commandlineparser/commandline/issues/677

Allows for enviroment variables to be part of a cli setup the order is Args > Env > Default
NB. Currently does not support sequences (Future work - will instead crash with a helpful error msg)

I also changed 0/1 to be parsable booleans as that's the language agnotisc / most common way to set booleans via environment variables.