### PR TITLE
Fixes PlatformNotSupported on Xamarin.Mac modern.

### DIFF
--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -41,13 +41,12 @@ namespace CommandLine
 
         private int GetWindowWidth()
         {
-
-#if !NET40
-            if (Console.IsOutputRedirected) return DefaultMaximumLength;
-#endif
             var width = 1;
             try
             {
+#if !NET40
+            	if (Console.IsOutputRedirected) return DefaultMaximumLength;
+#endif
                 width = Console.WindowWidth;
                 if (width < 1)
                 {

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -191,7 +191,7 @@ namespace CommandLine.Text
                     maximumDisplayWidth = DefaultMaximumLength;
                 }
             }
-            catch (IOException)
+            catch (Exception e) when ( e is IOException || e is PlatformNotSupportedException)
             {
                 maximumDisplayWidth = DefaultMaximumLength;
             }


### PR DESCRIPTION
On Xamarin.Mac `Console.IsOutputRedirected` throws a `PlatformNotSupportedException`.
This PR moves that line to within the try-catch-block so it can be safely ignored. 
Fixes #725