### PR TITLE
Better error message for missing value arguments

### DIFF
--- a/src/CommandLine/Core/NameExtensions.cs
+++ b/src/CommandLine/Core/NameExtensions.cs
@@ -20,12 +20,23 @@ namespace CommandLine.Core
                 specification.LongName);
         }
 
+        public static NameInfo FromValueSpecification(this ValueSpecification specification)
+        {
+            return new NameInfo(
+                specification.MetaName,
+                specification.MetaName);
+        }
+
         public static NameInfo FromSpecification(this Specification specification)
         {
             switch (specification.Tag)
             {
                 case SpecificationType.Option:
                     return FromOptionSpecification((OptionSpecification)specification);
+                case SpecificationType.Value:
+                    if (!string.IsNullOrEmpty(((ValueSpecification)specification).MetaName))
+                        return FromValueSpecification((ValueSpecification)specification);
+                    return NameInfo.EmptyName;
                 default:
                     return NameInfo.EmptyName;
             }

--- a/src/CommandLine/NameInfo.cs
+++ b/src/CommandLine/NameInfo.cs
@@ -50,7 +50,7 @@ namespace CommandLine
         {
             get
             {
-                return ShortName.Length > 0 && LongName.Length > 0
+                return ShortName.Length > 0 && LongName.Length > 0 && ShortName != LongName
                            ? ShortName + ", " + LongName
                            : ShortName.Length > 0
                                 ? ShortName


### PR DESCRIPTION
Fixes #363

The problem shows up when using an argument like this:

```csharp
[Value(0, Min = 1, HelpText = "Path(s) to file(s)", Required = true)]
public IEnumerable<string> FilePaths { get; }
```

Calling the CLI without providing a value for this argument will
currently result in the following error:

> ERROR(S):
> A sequence value not bound to option name is defined with few items than required.

This patch changes the behaviour so that, iff a MetaName is provided in the ValueAttribute, the user of the CLI will receive a message along the lines of:

> ERROR(S):
>   Required option '$MetaName' is missing.