### PR TITLE
Add setting to interpret options starting with a single dash as long named options

### DIFF
--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -22,6 +22,7 @@ namespace CommandLine.Core
             CultureInfo parsingCulture,
             bool autoHelp,
             bool autoVersion,
+            OptionsParseMode optionsParseMode,
             IEnumerable<ErrorType> nonFatalErrors)
         {
             return Build(
@@ -34,6 +35,7 @@ namespace CommandLine.Core
                 autoHelp,
                 autoVersion,
                 false,
+                optionsParseMode,
                 nonFatalErrors);
         }
 
@@ -47,6 +49,7 @@ namespace CommandLine.Core
             bool autoHelp,
             bool autoVersion,
             bool allowMultiInstance,
+            OptionsParseMode optionsParseMode,
             IEnumerable<ErrorType> nonFatalErrors)        {
             var typeInfo = factory.MapValueOrDefault(f => f().GetType(), typeof(T));
 
@@ -137,7 +140,7 @@ namespace CommandLine.Core
 
             var preprocessorErrors = (
                     argumentsList.Any()
-                    ? arguments.Preprocess(PreprocessorGuards.Lookup(nameComparer, autoHelp, autoVersion))
+                    ? arguments.Preprocess(PreprocessorGuards.Lookup(nameComparer, autoHelp, autoVersion, optionsParseMode))
                     : Enumerable.Empty<Error>()
                 ).Memoize();
 

--- a/src/CommandLine/Core/PreprocessorGuards.cs
+++ b/src/CommandLine/Core/PreprocessorGuards.cs
@@ -9,30 +9,31 @@ namespace CommandLine.Core
     static class PreprocessorGuards
     {
         public static IEnumerable<Func<IEnumerable<string>, IEnumerable<Error>>>
-            Lookup(StringComparer nameComparer, bool autoHelp, bool autoVersion)
+            Lookup(StringComparer nameComparer, bool autoHelp, bool autoVersion, OptionsParseMode optionsParseMode)
         {
             var list = new List<Func<IEnumerable<string>, IEnumerable<Error>>>();
             if (autoHelp)
-                list.Add(HelpCommand(nameComparer));
+                list.Add(HelpCommand(nameComparer, optionsParseMode));
             if (autoVersion)
-                list.Add(VersionCommand(nameComparer));
+                list.Add(VersionCommand(nameComparer, optionsParseMode));
             return list;
         }
-
-        public static Func<IEnumerable<string>, IEnumerable<Error>> HelpCommand(StringComparer nameComparer)
+        public static Func<IEnumerable<string>, IEnumerable<Error>> HelpCommand(StringComparer nameComparer, OptionsParseMode optionsParseMode)
         {
             return
                 arguments =>
-                    nameComparer.Equals("--help", arguments.First())
+                    optionsParseMode != OptionsParseMode.SingleDashOnly && nameComparer.Equals("--help", arguments.First())
+                    || optionsParseMode != OptionsParseMode.Default && nameComparer.Equals("-help", arguments.First())
                         ? new Error[] { new HelpRequestedError() }
                         : Enumerable.Empty<Error>();
         }
 
-        public static Func<IEnumerable<string>, IEnumerable<Error>> VersionCommand(StringComparer nameComparer)
+        public static Func<IEnumerable<string>, IEnumerable<Error>> VersionCommand(StringComparer nameComparer, OptionsParseMode optionsParseMode)
         {
             return
                 arguments =>
-                    nameComparer.Equals("--version", arguments.First())
+                    optionsParseMode != OptionsParseMode.SingleDashOnly && nameComparer.Equals("--version", arguments.First())
+                    || optionsParseMode != OptionsParseMode.Default && nameComparer.Equals("-version", arguments.First())
                         ? new Error[] { new VersionRequestedError() }
                         : Enumerable.Empty<Error>();
         }

--- a/src/CommandLine/OptionsParseMode.cs
+++ b/src/CommandLine/OptionsParseMode.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+namespace CommandLine
+{
+    /// <summary>
+    /// Defines how commandline options are being parsed.
+    /// </summary>
+    public enum OptionsParseMode
+    {
+        /// <summary>
+        /// Options that start with a double dash must be defined using its full name. E.g. git rebase --interactive
+        /// Options that start with a single dash are interpreted as list of short named options. E.g. git clean -xdf
+        /// </summary>
+        Default,
+        
+        /// <summary>
+        /// Options that start with a single or double dash are interpreted as short or full named option.
+        /// </summary>
+        SingleOrDoubleDash,
+        
+        /// <summary>
+        /// Options that start with a single dash are interpreted as short or full named option.
+        /// Options that start with a double dash are considered an invalid input.
+        /// </summary>
+        SingleDashOnly
+    }
+}

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -190,11 +190,13 @@ namespace CommandLine
                     settings.NameComparer,
                     settings.IgnoreUnknownArguments,
                     settings.EnableDashDash,
-                    settings.PosixlyCorrect)(arguments, optionSpecs)
+                    settings.PosixlyCorrect,
+                    settings.OptionsParseMode)(arguments, optionSpecs)
                 : Tokenizer.ConfigureTokenizer(
                     settings.NameComparer,
                     settings.IgnoreUnknownArguments,
-                    settings.EnableDashDash)(arguments, optionSpecs);
+                    settings.EnableDashDash,
+                    settings.OptionsParseMode)(arguments, optionSpecs);
         }
 
         private static ParserResult<T> MakeParserResult<T>(ParserResult<T> parserResult, ParserSettings settings)
@@ -202,15 +204,16 @@ namespace CommandLine
             return DisplayHelp(
                 parserResult,
                 settings.HelpWriter,
-                settings.MaximumDisplayWidth);
+                settings.MaximumDisplayWidth,
+                settings.OptionsParseMode != OptionsParseMode.Default);
         }
 
