### PR TITLE
A minor spelling mistake 

### DIFF
--- a/demo/ReadText.LocalizedDemo/Properties/Resources.Designer.cs
+++ b/demo/ReadText.LocalizedDemo/Properties/Resources.Designer.cs
@@ -331,7 +331,7 @@ namespace ReadText.LocalizedDemo.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A sequence value not bound to option name is defined with few items than required..
+        ///   Looks up a localized string similar to A sequence value not bound to option name is defined with fewer items than required..
         /// </summary>
         public static string SentenceSequenceOutOfRangeErrorValue {
             get {

--- a/demo/ReadText.LocalizedDemo/Properties/Resources.resx
+++ b/demo/ReadText.LocalizedDemo/Properties/Resources.resx
@@ -208,7 +208,7 @@
     <value>A sequence option '{0}' is defined with fewer or more items than required.</value>
   </data>
   <data name="SentenceSequenceOutOfRangeErrorValue" xml:space="preserve">
-    <value>A sequence value not bound to option name is defined with few items than required.</value>
+    <value>A sequence value not bound to option name is defined with fewer items than required.</value>
   </data>
   <data name="SentenceSetValueExceptionError" xml:space="preserve">
     <value>Error setting value to option '{0}': {1}</value>

--- a/src/CommandLine/Text/SentenceBuilder.cs
+++ b/src/CommandLine/Text/SentenceBuilder.cs
@@ -138,7 +138,7 @@ namespace CommandLine.Text
                                 case ErrorType.SequenceOutOfRangeError:
                                     var seqOutRange = ((SequenceOutOfRangeError)error);
                                     return seqOutRange.NameInfo.Equals(NameInfo.EmptyName)
-                                               ? "A sequence value not bound to option name is defined with few items than required."
+                                               ? "A sequence value not bound to option name is defined with fewer items than required."
                                                : "A sequence option '".JoinTo(seqOutRange.NameInfo.NameText,
                                                     "' is defined with fewer or more items than required.");
                                 case ErrorType.BadVerbSelectedError:


### PR DESCRIPTION
(with few items => with fewer items)