### PR TITLE
Fix for #776 and #797

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,7 @@ artifacts/*
 *.DotSettings.user
 # Visual Studio 2015 cache/options directory
 .vs/
+# Rider
+.idea/
 
 [R|r]elease/** 

--- a/tests/CommandLine.Tests/Unit/Core/TokenizerTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TokenizerTests.cs
@@ -62,12 +62,12 @@ namespace CommandLine.Tests.Unit.Core
         }
 
         [Fact]
-        public void Normalize_should_remove_all_value_with_explicit_assignment_of_existing_name()
+        public void Normalize_should_remove_all_names_and_values_with_explicit_assignment_of_non_existing_names()
         {
             // Fixture setup
             var expectedTokens = new[] {
-                Token.Name("x"), Token.Name("string-seq"), Token.Value("aaa"), Token.Value("bb"),
-                Token.Name("unknown"), Token.Name("switch") };
+                Token.Name("x"), Token.Name("string-seq"), Token.Value("value0", true), Token.Value("bb"),
+                Token.Name("switch") };
             Func<string, bool> nameLookup =
                 name => name.Equals("x") || name.Equals("string-seq") || name.Equals("switch");
 
@@ -78,8 +78,36 @@ namespace CommandLine.Tests.Unit.Core
                         Enumerable.Empty<Token>()
                             .Concat(
                                 new[] {
-                                    Token.Name("x"), Token.Name("string-seq"), Token.Value("aaa"), Token.Value("bb"),
+                                    Token.Name("x"), Token.Name("string-seq"), Token.Value("value0", true), Token.Value("bb"),
                                     Token.Name("unknown"), Token.Value("value0", true), Token.Name("switch") })
+                    //,Enumerable.Empty<Error>()),
+                    , nameLookup);
+
+            // Verify outcome
+            result.Should().BeEquivalentTo(expectedTokens);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void Normalize_should_remove_all_names_of_non_existing_names()
+        {
+            // Fixture setup
+            var expectedTokens = new[] {
+                Token.Name("x"), Token.Name("string-seq"), Token.Value("value0", true), Token.Value("bb"),
+                Token.Name("switch") };
+            Func<string, bool> nameLookup =
+                name => name.Equals("x") || name.Equals("string-seq") || name.Equals("switch");
+
+            // Exercize system
+            var result =
+                Tokenizer.Normalize(
+                    //Result.Succeed(
+                    Enumerable.Empty<Token>()
+                        .Concat(
+                            new[] {
+                                Token.Name("x"), Token.Name("string-seq"), Token.Value("value0", true), Token.Value("bb"),
+                                Token.Name("unknown"), Token.Name("switch") })
                     //,Enumerable.Empty<Error>()),
                     , nameLookup);
 

--- a/tests/CommandLine.Tests/Unit/Issue776Tests.cs
+++ b/tests/CommandLine.Tests/Unit/Issue776Tests.cs
@@ -1,0 +1,36 @@
+﻿using FluentAssertions;
+using Xunit;
+
+// Issue #776 and #797
+// When IgnoreUnknownArguments is used and there are unknown arguments with explicitly assigned values, other arguments with explicit assigned values should not be influenced.
+// The bug only occured when the value was the same for a known and an unknown argument.
+
+namespace CommandLine.Tests.Unit
+{
+    public class Issue776Tests
+    {
+        [Theory]
+        [InlineData("3")]
+        [InlineData("4")]
+        public void IgnoreUnknownArguments_should_work_for_all_values(string dummyValue)
+        {
+            var arguments = new[] { "--cols=4", $"--dummy={dummyValue}" };
+            var result = new Parser(with => { with.IgnoreUnknownArguments = true; })
+                .ParseArguments<Options>(arguments);
+
+            Assert.Empty(result.Errors);
+            Assert.Equal(ParserResultType.Parsed, result.Tag);
+
+            result.WithParsed(options =>
+            {
+                options.Cols.Should().Be(4);
+            });
+        }
+
+        private class Options
+        {
+            [Option("cols", Required = false)]
+            public int Cols { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #776 and #797 by removing the name and value tokens during normalize and by not matching value tokens by their value/equals call during removal.

Normalization now not only removes the value token but also the name token.
That way name tokens are also removed if they don't have a value.