### PR TITLE
Treat Options without parameterless constructor as immutable

### DIFF
--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -4,10 +4,10 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using CommandLine.Infrastructure;
 using CSharpx;
 using RailwaySharp.ErrorHandling;
-using System.Reflection;
 
 namespace CommandLine.Core
 {
@@ -62,7 +62,7 @@ namespace CommandLine.Core
                 .Memoize();
 
             Func<T> makeDefault = () =>
-                typeof(T).IsMutable()
+                typeof(T).IsMutable() && typeof(T).HasParameterlessConstructor()
                     ? factory.MapValueOrDefault(f => f(), () => Activator.CreateInstance<T>())
                     : ReflectionHelper.CreateDefaultImmutableInstance<T>(
                         (from p in specProps select p.Specification.ConversionType).ToArray());
@@ -110,7 +110,7 @@ namespace CommandLine.Core
 
                 //build the instance, determining if the type is mutable or not.
                 T instance;
-                if(typeInfo.IsMutable() == true)
+                if (typeInfo.IsMutable() && typeInfo.HasParameterlessConstructor())
                 {
                     instance = BuildMutable(factory, specPropsWithValue, setPropertyErrors);
                 }

--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using CommandLine.Infrastructure;
 using CSharpx;
 using RailwaySharp.ErrorHandling;
@@ -61,11 +62,12 @@ namespace CommandLine.Core
                 .OfType<OptionSpecification>()
                 .Memoize();
 
-            Func<T> makeDefault = () =>
-                typeof(T).IsMutable() && typeof(T).HasParameterlessConstructor()
-                    ? factory.MapValueOrDefault(f => f(), () => Activator.CreateInstance<T>())
-                    : ReflectionHelper.CreateDefaultImmutableInstance<T>(
-                        (from p in specProps select p.Specification.ConversionType).ToArray());
+            Func<T> makeDefaultImmutable = () => ReflectionHelper.CreateDefaultImmutableInstance<T>((from p in specProps select p.Specification.ConversionType).ToArray());
+
+            Func<T> makeDefault =
+                typeof(T).IsMutable()
+                    ? () => factory.MapValueOrDefault(f => f(), () => typeof(T).HasParameterlessConstructor() ? Activator.CreateInstance<T>() : makeDefaultImmutable())
+                    : makeDefaultImmutable;
 
             Func<IEnumerable<Error>, ParserResult<T>> notParsed =
                 errs => new NotParsed<T>(makeDefault().GetType().ToTypeInfo(), errs);
@@ -110,7 +112,7 @@ namespace CommandLine.Core
 
                 //build the instance, determining if the type is mutable or not.
                 T instance;
-                if (typeInfo.IsMutable() && typeInfo.HasParameterlessConstructor())
+                if (typeInfo.IsMutable() && (!factory.IsNothing() || typeInfo.HasParameterlessConstructor()))
                 {
                     instance = BuildMutable(factory, specPropsWithValue, setPropertyErrors);
                 }

--- a/src/CommandLine/Core/ReflectionExtensions.cs
+++ b/src/CommandLine/Core/ReflectionExtensions.cs
@@ -131,18 +131,18 @@ namespace CommandLine.Core
             // Find all inherited defined properties and fields on the type
             var inheritedTypes = type.GetTypeInfo().FlattenHierarchy().Select(i => i.GetTypeInfo());
 
-            foreach (var inheritedType in inheritedTypes) 
+            foreach (var inheritedType in inheritedTypes)
             {
-                if (
-                    inheritedType.GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.Instance).Any(p => p.CanWrite) ||
-                    inheritedType.GetTypeInfo().GetFields(BindingFlags.Public | BindingFlags.Instance).Any()
-                    )
+                if (inheritedType.GetTypeInfo().GetConstructor(Type.EmptyTypes) == null || (
+                    inheritedType.GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.Instance).All(p => !p.CanWrite) &&
+                    !inheritedType.GetTypeInfo().GetFields(BindingFlags.Public | BindingFlags.Instance).Any()
+                    ))
                 {
-                    return true;
+                    return false;
                 }
             }
 
-            return false;
+            return true;
         }
 
         public static object CreateDefaultForImmutable(this Type type)

