### PR TITLE
fix-379 Fixing issue with default value on enums for help text

### DIFF
--- a/src/CommandLine/UnParserExtensions.cs
+++ b/src/CommandLine/UnParserExtensions.cs
@@ -301,6 +301,7 @@ namespace CommandLine
 #if !SKIP_FSHARP
             if (ReflectionHelper.IsFSharpOptionType(value.GetType()) && !FSharpOptionHelper.IsSome(value)) return true;
 #endif
+            if (value is Enum && value.Equals(value.GetType().GetDefaultValue())) return false;
             if (value is ValueType && value.Equals(value.GetType().GetDefaultValue())) return true;
             if (value is string && ((string)value).Length == 0) return true;
             if (value is IEnumerable && !((IEnumerable)value).GetEnumerator().MoveNext()) return true;

--- a/tests/CommandLine.Tests/Fakes/Options_With_Empty_Enum_First_Element.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_Empty_Enum_First_Element.cs
@@ -1,0 +1,37 @@
+﻿using CommandLine.Text;
+using System.Collections.Generic;
+
+namespace CommandLine.Tests.Fakes
+{
+    public enum EntityType
+    {
+        T0,
+        T1,
+        T2
+    }
+
+    public class Options_With_Empty_Enum_First_Element
+    {
+        [Option('t', "type", HelpText = "My entity")]
+        public EntityType BaseEnum { get; set; }
+
+        [Option('v', "value")]
+        public int Value { get; set; }
+        [Option('d')]
+        public double Double { get; set; }
+        [Option('b')]
+        public bool Bool { get; set; }
+
+        [Usage(ApplicationAlias = "test.exe")]
+        public static IEnumerable<Example> Examples
+        {
+            get
+            {
+                yield return new Example("1", new Options_With_Empty_Enum_First_Element { BaseEnum = EntityType.T0 });
+                yield return new Example("2", new Options_With_Empty_Enum_First_Element { BaseEnum = EntityType.T1 });
+                yield return new Example("3", new Options_With_Empty_Enum_First_Element { Value = 1, Double = 0.1, Bool = false });
+                yield return new Example("4", new Options_With_Empty_Enum_First_Element { BaseEnum = EntityType.T0, Value = 1, Double = 0.1, Bool = true });
+            }
+        }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/Issue379Tests.cs
+++ b/tests/CommandLine.Tests/Unit/Issue379Tests.cs
@@ -1,0 +1,28 @@
+﻿using CommandLine.Tests.Fakes;
+using CommandLine.Text;
+using System.Linq;
+using Xunit;
+
+namespace CommandLine.Tests.Unit
+{
+    public class Issue379Tests
+    {
+        [Fact]
+        public void OptionExamples_With_Default_Values_Should_Display_In_Help_Text()
+        {
+            // Fixture setup
+            ParserResult<Options_With_Empty_Enum_First_Element> result =
+                new NotParsed<Options_With_Empty_Enum_First_Element>(
+                    TypeInfo.Create(typeof(Options_With_Empty_Enum_First_Element)), Enumerable.Empty<Error>());
+
+            // Exercize system
+            var text = HelpText.RenderUsageText(result);
+
+            // Verify outcome
+            Assert.Contains("test.exe --type T0", text);
+            Assert.Contains("test.exe --type T1", text);
+            Assert.Contains("test.exe -d 0.1 --type T0 --value 1", text);
+            Assert.Contains("test.exe -b -d 0.1 --type T0 --value 1", text);
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/commandlineparser/commandline/issues/379

This fixes the issue where the default value for the enum was not being displayed however there are some other issues with this.

Now it will output the enum in help text even if the enum is not included in the command.  I believe this would require quite a rework of the input system in order to properly account for this edge case enum issue so not sure if that is actually what is wanted here.