### PR TITLE
Fix #490: Display appropriate separator when writing default enumerable values

### DIFF
--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -971,8 +971,11 @@ namespace CommandLine.Text
             if (addEnumValuesToHelpText && specification.EnumValues.Any())
                 optionHelpText += " Valid values: " + string.Join(", ", specification.EnumValues);
 
+            var separator = (specification is OptionSpecification optionSpecification && optionSpecification.Separator != '\0')
+                ? optionSpecification.Separator
+                : ' ';
             specification.DefaultValue.Do(
-                defaultValue => optionHelpText = "(Default: {0}) ".FormatInvariant(FormatDefaultValue(defaultValue)) + optionHelpText);
+                defaultValue => optionHelpText = "(Default: {0}) ".FormatInvariant(FormatDefaultValue(defaultValue, separator)) + optionHelpText);
 
             var optionGroupSpecification = GetOptionGroupSpecification();
 
@@ -1106,7 +1109,7 @@ namespace CommandLine.Text
             return specLength;
         }
 
-        private static string FormatDefaultValue<T>(T value)
+        private static string FormatDefaultValue<T>(T value, char separator)
         {
             if (value is bool)
                 return value.ToStringLocal().ToLowerInvariant();
@@ -1122,7 +1125,7 @@ namespace CommandLine.Text
             foreach (var item in asEnumerable)
                 builder
                     .Append(item.ToStringLocal())
-                    .Append(" ");
+                    .Append(separator);
 
             return builder.Length > 0
                 ? builder.ToString(0, builder.Length - 1)

--- a/tests/CommandLine.Tests/Fakes/Options_With_Default_Set_To_Sequence_With_Separator.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_Default_Set_To_Sequence_With_Separator.cs
@@ -1,0 +1,18 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace CommandLine.Tests.Fakes
+{
+    class Options_With_Default_Set_To_Sequence_With_Separator
+    {
+        [Option('z', "strseq", Default = new[] { "a", "b", "c" }, Separator = ',')]
+        public IEnumerable<string> StringSequence { get; set; }
+
+        [Option('y', "intseq", Default = new[] { 1, 2, 3 }, Separator = ',')]
+        public IEnumerable<int> IntSequence { get; set; }
+
+        [Option('q', "dblseq", Default = new[] { 1.1, 2.2, 3.3 }, Separator = ',')]
+        public IEnumerable<int> DoubleSequence { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -849,6 +849,33 @@ namespace CommandLine.Tests.Unit.Text
 
             // Teardown
         }
+        
+        [Fact]
+        public void Options_should_be_separated_by_separator()
+        {
+            // Fixture setup
+            var handlers = new CultureInfo("en-US").MakeCultureHandlers();
+            var fakeResult =
+                new NotParsed<Options_With_Default_Set_To_Sequence_With_Separator>(
+                    typeof(Options_With_Default_Set_To_Sequence_With_Separator).ToTypeInfo(),
+                    Enumerable.Empty<Error>()
+                );
+
+            // Exercize system
+            handlers.ChangeCulture();
+            var helpText = HelpText.AutoBuild(fakeResult);
+            handlers.ResetCulture();
+
+            // Verify outcome
+            var text = helpText.ToString();
+            var lines = text.ToLines().TrimStringArray();
+            
+            lines[3].Should().Be("-z, --strseq    (Default: a,b,c)");
+            lines[5].Should().Be("-y, --intseq    (Default: 1,2,3)");
+            lines[7].Should().Be("-q, --dblseq    (Default: 1.1,2.2,3.3)");
+
+            // Teardown
+        }
 
         [Fact]
         public void Options_Should_Render_OptionGroup_In_Parenthesis_When_Available()


### PR DESCRIPTION
Currently, the default values for an IEnumerable option are always written with spaces separating them, even when the separator is set to something else. This change reads the configured separator from the option to include in the generated Default value for the HelpText.

Adds a new test case to confirm behavior when separator is configured. Previous behavior is maintained if separator is not configured.

Fix #490