### PR TITLE
Fix HelpText unhandled PlatformNotSupportedException on unsupported platforms

### DIFF
--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -191,7 +191,7 @@ namespace CommandLine.Text
                     maximumDisplayWidth = DefaultMaximumLength;
                 }
             }
-            catch (IOException)
+            catch (Exception e) when (e is IOException || e is PlatformNotSupportedException || e is ArgumentOutOfRangeException)
             {
                 maximumDisplayWidth = DefaultMaximumLength;
             }
@@ -1133,3 +1133,4 @@ namespace CommandLine.Text
 
     }
 }
+

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -1133,4 +1133,3 @@ namespace CommandLine.Text
 
     }
 }
-


### PR DESCRIPTION
[Console.WindowWidth](https://learn.microsoft.com/en-us/dotnet/api/system.console.windowwidth) is not supported on some platforms _(e.g. Android/iOS)_.

This applies the same fix found in [ParserSettings.GetWindowWidth()](https://github.com/commandlineparser/commandline/blob/af753199688364aa76be4b25e91e6a3abd2c8158/src/CommandLine/ParserSettings.cs#L65) to handle the PlatformNotSupportedException generated on those platforms.