### PR TITLE
Small cleanup

### DIFF
--- a/src/CommandLine/Core/SpecificationProperty.cs
+++ b/src/CommandLine/Core/SpecificationProperty.cs
@@ -21,7 +21,7 @@ namespace CommandLine.Core
 
         public static SpecificationProperty Create(Specification specification, PropertyInfo property, Maybe<object> value)
         {
-            if (value == null) throw new ArgumentNullException("value");
+            if (value == null) throw new ArgumentNullException(nameof(value));
 
             return new SpecificationProperty(specification, property, value);
         }

--- a/src/CommandLine/Core/Token.cs
+++ b/src/CommandLine/Core/Token.cs
@@ -62,8 +62,7 @@ namespace CommandLine.Core
 
         public override bool Equals(object obj)
         {
-            var other = obj as Name;
-            if (other != null)
+            if (obj is Name other)
             {
                 return Equals(other);
             }

--- a/src/CommandLine/Error.cs
+++ b/src/CommandLine/Error.cs
@@ -189,7 +189,7 @@ namespace CommandLine
         protected internal TokenError(ErrorType tag, string token)
             : base(tag)
         {
-            if (token == null) throw new ArgumentNullException("token");
+            if (token == null) throw new ArgumentNullException(nameof(token));
 
             this.token = token;
         }
@@ -209,8 +209,7 @@ namespace CommandLine
         /// <returns><value>true</value> if the specified <see cref="System.Object"/> is equal to the current <see cref="System.Object"/>; otherwise, <value>false</value>.</returns>
         public override bool Equals(object obj)
         {
-            var other = obj as TokenError;
-            if (other != null)
+            if (obj is TokenError other)
             {
                 return Equals(other);
             }

--- a/src/CommandLine/Infrastructure/ReflectionHelper.cs
+++ b/src/CommandLine/Infrastructure/ReflectionHelper.cs
@@ -29,14 +29,7 @@ namespace CommandLine.Infrastructure
         /// </param>
         public static void SetAttributeOverride(IEnumerable<Attribute> overrides)
         {
-            if (overrides != null)
-            {
-                _overrides = overrides.ToDictionary(attr => attr.GetType(), attr => attr);
-            }
-            else
-            {
-                _overrides = null;
-            }
+            _overrides = overrides?.ToDictionary(attr => attr.GetType(), attr => attr);
         }
 
         public static Maybe<TAttribute> GetAttribute<TAttribute>()

--- a/src/CommandLine/NameInfo.cs
+++ b/src/CommandLine/NameInfo.cs
@@ -20,8 +20,8 @@ namespace CommandLine
 
         internal NameInfo(string shortName, string longName)
         {
-            if (shortName == null) throw new ArgumentNullException("shortName");
-            if (longName == null) throw new ArgumentNullException("longName");
+            if (shortName == null) throw new ArgumentNullException(nameof(shortName));
+            if (longName == null) throw new ArgumentNullException(nameof(longName));
 
             this.longName = longName;
             this.shortName = shortName;
@@ -65,8 +65,7 @@ namespace CommandLine
         /// <returns><value>true</value> if the specified <see cref="System.Object"/> is equal to the current <see cref="System.Object"/>; otherwise, <value>false</value>.</returns>
         public override bool Equals(object obj)
         {
-            var other = obj as NameInfo;
-            if (other != null)
+            if (obj is NameInfo other)
             {
                 return Equals(other);
             }

--- a/src/CommandLine/NullInstance.cs
+++ b/src/CommandLine/NullInstance.cs
@@ -3,7 +3,7 @@
 namespace CommandLine
 {
     /// <summary>
-    /// Models a null result when constructing a <see cref="ParserResult{T}"/> in a faling verbs scenario.
+    /// Models a null result when constructing a <see cref="ParserResult{T}"/> in a failing verbs scenario.
     /// </summary>
     public sealed class NullInstance
     {

--- a/src/CommandLine/OptionAttribute.cs
+++ b/src/CommandLine/OptionAttribute.cs
@@ -21,8 +21,8 @@ namespace CommandLine
 
         private OptionAttribute(string shortName, string longName) : base()
         {
-            if (shortName == null) throw new ArgumentNullException("shortName");
-            if (longName == null) throw new ArgumentNullException("longName");
+            if (shortName == null) throw new ArgumentNullException(nameof(shortName));
+            if (longName == null) throw new ArgumentNullException(nameof(longName));
 
             this.shortName = shortName;
             this.longName = longName;
@@ -91,7 +91,7 @@ namespace CommandLine
             get { return setName; }
             set
             {
-                if (value == null) throw new ArgumentNullException("value");
+                if (value == null) throw new ArgumentNullException(nameof(value));
 
                 setName = value;
             }

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -37,7 +37,7 @@ namespace CommandLine
         /// aspects and behaviors of the parser.</param>
         public Parser(Action<ParserSettings> configuration)
         {
-            if (configuration == null) throw new ArgumentNullException("configuration");
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
 
             settings = new ParserSettings();
             configuration(settings);
@@ -85,7 +85,7 @@ namespace CommandLine
         /// <exception cref="System.ArgumentNullException">Thrown if one or more arguments are null.</exception>
         public ParserResult<T> ParseArguments<T>(IEnumerable<string> args)
         {
-            if (args == null) throw new ArgumentNullException("args");
+            if (args == null) throw new ArgumentNullException(nameof(args));
 
             var factory = typeof(T).IsMutable()
                 ? Maybe.Just<Func<T>>(Activator.CreateInstance<T>)
@@ -118,9 +118,9 @@ namespace CommandLine
         /// <exception cref="System.ArgumentNullException">Thrown if one or more arguments are null.</exception>
         public ParserResult<T> ParseArguments<T>(Func<T> factory, IEnumerable<string> args)
         {
-            if (factory == null) throw new ArgumentNullException("factory");
-            if (!typeof(T).IsMutable()) throw new ArgumentException("factory");
-            if (args == null) throw new ArgumentNullException("args");
+            if (factory == null) throw new ArgumentNullException(nameof(factory));
+            if (!typeof(T).IsMutable()) throw new ArgumentException(nameof(factory));
+            if (args == null) throw new ArgumentNullException(nameof(args));
 
             return MakeParserResult(
                 InstanceBuilder.Build(
@@ -151,9 +151,9 @@ namespace CommandLine
         /// <remarks>All types must expose a parameterless constructor. It's strongly recommended to use a generic overload.</remarks>
         public ParserResult<object> ParseArguments(IEnumerable<string> args, params Type[] types)
         {
-            if (args == null) throw new ArgumentNullException("args");
-            if (types == null) throw new ArgumentNullException("types");
-            if (types.Length == 0) throw new ArgumentOutOfRangeException("types");
+            if (args == null) throw new ArgumentNullException(nameof(args));
+            if (types == null) throw new ArgumentNullException(nameof(types));
+            if (types.Length == 0) throw new ArgumentOutOfRangeException(nameof(types));
 
             return MakeParserResult(
                 InstanceChooser.Choose(

--- a/src/CommandLine/Text/CopyrightInfo.cs
+++ b/src/CommandLine/Text/CopyrightInfo.cs
@@ -71,8 +71,8 @@ namespace CommandLine.Text
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when parameter <paramref name="copyrightYears"/> is not supplied.</exception>
         public CopyrightInfo(bool isSymbolUpper, string author, params int[] copyrightYears)
         {
-            if (string.IsNullOrWhiteSpace(author)) throw new ArgumentException("author");
-            if (copyrightYears.Length == 0) throw new ArgumentOutOfRangeException("copyrightYears");
+            if (string.IsNullOrWhiteSpace(author)) throw new ArgumentException(nameof(author));
+            if (copyrightYears.Length == 0) throw new ArgumentOutOfRangeException(nameof(copyrightYears));
 
             const int ExtraLength = 10;
             this.isSymbolUpper = isSymbolUpper;

--- a/src/CommandLine/Text/Example.cs
+++ b/src/CommandLine/Text/Example.cs
@@ -23,9 +23,9 @@ namespace CommandLine.Text
         /// <param name="sample">A sample instance.</param>
         public Example(string helpText, IEnumerable<UnParserSettings> formatStyles, object sample)
         {
-            if (string.IsNullOrEmpty(helpText)) throw new ArgumentException("helpText can't be null or empty", "helpText");
-            if (formatStyles == null) throw new ArgumentNullException("formatStyles");
-            if (sample == null) throw new ArgumentNullException("sample");
+            if (string.IsNullOrEmpty(helpText)) throw new ArgumentException("helpText can't be null or empty", nameof(helpText));
+            if (formatStyles == null) throw new ArgumentNullException(nameof(formatStyles));
+            if (sample == null) throw new ArgumentNullException(nameof(sample));
 
             this.helpText = helpText;
             this.formatStyles = formatStyles;
@@ -84,8 +84,7 @@ namespace CommandLine.Text
         /// <returns><value>true</value> if the specified <see cref="System.Object"/> is equal to the current <see cref="System.Object"/>; otherwise, <value>false</value>.</returns>
         public override bool Equals(object obj)
         {
-            var other = obj as Example;
-            if (other != null)
+            if (obj is Example other)
             {
                 return Equals(other);
             }

--- a/src/CommandLine/Text/HeadingInfo.cs
+++ b/src/CommandLine/Text/HeadingInfo.cs
@@ -102,8 +102,8 @@ namespace CommandLine.Text
         /// <exception cref="System.ArgumentNullException">Thrown when parameter <paramref name="writer"/> is null.</exception>
         public void WriteMessage(string message, TextWriter writer)
         {
-            if (string.IsNullOrWhiteSpace("message")) throw new ArgumentException("message");
-            if (writer == null) throw new ArgumentNullException("writer");
+            if (string.IsNullOrWhiteSpace(message)) throw new ArgumentException(nameof(message));
+            if (writer == null) throw new ArgumentNullException(nameof(writer));
 
             writer.WriteLine(
                 new StringBuilder(programName.Length + message.Length + 2)

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -177,9 +177,9 @@ namespace CommandLine.Text
         /// <exception cref="System.ArgumentNullException">Thrown when one or more parameters are null or empty strings.</exception>
         public HelpText(SentenceBuilder sentenceBuilder, string heading, string copyright)
         {
-            if (sentenceBuilder == null) throw new ArgumentNullException("sentenceBuilder");
-            if (heading == null) throw new ArgumentNullException("heading");
-            if (copyright == null) throw new ArgumentNullException("copyright");
+            if (sentenceBuilder == null) throw new ArgumentNullException(nameof(sentenceBuilder));
+            if (heading == null) throw new ArgumentNullException(nameof(heading));
+            if (copyright == null) throw new ArgumentNullException(nameof(copyright));
 
             preOptionsHelp = new StringBuilder(BuilderCapacity);
             postOptionsHelp = new StringBuilder(BuilderCapacity);
@@ -211,7 +211,7 @@ namespace CommandLine.Text
             get { return heading; }
             set
             {
-                if (value == null) throw new ArgumentNullException("value");
+                if (value == null) throw new ArgumentNullException(nameof(value));
 
                 heading = value;
             }
@@ -226,7 +226,7 @@ namespace CommandLine.Text
             get { return copyright; }
             set
             {
-                if (value == null) throw new ArgumentNullException("value");
+                if (value == null) throw new ArgumentNullException(nameof(value));
 
                 copyright = value;
             }
@@ -419,7 +419,7 @@ namespace CommandLine.Text
         public static HelpText AutoBuild<T>(ParserResult<T> parserResult, Func<HelpText, HelpText> onError, int maxDisplayWidth = DefaultMaximumLength)
         {
             if (parserResult.Tag != ParserResultType.NotParsed)
-                throw new ArgumentException("Excepting NotParsed<T> type.", "parserResult");
+                throw new ArgumentException("Excepting NotParsed<T> type.", nameof(parserResult));
 
             var errors = ((NotParsed<T>)parserResult).Errors;
 
@@ -455,8 +455,8 @@ namespace CommandLine.Text
         /// <param name="current">The <see cref="CommandLine.Text.HelpText"/> instance.</param>
         public static HelpText DefaultParsingErrorsHandler<T>(ParserResult<T> parserResult, HelpText current)
         {
-            if (parserResult == null) throw new ArgumentNullException("parserResult");
-            if (current == null) throw new ArgumentNullException("current");
+            if (parserResult == null) throw new ArgumentNullException(nameof(parserResult));
+            if (current == null) throw new ArgumentNullException(nameof(current));
 
             if (((NotParsed<T>)parserResult).Errors.OnlyMeaningfulOnes().Empty())
                 return current;
@@ -558,7 +558,7 @@ namespace CommandLine.Text
         /// <exception cref="System.ArgumentNullException">Thrown when parameter <paramref name="result"/> is null.</exception>
         public HelpText AddOptions<T>(ParserResult<T> result)
         {
-            if (result == null) throw new ArgumentNullException("result");
+            if (result == null) throw new ArgumentNullException(nameof(result));
 
             return AddOptionsImpl(
                 GetSpecificationsFromType(result.TypeInfo.Current),
@@ -575,8 +575,8 @@ namespace CommandLine.Text
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown if <paramref name="types"/> array is empty.</exception>
         public HelpText AddVerbs(params Type[] types)
         {
-            if (types == null) throw new ArgumentNullException("types");
-            if (types.Length == 0) throw new ArgumentOutOfRangeException("types");
+            if (types == null) throw new ArgumentNullException(nameof(types));
+            if (types.Length == 0) throw new ArgumentOutOfRangeException(nameof(types));
 
             return AddOptionsImpl(
                 AdaptVerbsToSpecifications(types),
@@ -593,7 +593,7 @@ namespace CommandLine.Text
         /// <exception cref="System.ArgumentNullException">Thrown when parameter <paramref name="result"/> is null.</exception>    
         public HelpText AddOptions<T>(int maximumLength, ParserResult<T> result)
         {
-            if (result == null) throw new ArgumentNullException("result");
+            if (result == null) throw new ArgumentNullException(nameof(result));
 
             return AddOptionsImpl(
                 GetSpecificationsFromType(result.TypeInfo.Current),
@@ -611,8 +611,8 @@ namespace CommandLine.Text
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown if <paramref name="types"/> array is empty.</exception>
         public HelpText AddVerbs(int maximumLength, params Type[] types)
         {
-            if (types == null) throw new ArgumentNullException("types");
-            if (types.Length == 0) throw new ArgumentOutOfRangeException("types");
+            if (types == null) throw new ArgumentNullException(nameof(types));
+            if (types.Length == 0) throw new ArgumentOutOfRangeException(nameof(types));
 
             return AddOptionsImpl(
                 AdaptVerbsToSpecifications(types),
@@ -654,7 +654,7 @@ namespace CommandLine.Text
             Func<IEnumerable<MutuallyExclusiveSetError>, string> formatMutuallyExclusiveSetErrors,
             int indent)
         {
-            if (parserResult == null) throw new ArgumentNullException("parserResult");
+            if (parserResult == null) throw new ArgumentNullException(nameof(parserResult));
 
             var meaningfulErrors =
                 ((NotParsed<T>)parserResult).Errors.OnlyMeaningfulOnes();

--- a/src/CommandLine/Text/SentenceBuilder.cs
+++ b/src/CommandLine/Text/SentenceBuilder.cs
@@ -126,10 +126,10 @@ namespace CommandLine.Text
                                 case ErrorType.UnknownOptionError:
                                     return "Option '".JoinTo(((UnknownOptionError)error).Token, "' is unknown.");
                                 case ErrorType.MissingRequiredOptionError:
-                                    var errMisssing = ((MissingRequiredOptionError)error);
-                                    return errMisssing.NameInfo.Equals(NameInfo.EmptyName)
+                                    var errMissing = ((MissingRequiredOptionError)error);
+                                    return errMissing.NameInfo.Equals(NameInfo.EmptyName)
                                                ? "A required value not bound to option name is missing."
-                                               : "Required option '".JoinTo(errMisssing.NameInfo.NameText, "' is missing.");
+                                               : "Required option '".JoinTo(errMissing.NameInfo.NameText, "' is missing.");
                                 case ErrorType.BadFormatConversionError:
                                     var badFormat = ((BadFormatConversionError)error);
                                     return badFormat.NameInfo.Equals(NameInfo.EmptyName)

--- a/tests/CommandLine.Tests/CultureInfoExtensions.cs
+++ b/tests/CommandLine.Tests/CultureInfoExtensions.cs
@@ -16,11 +16,11 @@ namespace CommandLine.Tests
     {
         public static CultureHandlers MakeCultureHandlers(this CultureInfo newCulture)
         {
-            var currentCulutre = Thread.CurrentThread.CurrentCulture;
+            var currentClutre = Thread.CurrentThread.CurrentCulture;
 
             Action changer = () => Thread.CurrentThread.CurrentCulture = newCulture;
 
-            Action resetter = () => Thread.CurrentThread.CurrentCulture = currentCulutre;
+            Action resetter = () => Thread.CurrentThread.CurrentCulture = currentClutre;
 
             return new CultureHandlers { ChangeCulture = changer, ResetCulture = resetter };
         }

--- a/tests/CommandLine.Tests/CultureInfoExtensions.cs
+++ b/tests/CommandLine.Tests/CultureInfoExtensions.cs
@@ -16,11 +16,11 @@ namespace CommandLine.Tests
     {
         public static CultureHandlers MakeCultureHandlers(this CultureInfo newCulture)
         {
-            var currentClutre = Thread.CurrentThread.CurrentCulture;
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
 
             Action changer = () => Thread.CurrentThread.CurrentCulture = newCulture;
 
-            Action resetter = () => Thread.CurrentThread.CurrentCulture = currentClutre;
+            Action resetter = () => Thread.CurrentThread.CurrentCulture = currentCulture;
 
             return new CultureHandlers { ChangeCulture = changer, ResetCulture = resetter };
         }


### PR DESCRIPTION
- Typo fixes;
- Make use of `nameof` for parameter names;
- Make use of pattern matching with `is` instead of `as` and null check.