### PR TITLE
Issue 377 proposed fix

### DIFF
--- a/src/CommandLine/Core/TypeConverter.cs
+++ b/src/CommandLine/Core/TypeConverter.cs
@@ -27,6 +27,7 @@ namespace CommandLine.Core
             var type =
                 conversionType.GetTypeInfo()
                               .GetGenericArguments()
+                              .FailIfMoreThanoneElement(new InvalidOperationException("Unsupported sequence type - non scalar properties should be sequence of type IEnumerable<T>."))
                               .SingleOrDefault()
                               .ToMaybe()
                               .FromJustOrFail(

--- a/src/CommandLine/Infrastructure/CSharpx/EnumerableExtensions.cs
+++ b/src/CommandLine/Infrastructure/CSharpx/EnumerableExtensions.cs
@@ -459,5 +459,30 @@ namespace CSharpx
                 }
             }
         }
+
+        /// <summary>
+        /// Throws the specified exception if the <c>IEnumerable</c> contains more than one element.
+        /// </summary>
+        /// <param name="source">The IEnumerable this extension method is called upon</param>
+        /// <param name="exceptionToThrow">The exception to throw if the sequence has more than one element</param>
+        /// <remarks>
+        /// It is not recommended to use this extension method without a custom exception
+        /// one could simply use the default Linq .Single() and .SingleOrDefault() methods.
+        /// </remarks>
+        public static IEnumerable<T> FailIfMoreThanoneElement<T>(this IEnumerable<T> source, Exception exceptionToThrow = null)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            if (source.Take(2).Count() > 1)
+            {
+                if (exceptionToThrow != null)
+                    throw exceptionToThrow;
+
+                // A desidered exception has not been specified - in this case a default error message is used
+                throw new InvalidOperationException("Sequence contains more than one elemen");
+            }
+
+            return source;
+        }
     }
 }

--- a/tests/CommandLine.Tests/Unit/Issue377Tests.cs
+++ b/tests/CommandLine.Tests/Unit/Issue377Tests.cs
@@ -1,0 +1,74 @@
+﻿using CommandLine.Text;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static CommandLine.Tests.Unit.Issue389Tests;
+using Xunit;
+using FluentAssertions;
+
+namespace CommandLine.Tests.Unit
+{
+    //Reference: PR# 377
+    public class Issue377Tests
+    {
+
+        // Test the normal behavior of the library
+        [Fact]
+        public void Test_Read_File_List_With_IEnumerable_And_Type()
+        {
+            ParserResult<Options_IEnumerable_With_Type> parsedOptions = Parser.Default.ParseArguments<Options_IEnumerable_With_Type>(new string[] { "--read", "file1", "file2" });
+            parsedOptions.Tag.Should().Be(ParserResultType.Parsed);
+            parsedOptions.Value.Should().NotBeNull();
+            parsedOptions.Value.InputFiles.Should().HaveCount(2);
+            parsedOptions.Value.InputFiles.First().Should().Be("file1");
+            parsedOptions.Value.InputFiles.Last().Should().Be("file2");
+        }
+
+
+        // Test the normal behavior of the library
+        [Fact]
+        public void Test_Read_File_List_With_IEnumerable_And_Without_Type()
+        {
+            Action parseUnsupportedType = () => Parser.Default.ParseArguments<Options_IEnumerable_Without_Type>(new string[] { "--read", "file1", "file2" });
+            Assert.Throws<InvalidOperationException>(parseUnsupportedType);
+        }
+
+        // Tests the behaviour of the library with an unsupported type (i.e. a dictionary)
+        [Fact]
+        public void Test_Read_File_List_With_IDictionary()
+        {
+            Action parseUnsupportedType = () => Parser.Default.ParseArguments<Options_Dictionary>(new string[] { "--read", "file1", "file2" });
+            Assert.Throws<InvalidOperationException>(parseUnsupportedType);
+        }
+
+        // Options with IEnumerable
+        internal class Options_IEnumerable_With_Type
+        {
+
+            [Option('r', "read", Required = true, HelpText = "Input files to be processed.")]
+            public IEnumerable<string> InputFiles { get; set; }
+
+        }
+
+        // Options with IEnumerable
+        internal class Options_IEnumerable_Without_Type
+        {
+
+            [Option('r', "read", Required = true, HelpText = "Input files to be processed.")]
+            public IEnumerable InputFiles { get; set; }
+
+        }
+
+        // Options with unsupported IDictionary type
+        internal class Options_Dictionary
+        {
+
+            [Option('r', "read", Required = true, HelpText = "Input files to be processed.")]
+            public IDictionary<string, string> InputFiles { get; set; }
+
+        }
+    }
+}


### PR DESCRIPTION
A proposed fix in order to close [Issue 377](https://github.com/commandlineparser/commandline/issues/377)

I think in the future it would be nicer to move all checks made inside `TypeConverter.ChangeTypeSequence(...)` to `SpecificationGuards`