### PR TITLE
Fix parsing values which starts with dash, but has whitespace inside.

### DIFF
--- a/src/CommandLine/Core/Tokenizer.cs
+++ b/src/CommandLine/Core/Tokenizer.cs
@@ -28,7 +28,7 @@ namespace CommandLine.Core
             Action<Error> onError = errors.Add;
 
             var tokens = (from arg in arguments
-                          from token in !arg.StartsWith("-", StringComparison.Ordinal)
+                          from token in (!arg.StartsWith("-", StringComparison.Ordinal) || arg.Contains(" "))
                                ? new[] { Token.Value(arg) }
                                : arg.StartsWith("--", StringComparison.Ordinal)
                                      ? TokenizeLongName(arg, onError)

--- a/src/CommandLine/Core/Tokenizer.cs
+++ b/src/CommandLine/Core/Tokenizer.cs
@@ -28,7 +28,7 @@ namespace CommandLine.Core
             Action<Error> onError = errors.Add;
 
             var tokens = (from arg in arguments
-                          from token in (!arg.StartsWith("-", StringComparison.Ordinal) || arg.Contains(" "))
+                          from token in (!arg.StartsWith("-", StringComparison.Ordinal) || (arg.Contains(" ") && !arg.Contains("=")))
                                ? new[] { Token.Value(arg) }
                                : arg.StartsWith("--", StringComparison.Ordinal)
                                      ? TokenizeLongName(arg, onError)

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -164,6 +164,27 @@ namespace CommandLine.Tests.Unit
         }
 
         [Fact]
+        public void Parse_options_with_whitespace_and_double_dash()
+        {
+            // Fixture setup
+            var expectedOptions = new Simple_Options
+            {
+                StringValue = "--astring value",
+                IntSequence = Enumerable.Empty<int>(),
+            };
+            var sut = new Parser();
+
+            // Exercize system
+            var result =
+                sut.ParseArguments<Simple_Options>(
+                    new[] { "--stringvalue", "--astring value" });
+
+            // Verify outcome
+            ((Parsed<Simple_Options>)result).Value.Should().BeEquivalentTo(expectedOptions);
+            // Teardown
+        }
+
+        [Fact]
         public void Parse_options_with_repeated_value_in_values_sequence_and_option()
         {
             var text = "x1 x2 x3 -c x1"; // x1 is the same in -c option and first value


### PR DESCRIPTION
this is required when your option can accept command line arguments to other applications.

See https://github.com/dotnet/BenchmarkDotNet/pull/2320#issuecomment-1577300888 for example of parsing issues