### PR TITLE
Fixes issue #752

### DIFF
--- a/src/CommandLine/OptionAttribute.cs
+++ b/src/CommandLine/OptionAttribute.cs
@@ -19,7 +19,13 @@ namespace CommandLine
         private char separator;
         private string group=string.Empty;
 
-        private OptionAttribute(string shortName, string longName) : base()
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommandLine.OptionAttribute"/> class.
+        /// </summary>
+        /// <param name="shortName">The short name of the option.</param>
+        /// <param name="longName">The long name of the option.</param>
+        public OptionAttribute(string shortName, string longName) : base()
         {
             if (shortName == null) throw new ArgumentNullException("shortName");
             if (longName == null) throw new ArgumentNullException("longName");


### PR DESCRIPTION
Current `OptionAttribute` have a limitation of shortName being able to be set to just one character. This creates a limitation in the functionality of giving more readable or rememberable short names. For example, -FileSystem can be made to -FS. 

This PR tends to address this limitation. 

PS: this my first PR with this repository, let me know if more test cases have to be added. 

Issue #752 