--- a/src/CommandLine/Core/ReflectionExtensions.cs
+++ b/src/CommandLine/Core/ReflectionExtensions.cs
@@ -133,16 +133,21 @@ namespace CommandLine.Core
 
             foreach (var inheritedType in inheritedTypes)
             {
-                if (inheritedType.GetTypeInfo().GetConstructor(Type.EmptyTypes) == null || (
-                    inheritedType.GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.Instance).All(p => !p.CanWrite) &&
-                    !inheritedType.GetTypeInfo().GetFields(BindingFlags.Public | BindingFlags.Instance).Any()
-                    ))
+                if (
+                    inheritedType.GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.Instance).Any(p => p.CanWrite) ||
+                    inheritedType.GetTypeInfo().GetFields(BindingFlags.Public | BindingFlags.Instance).Any()
+                    )
                 {
-                    return false;
+                    return true;
                 }
             }
 
-            return true;
+            return false;
+        }
+
+        public static bool HasParameterlessConstructor(this Type type)
+        {
+            return type.GetTypeInfo().GetConstructor(Type.EmptyTypes) != null;
         }
 
         public static object CreateDefaultForImmutable(this Type type)
@@ -156,7 +161,7 @@ namespace CommandLine.Core
 
         public static object AutoDefault(this Type type)
         {
-            if (type.IsMutable())
+            if (type.IsMutable() && type.HasParameterlessConstructor())
             {
                 return Activator.CreateInstance(type);
             }

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -87,7 +87,7 @@ namespace CommandLine
         {
             if (args == null) throw new ArgumentNullException("args");
 
-            var factory = typeof(T).IsMutable()
+            var factory = typeof(T).IsMutable() && typeof(T).HasParameterlessConstructor()
                 ? Maybe.Just<Func<T>>(Activator.CreateInstance<T>)
                 : Maybe.Nothing<Func<T>>();
 

--- a/tests/CommandLine.Tests/Unit/Issue890Tests.cs
+++ b/tests/CommandLine.Tests/Unit/Issue890Tests.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using CommandLine.Tests.Fakes;
+using CommandLine.Text;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+//Issue #890
+//When options class is mutable but doesn't have a parameterless constructor parsing fails.
+
+namespace CommandLine.Tests.Unit
+{
+    public class Issue890Tests
+    {
+        [Fact]
+        public void Create_mutable_instance_without_parameterless_ctor_should_not_fail()
+        {
+            var result = Parser.Default.ParseArguments<Options>(new[] { "-a" });
+
+            Assert.Equal(ParserResultType.Parsed, result.Tag);
+            Assert.NotNull(result.Value);
+            Assert.Equal("a", result.Value.Option);
+
+            Assert.Empty(result.Errors);
+        }
+        private class Options
+        {
+            public Options(string option)
+            {
+                Option = option;
+            }
+            [Option("a", Required = false)]
+            public string Option { get; set; }
+        }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/Issue890Tests.cs
+++ b/tests/CommandLine.Tests/Unit/Issue890Tests.cs
@@ -12,25 +12,27 @@ namespace CommandLine.Tests.Unit
 {
     public class Issue890Tests
     {
+        const char OptionSwitch = 'o';
         [Fact]
         public void Create_mutable_instance_without_parameterless_ctor_should_not_fail()
         {
-            var result = Parser.Default.ParseArguments<Options>(new[] { "-a" });
+            const string optionValue = "val";
+
+            var result = Parser.Default.ParseArguments<Options>(new string[] { $"-{OptionSwitch}", optionValue });
 
             Assert.Equal(ParserResultType.Parsed, result.Tag);
             Assert.NotNull(result.Value);
-            Assert.Equal("a", result.Value.Option);
-
+            Assert.Equal(optionValue, result.Value.Opt);
             Assert.Empty(result.Errors);
         }
         private class Options
         {
-            public Options(string option)
+            public Options(string opt)
             {
-                Option = option;
+                Opt = opt;
             }
-            [Option("a", Required = false)]
-            public string Option { get; set; }
+            [Option(OptionSwitch, "opt", Required = false)]
+            public string Opt { get; set; }
         }
     }
 }


### PR DESCRIPTION
Hey,

This is my attempt to address issue #890 by checking if the type has a parameterless constructor before using `Activator.CreateInstance<T>()`.

Please let me know if I didn't follow any of the repo guidelines or conventions.