### PR TITLE
Allow explicit definition of "entry" assembly

### DIFF
--- a/src/CommandLine/Infrastructure/ReflectionHelper.cs
+++ b/src/CommandLine/Infrastructure/ReflectionHelper.cs
@@ -16,6 +16,14 @@ namespace CommandLine.Infrastructure
         /// </summary>
         [ThreadStatic] private static IDictionary<Type, Attribute> _overrides;
 
+        private static Assembly _programAssembly;
+
+        public static Assembly ProgramAssembly
+        {
+            get => _programAssembly ?? GetExecutingOrEntryAssembly();
+            set => _programAssembly = value;
+        }
+
         /// <summary>
         /// Assembly attribute overrides for testing.
         /// </summary>
@@ -51,12 +59,10 @@ namespace CommandLine.Infrastructure
                         Maybe.Nothing<TAttribute>();
             }
 
-            var assembly = GetExecutingOrEntryAssembly();
-
 #if NET40
-            var attributes = assembly.GetCustomAttributes(typeof(TAttribute), false);
+            var attributes = ProgramAssembly.GetCustomAttributes(typeof(TAttribute), false);
 #else
-            var attributes = assembly.GetCustomAttributes<TAttribute>().ToArray();
+            var attributes = ProgramAssembly.GetCustomAttributes<TAttribute>().ToArray();
 #endif
 
             return attributes.Length > 0
@@ -66,14 +72,12 @@ namespace CommandLine.Infrastructure
 
         public static string GetAssemblyName()
         {
-            var assembly = GetExecutingOrEntryAssembly();
-            return assembly.GetName().Name;
+            return ProgramAssembly.GetName().Name;
         }
 
         public static string GetAssemblyVersion()
         {
-            var assembly = GetExecutingOrEntryAssembly();
-            return assembly.GetName().Version.ToStringInvariant();
+            return ProgramAssembly.GetName().Version.ToStringInvariant();
         }
 
         public static bool IsFSharpOptionType(Type type)

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -306,6 +306,17 @@ namespace CommandLine.Text
         }
 
         /// <summary>
+        /// Gets or sets the <see cref="Assembly"/> that will be used to look for meta data (assembly attributes) to auto build the help.
+        /// By default the entry assembly is automatically selected, but this may not match what is really expected, in particular when
+        /// running unit tests.
+        /// </summary>
+        public static Assembly AutoBuildMetadataAssembly
+        {
+            get => ReflectionHelper.ProgramAssembly;
+            set => ReflectionHelper.ProgramAssembly = value;
+        }
+
+        /// <summary>
         /// Creates a new instance of the <see cref="CommandLine.Text.HelpText"/> class using common defaults.
         /// </summary>
         /// <returns>

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -22,6 +22,7 @@ namespace CommandLine.Tests.Unit.Text
         public void Dispose()
         {
             ReflectionHelper.SetAttributeOverride(null);
+            HelpText.AutoBuildMetadataAssembly = null;
         }
 
         [Fact]
@@ -714,6 +715,21 @@ namespace CommandLine.Tests.Unit.Text
 
             onErrorCalled.Should().BeFalse(); // Other attributes have fallback logic
             actualResult.Copyright.Should().Be(string.Format("Copyright (C) {0} {1}", DateTime.Now.Year, expectedCompany));
+        }
+
+        [Fact]
+        public void AutoBuild_with_AutoBuildMetadataAssembly_defined()
+        {
+            HelpText.AutoBuildMetadataAssembly = typeof(HelpText).Assembly;
+            string expectedHeading = "CommandLine 0.0.0";
+            string expectedCopyright = "Copyright (c) 2005 - 2020 Giacomo Stelluti Scala & Contributors";
+
+            ParserResult<Simple_Options> fakeResult = new NotParsed<Simple_Options>(
+                TypeInfo.Create(typeof(Simple_Options)), new Error[0]);
+            HelpText actualResult = HelpText.AutoBuild(fakeResult, ht => ht, ex => ex);
+
+            actualResult.Heading.Should().Be(expectedHeading);
+            actualResult.Copyright.Should().Be(expectedCopyright);
         }
 
         [Fact]


### PR DESCRIPTION
This PR is related to my comment in #403

I've not add this as a parser setting like I've suggest because it would have need more changes to make that non static.
Furthermore the need can be seen as an advanced feature needed only in some unit tests.

This both reasons lead me to this design that allow consumer to setup AutoBuildMetadataAssembly in its production code, or only in its test code.