-        private static ParserResult<T> DisplayHelp<T>(ParserResult<T> parserResult, TextWriter helpWriter, int maxDisplayWidth)
+        private static ParserResult<T> DisplayHelp<T>(ParserResult<T> parserResult, TextWriter helpWriter, int maxDisplayWidth, bool useSingleDashForOptions)
         {
             parserResult.WithNotParsed(
                 errors =>
                     Maybe.Merge(errors.ToMaybe(), helpWriter.ToMaybe())
-                        .Do((_, writer) => writer.Write(HelpText.AutoBuild(parserResult, maxDisplayWidth)))
+                        .Do((_, writer) => writer.Write(HelpText.AutoBuild(parserResult, maxDisplayWidth, useSingleDashForOptions)))
                 );
 
             return parserResult;

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -102,6 +102,7 @@ namespace CommandLine
                     settings.AutoHelp,
                     settings.AutoVersion,
                     settings.AllowMultiInstance,
+                    settings.OptionsParseMode,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }
@@ -133,6 +134,7 @@ namespace CommandLine
                     settings.AutoHelp,
                     settings.AutoVersion,
                     settings.AllowMultiInstance,
+                    settings.OptionsParseMode,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }
@@ -166,6 +168,7 @@ namespace CommandLine
                     settings.AutoHelp,
                     settings.AutoVersion,
                     settings.AllowMultiInstance,
+                    settings.OptionsParseMode,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
         }

--- a/src/CommandLine/ParserSettings.cs
+++ b/src/CommandLine/ParserSettings.cs
@@ -25,6 +25,7 @@ namespace CommandLine
         private bool autoVersion;
         private CultureInfo parsingCulture;
         private Maybe<bool> enableDashDash;
+        private OptionsParseMode optionsParseMode;
         private int maximumDisplayWidth;
         private Maybe<bool> allowMultiInstance;
         private bool getoptMode;
@@ -172,6 +173,15 @@ namespace CommandLine
         {
             get => enableDashDash.MatchJust(out bool value) ? value : getoptMode;
             set => PopsicleSetter.Set(Consumed, ref enableDashDash, Maybe.Just(value));
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating how commandline options are being parsed.
+        /// </summary>
+        public OptionsParseMode OptionsParseMode
+        {
+            get => optionsParseMode;
+            set => PopsicleSetter.Set(Consumed, ref optionsParseMode, value);
         }
 
         /// <summary>

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -1025,5 +1025,32 @@ namespace CommandLine.Tests.Unit
             //Assert
             sut.Settings.MaximumDisplayWidth.Should().BeGreaterThan(1);
         }
+        
+        [Theory]
+        [InlineData(OptionsParseMode.SingleOrDoubleDash, ParserResultType.Parsed, new[]{ "-s", "value" })]
+        [InlineData(OptionsParseMode.SingleOrDoubleDash, ParserResultType.Parsed, new[]{ "-shortandlong", "value" })]
+        [InlineData(OptionsParseMode.SingleOrDoubleDash, ParserResultType.Parsed, new[]{ "--s", "value" })]
+        [InlineData(OptionsParseMode.SingleOrDoubleDash, ParserResultType.Parsed, new[]{ "--shortandlong", "value" })]
+        [InlineData(OptionsParseMode.SingleDashOnly, ParserResultType.Parsed, new[]{ "-s", "value" })]
+        [InlineData(OptionsParseMode.SingleDashOnly, ParserResultType.Parsed, new[]{ "-shortandlong", "value" })]
+        [InlineData(OptionsParseMode.SingleDashOnly, ParserResultType.NotParsed, new[]{ "--s", "value" })]
+        [InlineData(OptionsParseMode.SingleDashOnly, ParserResultType.NotParsed, new[]{ "--shortanlong", "value" })]
+        public void Parse_Options_With_Custom_OptionsParseMode(OptionsParseMode mode, ParserResultType result, string[] arguments)
+        {
+            // Arrange
+            var sut = new Parser(with =>
+            {
+                with.OptionsParseMode = mode;
+            });
+
+            // Act
+            var options = sut.ParseArguments<Simple_Options>(arguments);
+
+            // Assert
+            options.Tag.Should().Be(result);
+
+            if (options.Tag == ParserResultType.Parsed)
+                options.Value.ShortAndLong.Should().Be("value");
+        }
     }
 }


### PR DESCRIPTION
This PR adds a setting to use single dashes for command line options.

As several others in issue #685 we wanted to switch to this library, since it is more robust than other libraries available. But due to backwards compatibility we needed to support single dashes instead of double dashes for options else we would break our customer's scripts.
So we forked this library and added an option for single dash support and now would like to bring this to the official repo.

There is a new setting `OptionsParseMode` in `ParserSettings`

With three modes:

* `Default` is identical to the current behavior

Options that start with a double dash must be defined using their full name. 
(e.g. `git rebase --interactive`)
Options that start with a single dash are interpreted as list of short named options. 
(e.g. `git clean -xdf`)

* `SingleOrDoubleDash` 

Options that start with a single or double dash are interpreted as short or full named option. 
(e.g. `git rebase --interactive` or `git rebase -interactive` or `git rebase --i` or `git rebase -i`, but `git clean -xdf` would no longer be possible)

* `SingleDashOnly`

Options that start with a single dash are interpreted as short or full named option. 
(e.g. `git rebase -interactive` or `git rebase -i` )
Options that start with a double dash are considered as an invalid input. 
(e.g. `git rebase --interactive` would no longer be possible)

It would be great if you could consider this feature, since there are several library consumers that are looking for this option.