### PR TITLE
Fix #830 - Recognize Option, Value and Usage attributes on private members

### DIFF
--- a/src/CommandLine/Core/ReflectionExtensions.cs
+++ b/src/CommandLine/Core/ReflectionExtensions.cs
@@ -15,7 +15,10 @@ namespace CommandLine.Core
     {
         public static IEnumerable<T> GetSpecifications<T>(this Type type, Func<PropertyInfo, T> selector)
         {
-            return from pi in type.FlattenHierarchy().SelectMany(x => x.GetTypeInfo().GetProperties())
+            return from pi in type.FlattenHierarchy()
+                    .SelectMany(x => x.GetTypeInfo()
+                        .GetProperties(BindingFlags.Instance | BindingFlags.Static |
+                                       BindingFlags.NonPublic | BindingFlags.Public))
                    let attrs = pi.GetCustomAttributes(true)
                    where
                        attrs.OfType<OptionAttribute>().Any() ||
@@ -38,7 +41,9 @@ namespace CommandLine.Core
         public static Maybe<Tuple<PropertyInfo, UsageAttribute>> GetUsageData(this Type type)
         {
             return
-                (from pi in type.FlattenHierarchy().SelectMany(x => x.GetTypeInfo().GetProperties())
+                (from pi in type.FlattenHierarchy().SelectMany(x => x.GetTypeInfo().GetProperties(
+                        BindingFlags.Instance | BindingFlags.Static |
+                        BindingFlags.NonPublic | BindingFlags.Public))
                     let attrs = pi.GetCustomAttributes(typeof(UsageAttribute), true)
                     where attrs.Any()
                     select Tuple.Create(pi, (UsageAttribute)attrs.First()))

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -839,8 +839,10 @@ namespace CommandLine.Text
                     var prop = tuple.Item1;
                     var attr = tuple.Item2;
 
-                    var examples = (IEnumerable<Example>)prop
-                        .GetValue(null, BindingFlags.Public | BindingFlags.Static | BindingFlags.GetProperty, null, null, null);
+                    var examples = (IEnumerable<Example>) prop
+                        .GetValue(null,
+                            BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static |
+                            BindingFlags.GetProperty, null, null, null);
 
                     return Tuple.Create(attr, examples);
                 });

--- a/tests/CommandLine.Tests/Unit/Issue830Tests.cs
+++ b/tests/CommandLine.Tests/Unit/Issue830Tests.cs
@@ -36,7 +36,7 @@ namespace CommandLine.Tests.Unit
 
             var lines = result.ToLines().TrimStringArray();
             lines[3].Should().BeEquivalentTo("Do something very cool:");
-            lines[4].Should().BeEquivalentTo("CommandLine --opt test1 test2");
+            lines[4].Should().BeEquivalentTo("myApp.txt --opt test1 test2");
         }
 
         private class Options
@@ -51,7 +51,7 @@ namespace CommandLine.Tests.Unit
             [Value(0, Required = true)]
             private string PrivateValue { get; set; }
 
-            [Usage]
+            [Usage(ApplicationAlias = "myApp.txt")]
             private static IEnumerable<Example> PrivateUsage { get; } = new List<Example>
             {
                 new Example("Do something very cool", new Options

--- a/tests/CommandLine.Tests/Unit/Issue830Tests.cs
+++ b/tests/CommandLine.Tests/Unit/Issue830Tests.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using CommandLine.Text;
+using FluentAssertions;
+using Xunit;
+
+// Issue #830
+// Allow private properties as options and usage
+namespace CommandLine.Tests.Unit
+{
+    public class Issue830Tests
+    {
+        [Fact]
+        public void Parse_options_with_private_value_and_option()
+        {
+            var expectedOptions = new Options
+            {
+                Option = "a",
+                Value = "b"
+            };
+
+            var result = Parser.Default.ParseArguments<Options>(
+                new[] { "b", "--opt", "a" });
+
+            ((Parsed<Options>)result).Value.Should().BeEquivalentTo(expectedOptions);
+        }
+
+        [Fact]
+        public void Print_private_usage()
+        {
+            var help = new StringWriter();
+            var sut = new Parser(config => config.HelpWriter = help);
+
+            sut.ParseArguments<Options>(new string[] { "--help" });
+            var result = help.ToString();
+
+            var lines = result.ToLines().TrimStringArray();
+            lines[3].Should().BeEquivalentTo("Do something very cool:");
+            lines[4].Should().BeEquivalentTo("CommandLine --opt test1 test2");
+        }
+
+        private class Options
+        {
+            public string Option { get => PrivateOption; set => PrivateOption = value; }
+
+            public string Value { get => PrivateValue; set => PrivateValue = value; }
+
+            [Option("opt", Required = true)]
+            private string PrivateOption { get; set; }
+
+            [Value(0, Required = true)]
+            private string PrivateValue { get; set; }
+
+            [Usage]
+            private static IEnumerable<Example> PrivateUsage { get; } = new List<Example>
+            {
+                new Example("Do something very cool", new Options
+                {
+                    PrivateOption = "test1",
+                    PrivateValue = "test2"
+                })
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Potential use cases:
- Requiring additional parsing which requires type or multiplicity changes and wanting to avoid exposing those `init`/`set`-only properties unnecessarily, as usage of the Options class from a programming interface should not rely on the parsing and instead assign the parsed properties directly.
- The ability to encapsulate functionality in the Options class without having to expose the properties directly.
- Not wanting to expose the `Usage` functionality to the programming interface.

### Additional arguments:
- It's already possible to use private `init`/`set` on a public property, so this seems more like an oversight (or the other way around!)
- I don't think there are any good reasons to uphold this restriction.