### PR TITLE
Update F# example

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Demo to show IEnumerable  options and other usage:  [Online Demo](https://dotnet
   <summary>Click to expand!</summary>
 
 ```fsharp
+open CommandLine
 
 type options = {
   [<Option('r', "read", Required = true, HelpText = "Input files.")>] files : seq<string>;
@@ -163,11 +164,10 @@ type options = {
   [<Value(0, MetaName="offset", HelpText = "File offset.")>] offset : int64 option;
 }
 
-let main argv =
-  let result = CommandLine.Parser.Default.ParseArguments<options>(argv)
-  match result with
-  | :? Parsed<options> as parsed -> run parsed.Value
-  | :? NotParsed<options> as notParsed -> fail notParsed.Errors
+let arguments = CommandLine.Parser.Default.ParseArguments<options>(System.Environment.GetCommandLineArgs())
+match arguments with
+    | :? Parsed<options> as parsed -> printfn "Success: %A" parsed.Value
+    | _ -> ()
 ```
 </details>
 


### PR DESCRIPTION
The old example is referencing undefined methods 'run' and 'fail' and does not have an implicit entry point. It also doesn't open `CommandLine`. I tried to write a shorter example that will not produce errors if pasted into an empty console app.