### PR TITLE
Fix ReadText.LocalizedDemo strings

### DIFF
--- a/demo/ReadText.LocalizedDemo/LocalizableSentenceBuilder.cs
+++ b/demo/ReadText.LocalizedDemo/LocalizableSentenceBuilder.cs
@@ -57,7 +57,7 @@ namespace ReadText.LocalizedDemo
                         case ErrorType.MissingRequiredOptionError:
                             var errMisssing = ((MissingRequiredOptionError)error);
                             return errMisssing.NameInfo.Equals(NameInfo.EmptyName)
-                                       ? Properties.Resources.SentenceMissingRequiredOptionError
+                                       ? Properties.Resources.SentenceBadFormatConversionErrorValue
                                        : String.Format(Properties.Resources.SentenceMissingRequiredOptionError, errMisssing.NameInfo.NameText);
                         case ErrorType.BadFormatConversionError:
                             var badFormat = ((BadFormatConversionError)error);

--- a/demo/ReadText.LocalizedDemo/Properties/Resources.Designer.cs
+++ b/demo/ReadText.LocalizedDemo/Properties/Resources.Designer.cs
@@ -196,7 +196,7 @@ namespace ReadText.LocalizedDemo.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Možnost &apos;{0}&apos; je definována ve špatném formátu..
+        ///   Looks up a localized string similar to Option &apos;{0}&apos; is defined with a bad format..
         /// </summary>
         public static string SentenceBadFormatConversionErrorOption {
             get {

--- a/demo/ReadText.LocalizedDemo/Properties/Resources.resx
+++ b/demo/ReadText.LocalizedDemo/Properties/Resources.resx
@@ -163,7 +163,7 @@
     <value>Displays last lines of a file.</value>
   </data>
   <data name="SentenceBadFormatConversionErrorOption" xml:space="preserve">
-    <value>Možnost '{0}' je definována ve špatném formátu.</value>
+    <value>Option '{0}' is defined with a bad format.</value>
   </data>
   <data name="SentenceBadFormatConversionErrorValue" xml:space="preserve">
     <value>A value not bound to option name is defined with a bad format.</value>


### PR DESCRIPTION
- If it's not a missing option value case, then the localized string should be `Properties.Resources.SentenceBadFormatConversionErrorValue` which is consistent with other cases in the code.
- Make `SentenceBadFormatConversionErrorOption` an english string